### PR TITLE
Provide safety and intellisense for weekly cron job

### DIFF
--- a/npm-packages/convex/src/server/cron.ts
+++ b/npm-packages/convex/src/server/cron.ts
@@ -31,7 +31,7 @@ const DAYS_OF_WEEK = [
   "thursday",
   "friday",
   "saturday",
-];
+] as const;
 type DayOfWeek = (typeof DAYS_OF_WEEK)[number];
 /** @public */
 export type WeeklySchedule = {


### PR DESCRIPTION
<!-- Describe your PR here. -->

Adds `as const` to the `DAYS_OF_WEEK` array to make it literal. This should give type safety/intellisense when filling out `dayOfWeek` in a weekly cron job in `crons.ts`. 


<!--
  The following applies to third-party contributors.
  Convex employees and contractors can delete or ignore.
-->

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
