### PR TITLE
Fix Markdown link syntax

### DIFF
--- a/npm-packages/docs/docs/auth.mdx
+++ b/npm-packages/docs/docs/auth.mdx
@@ -80,7 +80,7 @@ public request against any authorization rules you can define in code.
 Thus Convex does not need an opinionated authorization framework like RLS, which
 is required in client oriented databases like Firebase or Supabase. This
 flexibility lets you build and use an [authorization
-framework[(https://en.wikipedia.org/wiki/Authorization)] for your needs.
+framework](https://en.wikipedia.org/wiki/Authorization) for your needs.
 
 That said, the most common way is to simply write code that checks if the user
 is logged in and if they are allowed to do the requested action at the beginning


### PR DESCRIPTION
Noticed a mis-formatted link in the docs.

https://docs.convex.dev/auth

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
