### PR TITLE
Add support for Cloudflare R2 Storage

### DIFF
--- a/crates/aws_s3/src/storage.rs
+++ b/crates/aws_s3/src/storage.rs
@@ -26,7 +26,7 @@ use aws_sdk_s3::{
     Client,
 };
 use aws_utils::{
-    must_config_from_env,
+    must_s3_config_from_env,
     s3::S3Client,
 };
 use bytes::Bytes;
@@ -132,7 +132,7 @@ impl<RT: Runtime> S3Storage<RT> {
         key_prefix: String,
         runtime: RT,
     ) -> anyhow::Result<Self> {
-        let config = must_config_from_env()
+        let config = must_s3_config_from_env()
             .context("AWS env variables are required when using S3 storage")?
             .retry_config(RetryConfig::standard())
             .load()

--- a/crates/aws_utils/src/lib.rs
+++ b/crates/aws_utils/src/lib.rs
@@ -14,8 +14,8 @@ use aws_types::region::Region;
 
 pub mod s3;
 
-static AWS_ENDPOINT_URL: LazyLock<Option<String>> =
-    LazyLock::new(|| env::var("AWS_ENDPOINT_URL").ok());
+static S3_ENDPOINT_URL: LazyLock<Option<String>> =
+    LazyLock::new(|| env::var("S3_ENDPOINT_URL").ok());
 
 static AWS_ACCESS_KEY_ID: LazyLock<Option<String>> =
     LazyLock::new(|| env::var("AWS_ACCESS_KEY_ID").ok());
@@ -39,12 +39,16 @@ pub fn must_config_from_env() -> anyhow::Result<ConfigLoader> {
     let Some(_) = AWS_SECRET_ACCESS_KEY.clone() else {
         anyhow::bail!("AWS_SECRET_ACCESS_KEY env variable must be set");
     };
-    let Some(endpoint_url) = AWS_ENDPOINT_URL.clone() else {
-        anyhow::bail!("AWS_ENDPOINT_URL env variable must be set");
-    };
     let credentials = EnvironmentVariableCredentialsProvider::new();
     Ok(aws_config::defaults(BehaviorVersion::v2024_03_28())
-        .endpoint_url(endpoint_url)
         .region(region)
         .credentials_provider(credentials))
+}
+
+pub fn must_s3_config_from_env() -> anyhow::Result<ConfigLoader> {
+    let mut config_loader = must_config_from_env()?;
+    if let Some(s3_endpoint_url) = S3_ENDPOINT_URL.clone() {
+        config_loader = config_loader.endpoint_url(s3_endpoint_url);
+    }
+    Ok(config_loader)
 }

--- a/crates/aws_utils/src/lib.rs
+++ b/crates/aws_utils/src/lib.rs
@@ -14,6 +14,9 @@ use aws_types::region::Region;
 
 pub mod s3;
 
+static AWS_ENDPOINT_URL: LazyLock<Option<String>> =
+    LazyLock::new(|| env::var("AWS_ENDPOINT_URL").ok());
+
 static AWS_ACCESS_KEY_ID: LazyLock<Option<String>> =
     LazyLock::new(|| env::var("AWS_ACCESS_KEY_ID").ok());
 
@@ -36,8 +39,12 @@ pub fn must_config_from_env() -> anyhow::Result<ConfigLoader> {
     let Some(_) = AWS_SECRET_ACCESS_KEY.clone() else {
         anyhow::bail!("AWS_SECRET_ACCESS_KEY env variable must be set");
     };
+    let Some(endpoint_url) = AWS_ENDPOINT_URL.clone() else {
+        anyhow::bail!("AWS_ENDPOINT_URL env variable must be set");
+    };
     let credentials = EnvironmentVariableCredentialsProvider::new();
     Ok(aws_config::defaults(BehaviorVersion::v2024_03_28())
+        .endpoint_url(endpoint_url)
         .region(region)
         .credentials_provider(credentials))
 }

--- a/crates/aws_utils/src/s3.rs
+++ b/crates/aws_utils/src/s3.rs
@@ -8,7 +8,7 @@ use aws_sdk_s3::{
 };
 use futures_async_stream::try_stream;
 
-use crate::must_config_from_env;
+use crate::must_s3_config_from_env;
 
 #[derive(Clone, Debug)]
 pub struct S3Client(pub Client);
@@ -21,7 +21,7 @@ impl S3Client {
             true => RetryConfig::standard(),
             false => RetryConfig::disabled(),
         };
-        let config = must_config_from_env()
+        let config = must_s3_config_from_env()
             .context("AWS env variables are required when using AWS Lambda")?
             .retry_config(retry_config)
             .load()


### PR DESCRIPTION
This PR introduces support for Cloudflare R2 by adding a new environment variable, AWS_ENDPOINT_URL, and replacing get_object_attributes with head_object.

From the [S3 documentation](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3/client/get_object_attributes.html), get_object_attributes combines the functionality of HeadObject and ListParts in a single call.
In the original code get_object_attributes was used to get the file size.
Since R2 does not support get_object_attributes, I use head_object instead.

@emmaling27 I would like your help on this.
I wanted to name the env variable S3_ENDPOINT_URL but I read that AWS automatically provides AWS_ENDPOINT_URL to lambda functions.
I can see you use `aws_config::defaults(BehaviorVersion::v2024_03_28())` which is equivalent to `aws_config::from_env()`, which I assumed automatically set defaults based on env variables ? From my tests it doesn't seem to do anything.
So right now I call `.endpoint_url(endpoint_url)` explicitly.
What is the best way to make it optional ? (I don't know much about rust)
Right now it's a mandatory variable ⚠️ which is not what we want.

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.