### PR TITLE
print tablename in unique() error message

### DIFF
--- a/npm-packages/convex/src/server/impl/query_impl.ts
+++ b/npm-packages/convex/src/server/impl/query_impl.ts
@@ -166,9 +166,15 @@ export class QueryImpl implements Query<GenericTableInfo> {
     | { type: "executing"; queryId: number }
     | { type: "closed" }
     | { type: "consumed" };
-
+  private tableName: string;
+  
   constructor(query: SerializedQuery) {
     this.state = { type: "preparing", query };
+    if (query.source.type === "FullTableScan") {
+      this.tableName = query.source.tableName;
+    } else {
+      this.tableName = query.source.indexName.split(".")[0];
+    }
   }
 
   private takeQuery(): SerializedQuery {
@@ -333,7 +339,7 @@ export class QueryImpl implements Query<GenericTableInfo> {
       return null;
     }
     if (first_two_array.length === 2) {
-      throw new Error(`unique() query returned more than one result: 
+      throw new Error(`unique() query returned more than one result from table ${this.tableName}: 
  [${first_two_array[0]._id}, ${first_two_array[1]._id}, ...]`);
     }
     return first_two_array[0];


### PR DESCRIPTION
<!-- Describe your PR here. -->
Improves usefulness of the error thrown when `.unique()` returns more than 1 result by now also printing the table name.

Improves quality of life: currently, it can be cumbersome to identify the actual table in which these non-unique elements belong.

This solution is a bit work-around-y, but it's the only solution I could come up with. Let me know if there is a better way to achieve this!

<!--
  The following applies to third-party contributors.
  Convex employees and contractors can delete or ignore.
-->

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
