### PR TITLE
Fix self-hosted guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,4 +31,4 @@ Instructions for building and running Convex packages locally:
 
 Note: If you just want to self-host Convex and not modify the codebase, we
 recommend using the pre-built Docker image or binary. See the
-[self-hosted README](../self-hosted/README.md) for more information.
+[self-hosted README](self-hosted/README.md) for more information.


### PR DESCRIPTION
## PR Summary
This small PR fixes the `self-hosted/README.md` reference in `CONTRIBUTING.md`.