### PR TITLE
docs: remove redundant line in mutation docs

### DIFF
--- a/npm-packages/docs/docs/functions/mutation-functions.mdx
+++ b/npm-packages/docs/docs/functions/mutation-functions.mdx
@@ -162,11 +162,8 @@ npm install @faker-js/faker
 
 ## Calling mutations from clients
 
-To call a mutation from [React](/client/react.mdx) use the generated
-[`useMutation`](/client/react.mdx#editing-data) hook:
-
 To call a mutation from [React](/client/react.mdx) use the
-[`useMutation`](/api/modules/react#usemutation) hook along with the generated
+[`useMutation`](/client/react.mdx#editing-data) hook along with the generated
 [`api`](/generated-api/api) object.
 
 <TSAndJSSnippet sourceTS={Call} sourceJS={Call} title="src/myApp.tsx" />


### PR DESCRIPTION
Removes repeated sentence from mutation docs to keep it consistent with query docs.

Thanks for the great tool and docs!

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
