### PR TITLE
(docs: nextjs QS) fix incorrect title; update convexclientprovider explanation

### DIFF
--- a/npm-packages/docs/docs/quickstart/nextjs.mdx
+++ b/npm-packages/docs/docs/quickstart/nextjs.mdx
@@ -48,7 +48,7 @@ Alternatively see the
 version of this quickstart.
 
 <StepByStep>
-  <Step title="Create a React app">
+  <Step title="Create a Next.js app">
     Create a Next.js app using the `npx create-next-app` command.
 
     Choose the default option for every prompt (hit Enter).
@@ -66,8 +66,8 @@ version of this quickstart.
   </Step>
   <Step title="Install the Convex client and server library">
     To get started, install the `convex`
-    package which provides a convenient interface for working
-    with Convex from a React app.
+    package, which provides a convenient interface for working
+    with Convex.
 
     Navigate to your app and install `convex`.
 
@@ -106,9 +106,7 @@ version of this quickstart.
   </Step>
 
   <Step title="Add the sample data to your database">
-    Now that your project is ready, add a `tasks` table
-    with the sample data into your Convex database with
-    the `import` command.
+    Use the [`import`](/database/import-export/import) command to add a `tasks` table with the sample data into your Convex database.
 
     ```
     npx convex import --table tasks sampleData.jsonl
@@ -117,12 +115,11 @@ version of this quickstart.
   </Step>
 
   <Step title="Expose a database query">
-    Add a new file <JSDialectFileName name="tasks.ts" /> in the `convex/` folder
-    with a query function that loads the data.
+    In the `convex/` folder, add a new file <JSDialectFileName name="tasks.ts" /> with a query function that loads the data.
 
     Exporting a query function from this file
     declares an API function named after the file
-    and the export name, `api.tasks.get`.
+    and the export name: `api.tasks.get`.
 
     <TSAndJSSnippet
       sourceTS={tasks}
@@ -133,8 +130,9 @@ version of this quickstart.
   </Step>
 
   <Step title="Create a client component for the Convex provider">
-    Add a new file <JSDialectFileName name="ConvexClientProvider.tsx" /> in the `app/` folder. Include the `"use client";` directive, create a
-    `ConvexReactClient` and a component that wraps its children in a `ConvexProvider`.
+    For `<ConvexProvider>` to work on the client, `<ConvexReactClient>` must be passed to it.
+
+    In the `app/` folder, add a new file <JSDialectFileName name="ConvexClientProvider.tsx" /> with the following code. This creates a component that wraps `<ConvexProvider>` and passes it the `<ConvexReactClient>`.
 
     <TSAndJSSnippet
       sourceTS={ConvexClientProvider}
@@ -145,7 +143,7 @@ version of this quickstart.
   </Step>
 
   <Step title="Wire up the ConvexClientProvider">
-    In <JSDialectFileName name="app/layout.tsx" ext="js" />, wrap the children of the `body` element with the `ConvexClientProvider`.
+    In <JSDialectFileName name="app/layout.tsx" ext="js" />, wrap the children of the `body` element with the `<ConvexClientProvider>`.
 
     <TSAndJSSnippet
       sourceTS={layout}
@@ -158,7 +156,7 @@ version of this quickstart.
   </Step>
 
   <Step title="Display the data in your app">
-    In <JSDialectFileName name="app/page.tsx" ext="js" />, use the `useQuery` hook to fetch from your `api.tasks.get`
+    In <JSDialectFileName name="app/page.tsx" ext="js" />, use the `useQuery()` hook to fetch from your `api.tasks.get`
     API function.
 
     <TSAndJSSnippet
@@ -172,7 +170,7 @@ version of this quickstart.
   </Step>
 
   <Step title="Start the app">
-    Start the app, open [http://localhost:3000](http://localhost:3000) in a browser,
+    Run your development server, open [http://localhost:3000](http://localhost:3000) in a browser,
     and see the list of tasks.
 
     ```sh


### PR DESCRIPTION
<!-- Describe your PR here. -->

Clerk employee here 👋  While checking out the Convex docs to see how to integrate Convex into a Clerk + Next.js app, I noticed the Next.js QS could use some love. From the Clerk Docs team to yours 💜 

Notes about the changes:
- This all actually started as just [a title change](https://github.com/get-convex/convex-backend/compare/main...alexisintech:convex-backend:main?expand=1#diff-d0f1ae84b677c8e3045bd950b798b2e273145a91bb686efb419883e4f01c16dbR51), I saw "Create a React app" and I was like, well actually you're creating a Next.js app. So I went to open a PR, and was like, well while I'm here, I'll just update a few more things...
- Organize order of events sequentially, for better UX. E.g. "in the `convex/` folder" should be the lead of a sentence, because its the first in a sequence of events. A user will first need to go to their `convex/` folder to then create a new file; it's the first step so it should be the first direction given in the sentence.
- [The colon change in ``and the export name: `api.tasks.get`.``](https://github.com/get-convex/convex-backend/compare/main...alexisintech:convex-backend:main?expand=1#diff-d0f1ae84b677c8e3045bd950b798b2e273145a91bb686efb419883e4f01c16dbR122). It originally read as ``the export name, `api.tasks.get`.`` which grammatically was telling me that the export name was `api.tasks.get` which I was really confused by. When I finally got to the end of the QS, I learned that the API function itself is what's called `api.tasks.get` and then I understood what the doc was trying to convey. So I've made a small change to help understandability.
- Updated the explanation of creating a provider wrapper. I feel the copy was telling me what the code was doing syntactically, but the code speaks for itself. That's why there's an example paired with the copy! So instead, the copy here should be **explaining** what the code is doing. I updated the explanation to the best of my ability, and to how it made sense to me, but if the explanation is incorrect then of course, feel free to update.

Also, I'm surprised you don't abstract the `ConvexClientProvider` part away for users so they can skip the step of creating it themselves and simply import it from Convex itself and then wrap their app (similar to how we do `ClerkProvider`). 👀 

Cheers 😸💖

<!--
  The following applies to third-party contributors.
  Convex employees and contractors can delete or ignore.
-->

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
