### PR TITLE
fix: small url typo for AI Agent component in docs

### DIFF
--- a/npm-packages/docs/docs/components.mdx
+++ b/npm-packages/docs/docs/components.mdx
@@ -146,7 +146,7 @@ full directory on the [Convex website](https://convex.dev/components).
   items={[
     {
       type: "link",
-      href: "https://www.convex.dev/components/persistent-text-streaming",
+      href: "https://www.convex.dev/components/agent",
       label: "AI Agent",
       description: "Define agents with tools and memory",
     },


### PR DESCRIPTION
Small url typo in the documentation of components

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
