### PR TITLE
Fix docs for Clerk `getAuthToken`

### DIFF
--- a/npm-packages/docs/docs/client/react/nextjs/nextjs-server-rendering.mdx
+++ b/npm-packages/docs/docs/client/react/nextjs/nextjs-server-rendering.mdx
@@ -138,10 +138,10 @@ The implementation of `getAuthToken` depends on your authentication provider.
 <Tabs>
 <TabItem value="clerk" label="Clerk">
 ```ts title="app/auth.ts"
-import { auth } from "@clerk/nextjs";
+import { auth } from "@clerk/nextjs/server";
 
 export async function getAuthToken() {
-  return (await auth().getToken({ template: "convex" })) ?? undefined;
+  return (await auth()).getToken({ template: "convex" }) ?? undefined;
 }
 ```
 </TabItem>

--- a/npm-packages/docs/docs/client/react/nextjs/nextjs-server-rendering.mdx
+++ b/npm-packages/docs/docs/client/react/nextjs/nextjs-server-rendering.mdx
@@ -141,7 +141,7 @@ The implementation of `getAuthToken` depends on your authentication provider.
 import { auth } from "@clerk/nextjs/server";
 
 export async function getAuthToken() {
-  return (await auth()).getToken({ template: "convex" }) ?? undefined;
+  return (await (await auth()).getToken({ template: "convex" })) ?? undefined;
 }
 ```
 </TabItem>


### PR DESCRIPTION
The current example provided is invalid. I've updated the docs to reflect the proper way to implement `getAuthToken` for Clerk