### PR TITLE
Bump tracing-appender version to resolve reolution issue

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -141,7 +141,7 @@ tower = { version = "0.4", features = [ "limit", "timeout" ] }
 tower-cookies = "0.10"
 tower-http = { version = "0.5", features = [ "trace", "cors", "decompression-br" ] }
 tracing = "0.1"
-tracing-appender = { version = "0.2" }
+tracing-appender = { version = "0.2.3" }
 tracing-subscriber = { version = "0.3.17", features = [ "env-filter", "json" ] }
 tracy-client = { version = "0.17.0", default-features = false, features = [ "fibers" ] }
 tungstenite = { version = "0.21.0", features = [ "url", "native-tls-vendored" ] }


### PR DESCRIPTION
Bump tracing-appender version to resolve "use of undeclared crate or module `tracing_subscriber`" from, for example...

tracing-appender-0.2.2/src/non_blocking.rs:59:5

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
