### PR TITLE
Update database usage section for self hosted

### DIFF
--- a/npm-packages/docs/docs/understanding/index.mdx
+++ b/npm-packages/docs/docs/understanding/index.mdx
@@ -45,7 +45,7 @@ relations, like `tasks` assigned to a `user` using IDs to reference documents in
 other tables.
 
 The Convex cloud offering runs on top of Amazon RDS using MySQL as its
-persistence layer. The Open Source version uses SQLite, and soon Postgres or
+persistence layer. The Open Source version uses SQLite, Postgres and
 MySQL. The database is ACID-compliant and uses
 [serializable isolation and optimistic concurrency control](/docs/database/advanced/occ.md).
 All that to say, Convex provides the strictest possible transactional


### PR DESCRIPTION
<!-- Describe your PR here. -->
Fixes the database section since convex recently started adding internal data to postgres and MySQL as well in self hosted versions.

[Source](https://github.com/get-convex/convex-backend/tree/main/self-hosted#running-the-database-on-postgres-or-mysql)


<!--
  The following applies to third-party contributors.
  Convex employees and contractors can delete or ignore.
-->

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
