### PR TITLE
Agents component: Dashboard playground UI

### DIFF
--- a/npm-packages/dashboard-common/src/features/agents/components/Agents.tsx
+++ b/npm-packages/dashboard-common/src/features/agents/components/Agents.tsx
@@ -1,0 +1,12 @@
+import { Nent } from "@common/lib/useNents";
+
+export function Agents({ nents: allNents }: { nents: Nent[] }) {
+  const nents = allNents.filter((nent) => nent.name !== null);
+  const usingAgentComponent = nents.some(
+    (nent) => nent.name === "agent" && nent.path === "agent"
+  );
+  if (usingAgentComponent) {
+    return <div>Using AI Agents... show dashboard</div>;
+  }
+  return <div>Not using agents... follow docs to get set up</div>;
+}

--- a/npm-packages/dashboard-common/src/features/agents/components/AgentsView.tsx
+++ b/npm-packages/dashboard-common/src/features/agents/components/AgentsView.tsx
@@ -1,0 +1,15 @@
+import { DeploymentPageTitle } from "@common/elements/DeploymentPageTitle";
+import { LoadingTransition } from "@ui/Loading";
+import { PageContent } from "@common/elements/PageContent";
+import { useNents } from "@common/lib/useNents";
+import { Agents } from "@common/features/agents/components/Agents";
+
+export function AgentsView() {
+  const { nents } = useNents();
+  return (
+    <PageContent>
+      <DeploymentPageTitle title="AI Agents" />
+      <LoadingTransition>{nents && <Agents nents={nents} />}</LoadingTransition>
+    </PageContent>
+  );
+}

--- a/npm-packages/dashboard-common/src/layouts/DeploymentDashboardLayout.tsx
+++ b/npm-packages/dashboard-common/src/layouts/DeploymentDashboardLayout.tsx
@@ -21,6 +21,7 @@ import { FunctionRunnerWrapper } from "@common/features/functionRunner/component
 import { FunctionsProvider } from "@common/lib/functions/FunctionsProvider";
 import { useIsGlobalRunnerShown } from "@common/features/functionRunner/lib/functionRunner";
 import { useIsCloudDeploymentInSelfHostedDashboard } from "@common/lib/useIsCloudDeploymentInSelfHostedDashboard";
+import { BotIcon } from "@common/lib/logos/BotIcon";
 
 type LayoutProps = {
   children: JSX.Element;
@@ -79,6 +80,12 @@ export function DeploymentDashboardLayout({
       ),
       href: `${uriPrefix}/logs`,
     },
+    {
+      key: "agent",
+      label: "AI Agents",
+      Icon: (props: any) => <BotIcon {...props} />,
+      href: `${uriPrefix}/agents`,
+    },
   ];
 
   const sidebarItems = [
@@ -125,7 +132,7 @@ export function DeploymentDashboardLayout({
           <div
             className={classNames(
               "flex w-full grow overflow-x-hidden",
-              !isGlobalRunnerVertical && "flex-col",
+              !isGlobalRunnerVertical && "flex-col"
             )}
           >
             {/* If the function runner is fully expanded, hide the content */}
@@ -155,7 +162,7 @@ function PauseBanner() {
   const deploymentState = useQuery(udfs.deploymentState.deploymentState);
 
   const { useCurrentTeam, useCurrentUsageBanner } = useContext(
-    DeploymentInfoContext,
+    DeploymentInfoContext
   );
 
   const team = useCurrentTeam();

--- a/npm-packages/dashboard-common/src/lib/logos/BotIcon.tsx
+++ b/npm-packages/dashboard-common/src/lib/logos/BotIcon.tsx
@@ -1,0 +1,23 @@
+export function BotIcon() {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="16"
+      height="16"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className="text-content-secondary"
+    >
+      <path d="M12 8V4H8" />
+      <rect width="16" height="12" x="4" y="8" rx="2" />
+      <path d="M2 14h2" />
+      <path d="M20 14h2" />
+      <path d="M15 13v2" />
+      <path d="M9 13v2" />
+    </svg>
+  );
+}

--- a/npm-packages/dashboard-self-hosted/src/pages/agents.tsx
+++ b/npm-packages/dashboard-self-hosted/src/pages/agents.tsx
@@ -1,0 +1,3 @@
+import { AgentsView } from "@common/features/agents/components/AgentsView";
+
+export default AgentsView;


### PR DESCRIPTION
Following on from [this discussion](https://github.com/get-convex/agent/issues/3) by @ianmacartney - looking to add some dashboard functionality to add more traceability to agent performance similar to langsmith etc.

Couldnt find any references for whole feature drops onto this repo so please let me know how you'd like me to go about this to assist best with code reviews as dropping whole features isnt ideal but likewise half baked isnt great either

Current plan for first PR:
- Show screen for users who arent using the component that links to the docs on how to get set up
- Show paginated table of threads, click on row opens a sheet with the steps within that thread, the metadata and messages.
    - show input context
    - show by order top to bottom, with step order left to right 
    - show graph based on parent ID (maybe only if non-linear?)

Future work (credits - @ianmacartney )

- Visualize tool calling graphs.
- Inspect and replay past conversations while tuning prompts.
- Interactively debug failed generations.
- Search messages while tuning search parameters for your usecase.
- Replaying failed steps and exporting evals to prevent regressions once you get it working.
- Allow re-running with different input context
- Allow re-running sub-steps? how to find the tool to call?
- Interactive playground
- Log search history results

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
