### PR TITLE
fix broken internal link to generating file url(s)

### DIFF
--- a/npm-packages/docs/docs/file-storage/serve-files.mdx
+++ b/npm-packages/docs/docs/file-storage/serve-files.mdx
@@ -58,7 +58,7 @@ This enables access control at the time the file is served, such as when an
 image is displayed on a website. But note that the HTTP actions response size is
 [currently limited](/docs/functions/http-actions.mdx#limits) to 20MB. For larger
 files you need to use file URLs as described
-[above](#generating-file-url-in-queries).
+[above](#generating-file-urls-in-queries).
 
 A file [`Blob`](https://developer.mozilla.org/en-US/docs/Web/API/Blob) object
 can be generated from a storage ID by the


### PR DESCRIPTION
<!-- Describe your PR here. -->

Fixes broken internal link on page https://docs.convex.dev/file-storage/serve-files

The internal page link to 'above' points to
https://docs.convex.dev/file-storage/serve-files#generating-file-url-in-queries
should be (note missing `s`)
https://docs.convex.dev/file-storage/serve-files#generating-file-urls-in-queries

<!--
  The following applies to third-party contributors.
  Convex employees and contractors can delete or ignore.
-->

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
