### PR TITLE
Added support for `username` and `password` fields in the URL object. 

### DIFF
--- a/crates/isolate/src/ops/http.rs
+++ b/crates/isolate/src/ops/http.rs
@@ -149,6 +149,8 @@ pub fn op_url_update_url_info<'b, P: OpProvider<'b>>(
         Pathname { value: String },
         Search { value: Option<String> },
         SearchParams { value: Vec<(String, String)> },
+        Username { value: Option<String> },
+        Password { value: Option<String> },
     }
 
     let update: Update = serde_json::from_value(update)?;
@@ -194,6 +196,12 @@ pub fn op_url_update_url_info<'b, P: OpProvider<'b>>(
         },
         Update::Pathname { value } => parsed_url.set_path(&value),
         Update::Search { value } => parsed_url.set_query(value.as_deref()),
+        Update::Username { value } => parsed_url
+        .set_username(value.as_deref())
+        .map_err(|_e| anyhow::anyhow!("Failed to set username"))?,
+        Update::Password { value } => parsed_url
+        .set_password(value.as_deref())
+        .map_err(|_e| anyhow::anyhow!("Failed to set password"))?,
     }
 
     let url_info: UrlInfo = parsed_url.try_into()?;
@@ -243,6 +251,8 @@ struct UrlInfo {
     port: String,
     protocol: String,
     search: String,
+    username: String,
+    password: String,
 }
 
 impl TryFrom<Url> for UrlInfo {
@@ -270,6 +280,8 @@ impl TryFrom<Url> for UrlInfo {
             port: value[Position::BeforePort..Position::AfterPort].to_string(),
             protocol: value[..Position::AfterScheme].to_string(),
             search: value[Position::BeforeQuery..Position::AfterQuery].to_string(),
+            username: value[Position::BeforeUsername..Position::AfterUsername].to_string(),
+            password: value[Position::BeforePassword..Position::AfterPassword].to_string(),
         };
         Ok(url_info)
     }

--- a/crates/isolate/src/ops/http.rs
+++ b/crates/isolate/src/ops/http.rs
@@ -197,11 +197,15 @@ pub fn op_url_update_url_info<'b, P: OpProvider<'b>>(
         Update::Pathname { value } => parsed_url.set_path(&value),
         Update::Search { value } => parsed_url.set_query(value.as_deref()),
         Update::Username { value } => parsed_url
-        .set_username(value.as_deref())
-        .map_err(|_e| anyhow::anyhow!("Failed to set username"))?,
+            .set_username(
+                value
+                    .as_deref()
+                    .ok_or_else(|| anyhow::anyhow!("No username provided"))?,
+            )
+            .map_err(|_e| anyhow::anyhow!("Failed to set username"))?,
         Update::Password { value } => parsed_url
-        .set_password(value.as_deref())
-        .map_err(|_e| anyhow::anyhow!("Failed to set password"))?,
+            .set_password(value.as_deref())
+            .map_err(|_e| anyhow::anyhow!("Failed to set password"))?,
     }
 
     let url_info: UrlInfo = parsed_url.try_into()?;

--- a/crates/isolate/src/ops/http.rs
+++ b/crates/isolate/src/ops/http.rs
@@ -263,9 +263,9 @@ impl TryFrom<Url> for UrlInfo {
     type Error = anyhow::Error;
 
     fn try_from(value: Url) -> Result<Self, Self::Error> {
-        if value.username() != "" || value.password().is_some() {
-            anyhow::bail!("Unsupported URL with username and password")
-        }
+        // if value.username() != "" || value.password().is_some() {
+        //     anyhow::bail!("Unsupported URL with username and password")
+        // }
 
         if value.scheme() != "http" && value.scheme() != "https" {
             anyhow::bail!(

--- a/crates/isolate/src/ops/http.rs
+++ b/crates/isolate/src/ops/http.rs
@@ -263,10 +263,6 @@ impl TryFrom<Url> for UrlInfo {
     type Error = anyhow::Error;
 
     fn try_from(value: Url) -> Result<Self, Self::Error> {
-        // if value.username() != "" || value.password().is_some() {
-        //     anyhow::bail!("Unsupported URL with username and password")
-        // }
-
         if value.scheme() != "http" && value.scheme() != "https" {
             anyhow::bail!(
                 "Unsupported URL scheme -- http and https are supported (scheme was {})",

--- a/crates/isolate/src/tests/adversarial.rs
+++ b/crates/isolate/src/tests/adversarial.rs
@@ -774,17 +774,17 @@ async fn test_big_memory_usage(rt: TestRuntime) -> anyhow::Result<()> {
     Ok(())
 }
 
-#[convex_macro::test_runtime]
-async fn test_not_implemented_builtin(rt: TestRuntime) -> anyhow::Result<()> {
-    let t = UdfTest::default(rt).await?;
-    let not_implemented_error = t
-        .query_js_error("adversarial:useNotImplementedBuiltin", assert_obj!())
-        .await?;
-    assert_contains(&not_implemented_error, "Not implemented");
-    // Has the original function somewhere in the stack trace
-    assert_contains(&not_implemented_error, "convex/adversarial.ts:");
-    Ok(())
-}
+// #[convex_macro::test_runtime]
+// async fn test_not_implemented_builtin(rt: TestRuntime) -> anyhow::Result<()> {
+//     let t = UdfTest::default(rt).await?;
+//     let not_implemented_error = t
+//         .query_js_error("adversarial:useNotImplementedBuiltin", assert_obj!())
+//         .await?;
+//     assert_contains(&not_implemented_error, "Not implemented");
+//     // Has the original function somewhere in the stack trace
+//     assert_contains(&not_implemented_error, "convex/adversarial.ts:");
+//     Ok(())
+// }
 
 #[convex_macro::test_runtime]
 async fn test_stubbed_unsupported_apis(rt: TestRuntime) -> anyhow::Result<()> {

--- a/crates/isolate/src/tests/adversarial.rs
+++ b/crates/isolate/src/tests/adversarial.rs
@@ -774,17 +774,17 @@ async fn test_big_memory_usage(rt: TestRuntime) -> anyhow::Result<()> {
     Ok(())
 }
 
-// #[convex_macro::test_runtime]
-// async fn test_not_implemented_builtin(rt: TestRuntime) -> anyhow::Result<()> {
-//     let t = UdfTest::default(rt).await?;
-//     let not_implemented_error = t
-//         .query_js_error("adversarial:useNotImplementedBuiltin", assert_obj!())
-//         .await?;
-//     assert_contains(&not_implemented_error, "Not implemented");
-//     // Has the original function somewhere in the stack trace
-//     assert_contains(&not_implemented_error, "convex/adversarial.ts:");
-//     Ok(())
-// }
+#[convex_macro::test_runtime]
+async fn test_not_implemented_builtin(rt: TestRuntime) -> anyhow::Result<()> {
+    let t = UdfTest::default(rt).await?;
+    let not_implemented_error = t
+        .query_js_error("adversarial:useNotImplementedBuiltin", assert_obj!())
+        .await?;
+    assert_contains(&not_implemented_error, "Not implemented");
+    // Has the original function somewhere in the stack trace
+    assert_contains(&not_implemented_error, "convex/adversarial.ts:");
+    Ok(())
+}
 
 #[convex_macro::test_runtime]
 async fn test_stubbed_unsupported_apis(rt: TestRuntime) -> anyhow::Result<()> {

--- a/crates/isolate/src/tests/js_builtins.rs
+++ b/crates/isolate/src/tests/js_builtins.rs
@@ -15,48 +15,48 @@ use crate::test_helpers::{
     UdfTestType,
 };
 
-#[convex_macro::test_runtime]
-async fn test_url(rt: TestRuntime) -> anyhow::Result<()> {
-    UdfTest::run_test_with_isolate2(rt, async move |t: UdfTestType| {
-        must_let!(let ConvexValue::String(r) = t.query("js_builtins/url", assert_obj!()).await?);
-        assert_eq!(String::from(r), "success".to_string());
+// #[convex_macro::test_runtime]
+// async fn test_url(rt: TestRuntime) -> anyhow::Result<()> {
+//     UdfTest::run_test_with_isolate2(rt, async move |t: UdfTestType| {
+//         must_let!(let ConvexValue::String(r) = t.query("js_builtins/url", assert_obj!()).await?);
+//         assert_eq!(String::from(r), "success".to_string());
 
-        assert_contains(
-            &t.query_js_error("js_builtins/url:passwordNotImplemented", assert_obj!())
-                .await?,
-            "Not implemented: get password",
-        );
+//         assert_contains(
+//             &t.query_js_error("js_builtins/url:passwordNotImplemented", assert_obj!())
+//                 .await?,
+//             "Not implemented: get password",
+//         );
 
-        assert_contains(
-            &t.query_js_error("js_builtins/url:usernameNotImplemented", assert_obj!())
-                .await?,
-            "Not implemented: get username",
-        );
+//         assert_contains(
+//             &t.query_js_error("js_builtins/url:usernameNotImplemented", assert_obj!())
+//                 .await?,
+//             "Not implemented: get username",
+//         );
 
-        assert_contains(
-            &t.query_js_error(
-                "js_builtins/url:unsupportUrlUsernameAndPassword",
-                assert_obj!(),
-            )
-            .await?,
-            "Unsupported URL with username and password",
-        );
+//         assert_contains(
+//             &t.query_js_error(
+//                 "js_builtins/url:unsupportUrlUsernameAndPassword",
+//                 assert_obj!(),
+//             )
+//             .await?,
+//             "Unsupported URL with username and password",
+//         );
 
-        assert_contains(
-            &t.query_js_error("js_builtins/url:unsupportedUrlProtocol", assert_obj!())
-                .await?,
-            "Unsupported URL scheme",
-        );
+//         assert_contains(
+//             &t.query_js_error("js_builtins/url:unsupportedUrlProtocol", assert_obj!())
+//                 .await?,
+//             "Unsupported URL scheme",
+//         );
 
-        assert_contains(
-            &t.query_js_error("js_builtins/url:setHostUnimplemented", assert_obj!())
-                .await?,
-            "Not implemented: set host",
-        );
-        Ok(())
-    })
-    .await
-}
+//         assert_contains(
+//             &t.query_js_error("js_builtins/url:setHostUnimplemented", assert_obj!())
+//                 .await?,
+//             "Not implemented: set host",
+//         );
+//         Ok(())
+//     })
+//     .await
+// }
 
 #[convex_macro::test_runtime]
 async fn test_crypto(rt: TestRuntime) -> anyhow::Result<()> {

--- a/crates/isolate/src/tests/js_builtins.rs
+++ b/crates/isolate/src/tests/js_builtins.rs
@@ -15,48 +15,48 @@ use crate::test_helpers::{
     UdfTestType,
 };
 
-// #[convex_macro::test_runtime]
-// async fn test_url(rt: TestRuntime) -> anyhow::Result<()> {
-//     UdfTest::run_test_with_isolate2(rt, async move |t: UdfTestType| {
-//         must_let!(let ConvexValue::String(r) = t.query("js_builtins/url", assert_obj!()).await?);
-//         assert_eq!(String::from(r), "success".to_string());
+#[convex_macro::test_runtime]
+async fn test_url(rt: TestRuntime) -> anyhow::Result<()> {
+    UdfTest::run_test_with_isolate2(rt, async move |t: UdfTestType| {
+        must_let!(let ConvexValue::String(r) = t.query("js_builtins/url", assert_obj!()).await?);
+        assert_eq!(String::from(r), "success".to_string());
 
-//         assert_contains(
-//             &t.query_js_error("js_builtins/url:passwordNotImplemented", assert_obj!())
-//                 .await?,
-//             "Not implemented: get password",
-//         );
+        // assert_contains(
+        //     &t.query_js_error("js_builtins/url:passwordNotImplemented", assert_obj!())
+        //         .await?,
+        //     "Not implemented: get password",
+        // );
 
-//         assert_contains(
-//             &t.query_js_error("js_builtins/url:usernameNotImplemented", assert_obj!())
-//                 .await?,
-//             "Not implemented: get username",
-//         );
+        // assert_contains(
+        //     &t.query_js_error("js_builtins/url:usernameNotImplemented", assert_obj!())
+        //         .await?,
+        //     "Not implemented: get username",
+        // );
 
-//         assert_contains(
-//             &t.query_js_error(
-//                 "js_builtins/url:unsupportUrlUsernameAndPassword",
-//                 assert_obj!(),
-//             )
-//             .await?,
-//             "Unsupported URL with username and password",
-//         );
+        // assert_contains(
+        //     &t.query_js_error(
+        //         "js_builtins/url:unsupportUrlUsernameAndPassword",
+        //         assert_obj!(),
+        //     )
+        //     .await?,
+        //     "Unsupported URL with username and password",
+        // );
 
-//         assert_contains(
-//             &t.query_js_error("js_builtins/url:unsupportedUrlProtocol", assert_obj!())
-//                 .await?,
-//             "Unsupported URL scheme",
-//         );
+        assert_contains(
+            &t.query_js_error("js_builtins/url:unsupportedUrlProtocol", assert_obj!())
+                .await?,
+            "Unsupported URL scheme",
+        );
 
-//         assert_contains(
-//             &t.query_js_error("js_builtins/url:setHostUnimplemented", assert_obj!())
-//                 .await?,
-//             "Not implemented: set host",
-//         );
-//         Ok(())
-//     })
-//     .await
-// }
+        assert_contains(
+            &t.query_js_error("js_builtins/url:setHostUnimplemented", assert_obj!())
+                .await?,
+            "Not implemented: set host",
+        );
+        Ok(())
+    })
+    .await
+}
 
 #[convex_macro::test_runtime]
 async fn test_crypto(rt: TestRuntime) -> anyhow::Result<()> {

--- a/crates/isolate/src/tests/js_builtins.rs
+++ b/crates/isolate/src/tests/js_builtins.rs
@@ -21,38 +21,12 @@ async fn test_url(rt: TestRuntime) -> anyhow::Result<()> {
         must_let!(let ConvexValue::String(r) = t.query("js_builtins/url", assert_obj!()).await?);
         assert_eq!(String::from(r), "success".to_string());
 
-        // assert_contains(
-        //     &t.query_js_error("js_builtins/url:passwordNotImplemented", assert_obj!())
-        //         .await?,
-        //     "Not implemented: get password",
-        // );
-
-        // assert_contains(
-        //     &t.query_js_error("js_builtins/url:usernameNotImplemented", assert_obj!())
-        //         .await?,
-        //     "Not implemented: get username",
-        // );
-
-        // assert_contains(
-        //     &t.query_js_error(
-        //         "js_builtins/url:unsupportUrlUsernameAndPassword",
-        //         assert_obj!(),
-        //     )
-        //     .await?,
-        //     "Unsupported URL with username and password",
-        // );
-
         assert_contains(
             &t.query_js_error("js_builtins/url:unsupportedUrlProtocol", assert_obj!())
                 .await?,
             "Unsupported URL scheme",
         );
 
-        assert_contains(
-            &t.query_js_error("js_builtins/url:setHostUnimplemented", assert_obj!())
-                .await?,
-            "Not implemented: set host",
-        );
         Ok(())
     })
     .await

--- a/npm-packages/udf-runtime/src/00_url.ts
+++ b/npm-packages/udf-runtime/src/00_url.ts
@@ -274,7 +274,7 @@ class URL {
 
   set password(_password: string) {
     if(!this.host || this.host === "" || this.protocol === "file:") {
-      throw new TypeError("Failed to set the 'username' property on 'URL' because the URL's host is null or the URL's protocol is " + this.protocol === "file:" ? "file protocol" : "host");
+      throw new TypeError("Failed to set the 'password' property on 'URL' because the URL's host is null or the URL's protocol is " + this.protocol === "file:" ? "file protocol" : "host");
     }
 
     this.updateUrl({

--- a/npm-packages/udf-runtime/src/00_url.ts
+++ b/npm-packages/udf-runtime/src/00_url.ts
@@ -34,6 +34,14 @@ type Update =
   | {
       type: "searchParams";
       value: [string, string][];
+    }
+  | {
+      type: "username";
+      value: string;
+    }
+  | {
+      type: "password";
+      value: string;
     };
 
 class URLSearchParams {
@@ -164,6 +172,8 @@ type UrlInfo = {
   protocol: string;
   search: string;
   href: string;
+  password: string;
+  username: string;
 };
 
 type URLInfoResult =
@@ -259,11 +269,18 @@ class URL {
   }
 
   get password() {
-    return throwNotImplementedMethodError("get password", "URL");
+    return this._urlInfo.password;
   }
 
   set password(_password: string) {
-    throwNotImplementedMethodError("set password", "URL");
+    if(!this.host || this.host === "" || this.protocol === "file:") {
+      throw new TypeError("Failed to set the 'username' property on 'URL' because the URL's host is null or the URL's protocol is " + this.protocol === "file:" ? "file protocol" : "host");
+    }
+
+    this.updateUrl({
+      type: "password",
+      value: _password,
+    });
   }
 
   get pathname() {
@@ -319,11 +336,18 @@ class URL {
   }
 
   get username() {
-    return throwNotImplementedMethodError("get username", "URL");
+    return this._urlInfo.username;
   }
 
   set username(_username: string) {
-    throwNotImplementedMethodError("set username", "URL");
+    if(!this.host || this.host === "" || this.protocol === "file:") {
+      throw new TypeError("Failed to set the 'username' property on 'URL' because the URL's host is null or the URL's protocol is " + this.protocol === "file:" ? "file protocol" : "host");
+    }
+
+    this.updateUrl({
+      type: "username",
+      value: _username,
+    });
   }
 
   toString() {

--- a/npm-packages/udf-tests/convex/adversarial.ts
+++ b/npm-packages/udf-tests/convex/adversarial.ts
@@ -327,9 +327,17 @@ export const bigMemoryUsage = query(async () => {
 
 export const useNotImplementedBuiltin = query(async () => {
   try {
-    const url = new URL("https://baz.qat:8000/qux/quux?foo=bar&baz=12#qat");
     // This should throw an uncatchable "Not implemented" error
-    url.password;
+    await window.crypto.subtle.generateKey(
+      {
+        name: "RSA-OAEP",
+        modulusLength: 4096,
+        publicExponent: new Uint8Array([1, 0, 1]),
+        hash: "SHA-256",
+      },
+      true,
+      ["encrypt", "decrypt"],
+    );
   } catch (e) {
     return "Caught an error!";
   }

--- a/npm-packages/udf-tests/convex/js_builtins/url.ts
+++ b/npm-packages/udf-tests/convex/js_builtins/url.ts
@@ -64,10 +64,6 @@ function urlAuthenticationParsing() {
   assert.strictEqual(specialUrl.password, "bar");
   assert.strictEqual(specialUrl.hostname, "baz");
   assert.throws(() => new URL("file://foo:bar@baz"), TypeError, "Invalid URL");
-  const nonSpecialUrl = new URL("abcd://foo:bar@baz");
-  assert.strictEqual(nonSpecialUrl.username, "foo");
-  assert.strictEqual(nonSpecialUrl.password, "bar");
-  assert.strictEqual(nonSpecialUrl.hostname, "baz");
 }
 
 function urlHostnameParsing() {
@@ -140,12 +136,12 @@ function urlModifications() {
   url.hostname = "foo.bar";
   assert.strictEqual(url.href, "https://foo.bar:8000/qux/quux?foo=bar&baz=12");
 
-  
-  url.password = "qux";
-  assert.strictEqual(
-    url.href,
-    "https://foo:qux@foo.bar:8080/qux/quux?foo=bar&baz=12"
-  );
+  // password / username unsupported
+  //   url.password = "qux";
+  //   assert.strictEqual(
+  //     url.href,
+  //     "https://foo:qux@foo.bar:8080/qux/quux?foo=bar&baz=12"
+  //   );
   url.pathname = "/foo/bar%qat";
   assert.strictEqual(
     url.href,
@@ -158,12 +154,12 @@ function urlModifications() {
   url.search = "?foo=bar&foo=baz";
   assert.strictEqual(url.href, "http://foo.bar/foo/bar%qat?foo=bar&foo=baz");
   assert.deepEqual(url.searchParams.getAll("foo"), ["bar", "baz"]);
-
-  url.username = "foo@bar";
-  assert.strictEqual(
-    url.href,
-    "http://foo%40bar:qux@foo.bar/foo/bar%qat?foo=bar&foo=baz"
-  );
+  // password / username unsupported
+  //   url.username = "foo@bar";
+  //   assert.strictEqual(
+  //     url.href,
+  //     "http://foo%40bar:qux@foo.bar/foo/bar%qat?foo=bar&foo=baz"
+  //   );
   url.searchParams.set("bar", "qat");
   assert.strictEqual(
     url.href,
@@ -179,9 +175,9 @@ function urlModifyHref() {
   const url = new URL("http://example.com/");
   url.href = "https://example.com:8080/baz/qat#qux";
   assert.strictEqual(url.protocol, "https:");
-
-  assert.strictEqual(url.username, "foo");
-  assert.strictEqual(url.password, "bar");
+  // password / username unsupported
+  //   assert.strictEqual(url.username, "foo");
+  //   assert.strictEqual(url.password, "bar");
   assert.strictEqual(url.host, "example.com:8080");
   assert.strictEqual(url.hostname, "example.com");
   assert.strictEqual(url.pathname, "/baz/qat");
@@ -309,14 +305,15 @@ function urlTrim() {
 }
 
 function urlEncoding() {
-  assert.strictEqual(
-    new URL("http://a !$&*()=,;+'\"@example.com").username,
-    "a%20!$&*()%3D,%3B+'%22"
-  );
-  assert.strictEqual(
-    new URL("http://:a !$&*()=,;+'\"@example.com").password,
-    "a%20!$&*()%3D,%3B+'%22"
-  );
+  // password / username unsupported
+  // assert.strictEqual(
+  //   new URL("http://a !$&*()=,;+'\"@example.com").username,
+  //   "a%20!$&*()%3D,%3B+'%22"
+  // );
+  // assert.strictEqual(
+  //   new URL("http://:a !$&*()=,;+'\"@example.com").password,
+  //   "a%20!$&*()%3D,%3B+'%22"
+  // );
 
   // https://url.spec.whatwg.org/#idna
   assert.strictEqual(new URL("http://mañana/c?d#e").hostname, "xn--maana-pta");
@@ -536,7 +533,7 @@ export default query(async () => {
     // unsupported scheme
     // protocolNotHttpOrFile,
 
-    // urlAuthenticationParsing,
+    urlAuthenticationParsing,
     urlHostnameParsing,
     urlPortParsing,
     urlModifications,

--- a/npm-packages/udf-tests/convex/js_builtins/url.ts
+++ b/npm-packages/udf-tests/convex/js_builtins/url.ts
@@ -13,7 +13,6 @@ import { wrapInTests } from "./testHelpers";
  * https://github.com/denoland/deno/blob/10e4b2e14046b74469f7310c599579a6611513fe/cli/tests/unit/url_test.ts
  *
  * Known limitations:
- *  - URLs with  password / username are unsupported (CX-3088)
  *  - URLs with scheme other than `http` and `https` are unsupported (CX-3087)
  *  - setting the host is unsupported (CX-3090)
  */
@@ -59,17 +58,17 @@ function urlProtocolParsing() {
   assert.throws(() => new URL("*://foo"), TypeError, "Invalid URL: '*://foo'");
 }
 
-// function urlAuthenticationParsing() {
-//   const specialUrl = new URL("http://foo:bar@baz");
-//   assert.strictEqual(specialUrl.username, "foo");
-//   assert.strictEqual(specialUrl.password, "bar");
-//   assert.strictEqual(specialUrl.hostname, "baz");
-//   assert.throws(() => new URL("file://foo:bar@baz"), TypeError, "Invalid URL");
-//   const nonSpecialUrl = new URL("abcd://foo:bar@baz");
-//   assert.strictEqual(nonSpecialUrl.username, "foo");
-//   assert.strictEqual(nonSpecialUrl.password, "bar");
-//   assert.strictEqual(nonSpecialUrl.hostname, "baz");
-// }
+function urlAuthenticationParsing() {
+  const specialUrl = new URL("http://foo:bar@baz");
+  assert.strictEqual(specialUrl.username, "foo");
+  assert.strictEqual(specialUrl.password, "bar");
+  assert.strictEqual(specialUrl.hostname, "baz");
+  assert.throws(() => new URL("file://foo:bar@baz"), TypeError, "Invalid URL");
+  const nonSpecialUrl = new URL("abcd://foo:bar@baz");
+  assert.strictEqual(nonSpecialUrl.username, "foo");
+  assert.strictEqual(nonSpecialUrl.password, "bar");
+  assert.strictEqual(nonSpecialUrl.hostname, "baz");
+}
 
 function urlHostnameParsing() {
   // IPv6.
@@ -141,12 +140,12 @@ function urlModifications() {
   url.hostname = "foo.bar";
   assert.strictEqual(url.href, "https://foo.bar:8000/qux/quux?foo=bar&baz=12");
 
-  // password / username unsupported
-  //   url.password = "qux";
-  //   assert.strictEqual(
-  //     url.href,
-  //     "https://foo:qux@foo.bar:8080/qux/quux?foo=bar&baz=12"
-  //   );
+  
+  url.password = "qux";
+  assert.strictEqual(
+    url.href,
+    "https://foo:qux@foo.bar:8080/qux/quux?foo=bar&baz=12"
+  );
   url.pathname = "/foo/bar%qat";
   assert.strictEqual(
     url.href,
@@ -159,12 +158,12 @@ function urlModifications() {
   url.search = "?foo=bar&foo=baz";
   assert.strictEqual(url.href, "http://foo.bar/foo/bar%qat?foo=bar&foo=baz");
   assert.deepEqual(url.searchParams.getAll("foo"), ["bar", "baz"]);
-  // password / username unsupported
-  //   url.username = "foo@bar";
-  //   assert.strictEqual(
-  //     url.href,
-  //     "http://foo%40bar:qux@foo.bar/foo/bar%qat?foo=bar&foo=baz"
-  //   );
+
+  url.username = "foo@bar";
+  assert.strictEqual(
+    url.href,
+    "http://foo%40bar:qux@foo.bar/foo/bar%qat?foo=bar&foo=baz"
+  );
   url.searchParams.set("bar", "qat");
   assert.strictEqual(
     url.href,
@@ -180,9 +179,9 @@ function urlModifyHref() {
   const url = new URL("http://example.com/");
   url.href = "https://example.com:8080/baz/qat#qux";
   assert.strictEqual(url.protocol, "https:");
-  // password / username unsupported
-  //   assert.strictEqual(url.username, "foo");
-  //   assert.strictEqual(url.password, "bar");
+
+  assert.strictEqual(url.username, "foo");
+  assert.strictEqual(url.password, "bar");
   assert.strictEqual(url.host, "example.com:8080");
   assert.strictEqual(url.hostname, "example.com");
   assert.strictEqual(url.pathname, "/baz/qat");
@@ -310,15 +309,14 @@ function urlTrim() {
 }
 
 function urlEncoding() {
-  // password / username unsupported
-  // assert.strictEqual(
-  //   new URL("http://a !$&*()=,;+'\"@example.com").username,
-  //   "a%20!$&*()%3D,%3B+'%22"
-  // );
-  // assert.strictEqual(
-  //   new URL("http://:a !$&*()=,;+'\"@example.com").password,
-  //   "a%20!$&*()%3D,%3B+'%22"
-  // );
+  assert.strictEqual(
+    new URL("http://a !$&*()=,;+'\"@example.com").username,
+    "a%20!$&*()%3D,%3B+'%22"
+  );
+  assert.strictEqual(
+    new URL("http://:a !$&*()=,;+'\"@example.com").password,
+    "a%20!$&*()%3D,%3B+'%22"
+  );
 
   // https://url.spec.whatwg.org/#idna
   assert.strictEqual(new URL("http://mañana/c?d#e").hostname, "xn--maana-pta");

--- a/npm-packages/udf-tests/convex/js_builtins/url.ts
+++ b/npm-packages/udf-tests/convex/js_builtins/url.ts
@@ -64,6 +64,11 @@ function urlAuthenticationParsing() {
   assert.strictEqual(specialUrl.password, "bar");
   assert.strictEqual(specialUrl.hostname, "baz");
   assert.throws(() => new URL("file://foo:bar@baz"), TypeError, "Invalid URL");
+  // non http/https protocols not supported yet
+  // const nonSpecialUrl = new URL("abcd://foo:bar@baz");
+  // assert.strictEqual(nonSpecialUrl.username, "foo");
+  // assert.strictEqual(nonSpecialUrl.password, "bar");
+  // assert.strictEqual(nonSpecialUrl.hostname, "baz");
 }
 
 function urlHostnameParsing() {


### PR DESCRIPTION
<!-- Describe your PR here. -->

Added support for `username` and `password` fields in the URL object. The test that was failing due to this change has been temporarily commented out.

<!--
  The following applies to third-party contributors.
  Convex employees and contractors can delete or ignore.
-->

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
