### PR TITLE
Refactor ComponentDefinitionsTable for better readability and optimization

### DIFF
--- a/crates/database/src/bootstrap_model/components/definition.rs
+++ b/crates/database/src/bootstrap_model/components/definition.rs
@@ -1,21 +1,15 @@
 use std::sync::LazyLock;
-
 use common::{
     bootstrap_model::components::definition::ComponentDefinitionMetadata,
-    document::{
-        ParsedDocument,
-        ResolvedDocument,
-    },
+    document::{ParsedDocument, ResolvedDocument},
 };
 use value::TableName;
+use crate::defaults::{SystemIndex, SystemTable};
 
-use crate::defaults::{
-    SystemIndex,
-    SystemTable,
-};
+const COMPONENT_DEFINITIONS_TABLE_NAME: &str = "_component_definitions";
 
 pub static COMPONENT_DEFINITIONS_TABLE: LazyLock<TableName> = LazyLock::new(|| {
-    "_component_definitions"
+    COMPONENT_DEFINITIONS_TABLE_NAME
         .parse()
         .expect("Invalid built-in _component_definitions table")
 });


### PR DESCRIPTION
-> Moved `_component_definitions` table name to a constant for better clarity and reusability.
->Simplified the `validate_document` function using the `?` operator for cleaner error handling.
-> Used `Vec::new()` in `indexes()` for efficient empty vector creation.
-> No functional changes introduced, just improved code quality.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
