### PR TITLE
docs(tanstack-quickstart): change start status from alpha to beta

### DIFF
--- a/npm-packages/docs/docs/quickstart/tanstack-start.mdx
+++ b/npm-packages/docs/docs/quickstart/tanstack-start.mdx
@@ -12,7 +12,7 @@ import router from "!!raw-loader!@site/../private-demos/quickstarts/tanstack-sta
 import index from "!!raw-loader!@site/../private-demos/quickstarts/tanstack-start/app/routes/index.tsx";
 import tasks from "!!raw-loader!@site/../private-demos/quickstarts/tanstack-start/convex/tasks.ts";
 
-<Admonition type="caution" title="TanStack Start is in Alpha">
+<Admonition type="caution" title="TanStack Start is in Beta">
 
 [TanStack Start](https://tanstack.com/start/latest) is a new React framework
 currently in beta. You can try it today but there are likely to be breaking


### PR DESCRIPTION
<!-- Describe your PR here. -->
This fixes an inconsistency in the TanStack Start quickstart docs, where the Admonition panel still labeled the project as “Alpha” even though the copy text referred to “Beta.” Since TanStack Start has officially entered beta, this change updates the Admonition title from “Alpha” to “Beta” so that the documentation accurately reflects its current stage.


<!--
  The following applies to third-party contributors.
  Convex employees and contractors can delete or ignore.
-->

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
