### PR TITLE
Remote IP available through context-object

### DIFF
--- a/crates/application/src/cron_jobs/mod.rs
+++ b/crates/application/src/cron_jobs/mod.rs
@@ -639,6 +639,7 @@ impl<RT: Runtime> CronJobContext<RT> {
                     request_id.clone().unwrap_or_else(RequestId::new),
                     execution_id.clone().unwrap_or_else(ExecutionId::new),
                     caller.parent_scheduled_job(),
+                    caller.remote_ip(),
                     caller.is_root(),
                 );
                 sentry::configure_scope(|scope| context.add_sentry_tags(scope));

--- a/crates/application/src/scheduled_jobs/mod.rs
+++ b/crates/application/src/scheduled_jobs/mod.rs
@@ -832,6 +832,7 @@ impl<RT: Runtime> ScheduledJobContext<RT> {
                     request_id.clone().unwrap_or_else(RequestId::new),
                     execution_id.clone().unwrap_or_else(ExecutionId::new),
                     caller.parent_scheduled_job(),
+                    caller.remote_ip(),
                     caller.is_root(),
                 );
                 sentry::configure_scope(|scope| context.add_sentry_tags(scope));

--- a/crates/application/src/tests/http_action.rs
+++ b/crates/application/src/tests/http_action.rs
@@ -77,7 +77,7 @@ async fn test_http_action_basic(rt: TestRuntime) -> anyhow::Result<()> {
             common::RequestId::new(),
             http_request,
             Identity::system(),
-            FunctionCaller::HttpEndpoint,
+            FunctionCaller::HttpEndpoint(None),
             response_streamer,
         )
         .await?;
@@ -134,7 +134,7 @@ async fn test_http_action_error(rt: TestRuntime) -> anyhow::Result<()> {
             common::RequestId::new(),
             http_request,
             Identity::system(),
-            FunctionCaller::HttpEndpoint,
+            FunctionCaller::HttpEndpoint(None),
             response_streamer,
         )
         .await?;
@@ -191,7 +191,7 @@ async fn test_http_action_not_found(rt: TestRuntime) -> anyhow::Result<()> {
             common::RequestId::new(),
             http_request,
             Identity::system(),
-            FunctionCaller::HttpEndpoint,
+            FunctionCaller::HttpEndpoint(None),
             response_streamer,
         )
         .await?;
@@ -243,7 +243,7 @@ async fn test_http_action_disconnect_before_head(
         common::RequestId::new(),
         http_request,
         Identity::system(),
-        FunctionCaller::HttpEndpoint,
+        FunctionCaller::HttpEndpoint(None),
         response_streamer,
     ));
     select! {
@@ -307,7 +307,7 @@ async fn test_http_action_disconnect_while_streaming(
                 common::RequestId::new(),
                 http_request,
                 Identity::system(),
-                FunctionCaller::HttpEndpoint,
+                FunctionCaller::HttpEndpoint(None),
                 response_streamer,
             )
             .await
@@ -382,7 +382,7 @@ async fn test_http_action_continues_after_client_disconnects(
                 common::RequestId::new(),
                 http_request,
                 Identity::system(),
-                FunctionCaller::HttpEndpoint,
+                FunctionCaller::HttpEndpoint(None),
                 response_streamer,
             )
             .await
@@ -414,7 +414,7 @@ async fn test_http_action_continues_after_client_disconnects(
                 udf_path: "functions:didWrite".parse()?,
             },
             vec![json!({})],
-            FunctionCaller::HttpEndpoint,
+            FunctionCaller::HttpEndpoint(None),
             ExecuteQueryTimestamp::Latest,
             None,
         )

--- a/crates/application/src/tests/logging.rs
+++ b/crates/application/src/tests/logging.rs
@@ -83,7 +83,7 @@ async fn test_udf_logs(rt: TestRuntime) -> anyhow::Result<()> {
             PublicFunctionPath::Component(path),
             vec![],
             Identity::system(),
-            FunctionCaller::SyncWorker(ClientVersion::unknown()),
+            FunctionCaller::SyncWorker(ClientVersion::unknown(), None),
         )
         .await?;
     assert!(result.result.is_ok());

--- a/crates/application/src/tests/returns_validation.rs
+++ b/crates/application/src/tests/returns_validation.rs
@@ -40,7 +40,7 @@ async fn run_zero_arg_mutation(
             vec![obj],
             Identity::user(UserIdentity::test()),
             None,
-            FunctionCaller::HttpEndpoint,
+            FunctionCaller::HttpEndpoint(None),
             None,
         )
         .await
@@ -60,7 +60,7 @@ async fn run_zero_arg_query(
             }),
             vec![obj],
             Identity::user(UserIdentity::test()),
-            FunctionCaller::HttpEndpoint,
+            FunctionCaller::HttpEndpoint(None),
         )
         .await
 }
@@ -79,7 +79,7 @@ async fn run_zero_arg_action(
             }),
             vec![obj],
             Identity::user(UserIdentity::test()),
-            FunctionCaller::HttpEndpoint,
+            FunctionCaller::HttpEndpoint(None),
         )
         .await
 }

--- a/crates/common/src/execution_context.rs
+++ b/crates/common/src/execution_context.rs
@@ -51,11 +51,13 @@ pub struct ExecutionContext {
 
 impl ExecutionContext {
     pub fn new(request_id: RequestId, caller: &FunctionCaller) -> Self {
+        let remote_ip = caller.remote_ip();
+        tracing::info!("🔍 Creating ExecutionContext with remote IP: {:?}", remote_ip);
         Self {
             request_id,
             execution_id: ExecutionId::new(),
             parent_scheduled_job: caller.parent_scheduled_job(),
-            remote_ip: caller.remote_ip(),
+            remote_ip,
             is_root: caller.is_root(),
         }
     }
@@ -312,11 +314,14 @@ impl TryFrom<pb::common::ExecutionContext> for ExecutionContext {
 impl From<ExecutionContext> for JsonValue {
     fn from(value: ExecutionContext) -> Self {
         let (parent_component_id, parent_document_id) = value.parent_scheduled_job.unzip();
+        let remote_ip_str = value.remote_ip.map(|addr| addr.to_string());
+        tracing::info!("🔍 Serializing ExecutionContext to JSON with remoteIp: {:?}", remote_ip_str);
         json!({
             "requestId": String::from(value.request_id),
             "executionId": value.execution_id.to_string(),
             "isRoot": value.is_root,
-            "remoteIp": value.remote_ip.map(|addr| addr.to_string()),
+            "remoteIp": remote_ip_str,
+            "testValue": "HELLO_FROM_RUST",
             "parentScheduledJob": parent_document_id.map(|id| id.to_string()),
             "parentScheduledJobComponentId": parent_component_id.unwrap_or(ComponentId::Root).serialize_to_string(),
         })

--- a/crates/common/src/execution_context.rs
+++ b/crates/common/src/execution_context.rs
@@ -52,7 +52,6 @@ pub struct ExecutionContext {
 impl ExecutionContext {
     pub fn new(request_id: RequestId, caller: &FunctionCaller) -> Self {
         let remote_ip = caller.remote_ip();
-        tracing::info!("🔍 Creating ExecutionContext with remote IP: {:?}", remote_ip);
         Self {
             request_id,
             execution_id: ExecutionId::new(),
@@ -315,7 +314,6 @@ impl From<ExecutionContext> for JsonValue {
     fn from(value: ExecutionContext) -> Self {
         let (parent_component_id, parent_document_id) = value.parent_scheduled_job.unzip();
         let remote_ip_str = value.remote_ip.map(|addr| addr.to_string());
-        tracing::info!("🔍 Serializing ExecutionContext to JSON with remoteIp: {:?}", remote_ip_str);
         json!({
             "requestId": String::from(value.request_id),
             "executionId": value.execution_id.to_string(),

--- a/crates/common/src/types/functions.rs
+++ b/crates/common/src/types/functions.rs
@@ -3,6 +3,7 @@ use std::{
         self,
         Debug,
     },
+    net::SocketAddr,
     str::FromStr,
 };
 
@@ -145,13 +146,13 @@ pub enum AllowedVisibility {
 #[derive(Clone, Debug, PartialEq, Eq, Ord, PartialOrd)]
 #[cfg_attr(any(test, feature = "testing"), derive(proptest_derive::Arbitrary))]
 pub enum FunctionCaller {
-    SyncWorker(ClientVersion),
-    HttpApi(ClientVersion),
+    SyncWorker(ClientVersion, Option<SocketAddr>),
+    HttpApi(ClientVersion, Option<SocketAddr>),
     /// Used by function tester in the dashboard
     Tester(ClientVersion),
     // This is a user defined http actions called externally. If the http action
     // calls other functions, their caller would be `Action`.
-    HttpEndpoint,
+    HttpEndpoint(Option<SocketAddr>),
     Cron,
     Scheduler {
         job_id: DeveloperDocumentId,
@@ -168,10 +169,10 @@ pub enum FunctionCaller {
 impl FunctionCaller {
     pub fn client_version(&self) -> Option<ClientVersion> {
         match self {
-            FunctionCaller::SyncWorker(c) => Some(c),
-            FunctionCaller::HttpApi(c) => Some(c),
+            FunctionCaller::SyncWorker(c, _) => Some(c),
+            FunctionCaller::HttpApi(c, _) => Some(c),
             FunctionCaller::Tester(c) => Some(c),
-            FunctionCaller::HttpEndpoint
+            FunctionCaller::HttpEndpoint(_)
             | FunctionCaller::Cron
             | FunctionCaller::Scheduler { .. }
             | FunctionCaller::Action { .. } => None,
@@ -183,10 +184,10 @@ impl FunctionCaller {
 
     pub fn parent_scheduled_job(&self) -> Option<(ComponentId, DeveloperDocumentId)> {
         match self {
-            FunctionCaller::SyncWorker(_)
-            | FunctionCaller::HttpApi(_)
+            FunctionCaller::SyncWorker(_, _)
+            | FunctionCaller::HttpApi(_, _)
             | FunctionCaller::Tester(_)
-            | FunctionCaller::HttpEndpoint
+            | FunctionCaller::HttpEndpoint(_)
             | FunctionCaller::Cron => None,
             #[cfg(any(test, feature = "testing"))]
             FunctionCaller::Test => None,
@@ -200,12 +201,26 @@ impl FunctionCaller {
         }
     }
 
+    pub fn remote_ip(&self) -> Option<SocketAddr> {
+        match self {
+            FunctionCaller::SyncWorker(_, remote_ip) 
+            | FunctionCaller::HttpApi(_, remote_ip) 
+            | FunctionCaller::HttpEndpoint(remote_ip) => *remote_ip,
+            FunctionCaller::Tester(_)
+            | FunctionCaller::Cron
+            | FunctionCaller::Scheduler { .. }
+            | FunctionCaller::Action { .. } => None,
+            #[cfg(any(test, feature = "testing"))]
+            FunctionCaller::Test => None,
+        }
+    }
+
     pub fn is_root(&self) -> bool {
         match self {
-            FunctionCaller::SyncWorker(_)
-            | FunctionCaller::HttpApi(_)
+            FunctionCaller::SyncWorker(_, _)
+            | FunctionCaller::HttpApi(_, _)
             | FunctionCaller::Tester(_)
-            | FunctionCaller::HttpEndpoint
+            | FunctionCaller::HttpEndpoint(_)
             | FunctionCaller::Cron
             | FunctionCaller::Scheduler { .. } => true,
             FunctionCaller::Action { .. } => false,
@@ -219,9 +234,9 @@ impl FunctionCaller {
         // to run it even if the client goes away. However, we preserve the right
         // to interrupt actions if the backend restarts.
         match self {
-            FunctionCaller::SyncWorker(_)
-            | FunctionCaller::HttpApi(_)
-            | FunctionCaller::HttpEndpoint
+            FunctionCaller::SyncWorker(_, _)
+            | FunctionCaller::HttpApi(_, _)
+            | FunctionCaller::HttpEndpoint(_)
             | FunctionCaller::Tester(_) => true,
             FunctionCaller::Cron
             | FunctionCaller::Scheduler { .. }
@@ -233,13 +248,13 @@ impl FunctionCaller {
 
     pub fn allowed_visibility(&self) -> AllowedVisibility {
         match self {
-            FunctionCaller::SyncWorker(_) | FunctionCaller::HttpApi(_) => {
+            FunctionCaller::SyncWorker(_, _) | FunctionCaller::HttpApi(_, _) => {
                 AllowedVisibility::PublicOnly
             },
             // NOTE: Allowed visibility doesn't make sense in the context of an
             // user defined http action since all http actions are public, and
             // we shouldn't be checking visibility. We define this for completeness.
-            FunctionCaller::HttpEndpoint => AllowedVisibility::PublicOnly,
+            FunctionCaller::HttpEndpoint(_) => AllowedVisibility::PublicOnly,
             FunctionCaller::Tester(_)
             | FunctionCaller::Cron
             | FunctionCaller::Scheduler { .. }
@@ -253,10 +268,10 @@ impl FunctionCaller {
 impl fmt::Display for FunctionCaller {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let s = match self {
-            FunctionCaller::SyncWorker(_) => "SyncWorker",
-            FunctionCaller::HttpApi(_) => "HttpApi",
+            FunctionCaller::SyncWorker(_, _) => "SyncWorker",
+            FunctionCaller::HttpApi(_, _) => "HttpApi",
             FunctionCaller::Tester(_) => "Tester",
-            FunctionCaller::HttpEndpoint => "HttpEndpoint",
+            FunctionCaller::HttpEndpoint(_) => "HttpEndpoint",
             FunctionCaller::Cron => "Cron",
             FunctionCaller::Scheduler { .. } => "Scheduler",
             FunctionCaller::Action { .. } => "Action",
@@ -270,16 +285,16 @@ impl fmt::Display for FunctionCaller {
 impl From<FunctionCaller> for pb::common::FunctionCaller {
     fn from(caller: FunctionCaller) -> Self {
         let caller = match caller {
-            FunctionCaller::SyncWorker(client_version) => {
+            FunctionCaller::SyncWorker(client_version, _) => {
                 pb::common::function_caller::Caller::SyncWorker(client_version.into())
             },
-            FunctionCaller::HttpApi(client_version) => {
+            FunctionCaller::HttpApi(client_version, _) => {
                 pb::common::function_caller::Caller::HttpApi(client_version.into())
             },
             FunctionCaller::Tester(client_version) => {
                 pb::common::function_caller::Caller::Tester(client_version.into())
             },
-            FunctionCaller::HttpEndpoint => pb::common::function_caller::Caller::HttpEndpoint(()),
+            FunctionCaller::HttpEndpoint(_) => pb::common::function_caller::Caller::HttpEndpoint(()),
             FunctionCaller::Cron => pb::common::function_caller::Caller::Cron(()),
             FunctionCaller::Scheduler {
                 job_id,
@@ -318,16 +333,16 @@ impl TryFrom<pb::common::FunctionCaller> for FunctionCaller {
     fn try_from(msg: pb::common::FunctionCaller) -> anyhow::Result<Self> {
         let caller = match msg.caller {
             Some(pb::common::function_caller::Caller::SyncWorker(client_version)) => {
-                FunctionCaller::SyncWorker(client_version.try_into()?)
+                FunctionCaller::SyncWorker(client_version.try_into()?, None)
             },
             Some(pb::common::function_caller::Caller::HttpApi(client_version)) => {
-                FunctionCaller::HttpApi(client_version.try_into()?)
+                FunctionCaller::HttpApi(client_version.try_into()?, None)
             },
             Some(pb::common::function_caller::Caller::Tester(client_version)) => {
                 FunctionCaller::Tester(client_version.try_into()?)
             },
             Some(pb::common::function_caller::Caller::HttpEndpoint(())) => {
-                FunctionCaller::HttpEndpoint
+                FunctionCaller::HttpEndpoint(None)
             },
             Some(pb::common::function_caller::Caller::Cron(())) => FunctionCaller::Cron,
             Some(pb::common::function_caller::Caller::Scheduler(caller)) => {

--- a/crates/common/src/types/functions.rs
+++ b/crates/common/src/types/functions.rs
@@ -213,7 +213,6 @@ impl FunctionCaller {
             #[cfg(any(test, feature = "testing"))]
             FunctionCaller::Test => None,
         };
-        tracing::info!("🔍 FunctionCaller::remote_ip() called, returning: {:?}", remote_ip);
         remote_ip
     }
 

--- a/crates/common/src/types/functions.rs
+++ b/crates/common/src/types/functions.rs
@@ -202,7 +202,7 @@ impl FunctionCaller {
     }
 
     pub fn remote_ip(&self) -> Option<SocketAddr> {
-        match self {
+        let remote_ip = match self {
             FunctionCaller::SyncWorker(_, remote_ip) 
             | FunctionCaller::HttpApi(_, remote_ip) 
             | FunctionCaller::HttpEndpoint(remote_ip) => *remote_ip,
@@ -212,7 +212,9 @@ impl FunctionCaller {
             | FunctionCaller::Action { .. } => None,
             #[cfg(any(test, feature = "testing"))]
             FunctionCaller::Test => None,
-        }
+        };
+        tracing::info!("🔍 FunctionCaller::remote_ip() called, returning: {:?}", remote_ip);
+        remote_ip
     }
 
     pub fn is_root(&self) -> bool {

--- a/crates/isolate/src/environment/udf/mod.rs
+++ b/crates/isolate/src/environment/udf/mod.rs
@@ -999,4 +999,8 @@ impl<RT: Runtime> DatabaseUdfEnvironment<RT> {
         }
         Ok(())
     }
+    
+    pub fn execution_context(&self) -> &ExecutionContext {
+        &self.context
+    }
 }

--- a/crates/isolate/src/isolate2/callback_context.rs
+++ b/crates/isolate/src/isolate2/callback_context.rs
@@ -595,5 +595,10 @@ mod op_provider {
         fn remove_text_decoder(&mut self, uuid: &Uuid) -> anyhow::Result<TextDecoderResource> {
             self.context_state()?.remove_text_decoder(uuid)
         }
+        
+        fn get_execution_context(&mut self) -> anyhow::Result<Option<serde_json::Value>> {
+            let state = self.context_state()?;
+            state.environment.get_execution_context()
+        }
     }
 }

--- a/crates/isolate/src/isolate2/callback_context.rs
+++ b/crates/isolate/src/isolate2/callback_context.rs
@@ -595,7 +595,7 @@ mod op_provider {
         fn remove_text_decoder(&mut self, uuid: &Uuid) -> anyhow::Result<TextDecoderResource> {
             self.context_state()?.remove_text_decoder(uuid)
         }
-        
+
         fn get_execution_context(&mut self) -> anyhow::Result<Option<serde_json::Value>> {
             let state = self.context_state()?;
             state.environment.get_execution_context()

--- a/crates/isolate/src/isolate2/context.rs
+++ b/crates/isolate/src/isolate2/context.rs
@@ -83,6 +83,7 @@ impl Context {
             let op_key = strings::op.create(&mut scope)?;
             convex_value.set(&mut scope, op_key.into(), op_value.into());
 
+
             let async_op_template =
                 v8::FunctionTemplate::new(&mut scope, CallbackContext::start_async_op);
             let async_op_value = async_op_template

--- a/crates/isolate/src/isolate2/environment.rs
+++ b/crates/isolate/src/isolate2/environment.rs
@@ -44,6 +44,6 @@ pub trait Environment {
     fn finish_execution(&mut self) -> anyhow::Result<EnvironmentOutcome>;
 
     fn get_all_table_mappings(&mut self) -> anyhow::Result<NamespacedTableMapping>;
-    
+
     fn get_execution_context(&mut self) -> anyhow::Result<Option<serde_json::Value>>;
 }

--- a/crates/isolate/src/isolate2/environment.rs
+++ b/crates/isolate/src/isolate2/environment.rs
@@ -44,4 +44,6 @@ pub trait Environment {
     fn finish_execution(&mut self) -> anyhow::Result<EnvironmentOutcome>;
 
     fn get_all_table_mappings(&mut self) -> anyhow::Result<NamespacedTableMapping>;
+    
+    fn get_execution_context(&mut self) -> anyhow::Result<Option<serde_json::Value>>;
 }

--- a/crates/isolate/src/isolate2/runner.rs
+++ b/crates/isolate/src/isolate2/runner.rs
@@ -243,7 +243,7 @@ struct UdfEnvironment<RT: Runtime> {
 
     #[allow(unused)]
     env_vars: PreloadedEnvironmentVariables,
-    
+
     execution_context: ExecutionContext,
 }
 
@@ -474,7 +474,7 @@ impl<RT: Runtime> Environment for UdfEnvironment<RT> {
         self.check_executing()?;
         Ok(self.shared.get_all_table_mappings())
     }
-    
+
     fn get_execution_context(&mut self) -> anyhow::Result<Option<serde_json::Value>> {
         let context_json: serde_json::Value = self.execution_context.clone().into();
         Ok(Some(context_json))

--- a/crates/isolate/src/ops/mod.rs
+++ b/crates/isolate/src/ops/mod.rs
@@ -38,9 +38,6 @@ use common::{
         EnvVarValue,
     },
 };
-use runtime::prod::ProdRuntime;
-#[cfg(any(test, feature = "testing"))]
-use runtime::testing::TestRuntime;
 use crypto::{
     op_crypto_decrypt,
     op_crypto_encrypt,
@@ -51,6 +48,9 @@ use deno_core::{
     ModuleSpecifier,
 };
 use rand_chacha::ChaCha12Rng;
+use runtime::prod::ProdRuntime;
+#[cfg(any(test, feature = "testing"))]
+use runtime::testing::TestRuntime;
 use sourcemap::SourceMap;
 use structured_clone::op_structured_clone;
 use uuid::Uuid;
@@ -205,7 +205,7 @@ pub trait OpProvider<'b> {
         -> anyhow::Result<Option<EnvVarValue>>;
 
     fn get_all_table_mappings(&mut self) -> anyhow::Result<NamespacedTableMapping>;
-    
+
     fn get_execution_context(&mut self) -> anyhow::Result<Option<serde_json::Value>>;
 }
 
@@ -356,34 +356,42 @@ impl<'a, 'b: 'a, RT: Runtime, E: IsolateEnvironment<RT>> OpProvider<'b>
         let state = self.state_mut()?;
         state.environment.get_all_table_mappings()
     }
-    
+
     fn get_execution_context(&mut self) -> anyhow::Result<Option<serde_json::Value>> {
+        use std::any::{
+            Any,
+            TypeId,
+        };
+
         use crate::environment::udf::DatabaseUdfEnvironment;
-        use std::any::{Any, TypeId};
-        
+
         let state = self.state_mut()?;
-        
+
         // Check if this is a DatabaseUdfEnvironment by checking type ID
         let environment_any = &state.environment as &dyn Any;
         let type_id = environment_any.type_id();
-        
+
         // Try common runtime types
         if type_id == TypeId::of::<DatabaseUdfEnvironment<ProdRuntime>>() {
-            if let Some(udf_env) = environment_any.downcast_ref::<DatabaseUdfEnvironment<ProdRuntime>>() {
+            if let Some(udf_env) =
+                environment_any.downcast_ref::<DatabaseUdfEnvironment<ProdRuntime>>()
+            {
                 let context_json: serde_json::Value = udf_env.execution_context().clone().into();
                 return Ok(Some(context_json));
             }
         }
-        
+
         // Add other runtime types as needed
         #[cfg(any(test, feature = "testing"))]
         if type_id == TypeId::of::<DatabaseUdfEnvironment<TestRuntime>>() {
-            if let Some(udf_env) = environment_any.downcast_ref::<DatabaseUdfEnvironment<TestRuntime>>() {
+            if let Some(udf_env) =
+                environment_any.downcast_ref::<DatabaseUdfEnvironment<TestRuntime>>()
+            {
                 let context_json: serde_json::Value = udf_env.execution_context().clone().into();
                 return Ok(Some(context_json));
             }
         }
-        
+
         // Not in UDF environment - return None
         Ok(None)
     }
@@ -465,7 +473,7 @@ pub fn run_op<'b, P: OpProvider<'b>>(
         "crypto/exportPkcs8X25519" => op_crypto_export_pkcs8_x25519(provider, args, rv)?,
         "crypto/generateKeyPair" => op_crypto_generate_keypair(provider, args, rv)?,
         "crypto/generateKeyBytes" => op_crypto_generate_key_bytes(provider, args, rv)?,
-        "getExecutionContext" => op_get_execution_context(provider, args, rv)?,
+        "getRemoteIp" => op_get_remote_ip(provider, args, rv)?,
         _ => {
             anyhow::bail!(ErrorMetadata::bad_request(
                 "UnknownOperation",
@@ -512,17 +520,24 @@ pub fn start_async_op<'b, P: OpProvider<'b>>(
     Ok(())
 }
 
-// Access to execution context for user functions
-pub fn op_get_execution_context<'b, P: OpProvider<'b>>(
+// Get remote IP address for the current request
+pub fn op_get_remote_ip<'b, P: OpProvider<'b>>(
     provider: &mut P,
     _args: v8::FunctionCallbackArguments,
     mut rv: v8::ReturnValue,
 ) -> anyhow::Result<()> {
-    // Get the execution context using the trait method
+    // Get the execution context and extract remote IP
     let context_json = provider.get_execution_context()?;
     
-    // Return the context or empty object if not available
-    let result = context_json.unwrap_or_else(|| serde_json::json!({}));
+    let result = if let Some(ctx) = context_json {
+        if let Some(ip) = ctx.get("remoteIp").and_then(|ip| ip.as_str()) {
+            serde_json::Value::String(ip.to_string())
+        } else {
+            serde_json::Value::Null
+        }
+    } else {
+        serde_json::Value::Null
+    };
     
     // Convert to V8 value and return
     let v8_value = serde_v8::to_v8(provider.scope(), result)?;

--- a/crates/isolate/src/ops/mod.rs
+++ b/crates/isolate/src/ops/mod.rs
@@ -518,12 +518,8 @@ pub fn op_get_execution_context<'b, P: OpProvider<'b>>(
     _args: v8::FunctionCallbackArguments,
     mut rv: v8::ReturnValue,
 ) -> anyhow::Result<()> {
-    tracing::info!("🔍 op_get_execution_context called!");
-    
     // Get the execution context using the trait method
     let context_json = provider.get_execution_context()?;
-    
-    tracing::info!("🔍 Retrieved execution context: {:?}", context_json);
     
     // Return the context or empty object if not available
     let result = context_json.unwrap_or_else(|| serde_json::json!({}));
@@ -532,6 +528,5 @@ pub fn op_get_execution_context<'b, P: OpProvider<'b>>(
     let v8_value = serde_v8::to_v8(provider.scope(), result)?;
     rv.set(v8_value);
     
-    tracing::info!("🔍 op_get_execution_context completed successfully");
     Ok(())
 }

--- a/crates/local_backend/src/http_actions.rs
+++ b/crates/local_backend/src/http_actions.rs
@@ -155,6 +155,7 @@ impl FromRequest<RouterState, axum::body::Body> for ExtractHttpRequestMetadata {
 #[debug_handler]
 pub async fn http_any_method(
     State(st): State<RouterState>,
+    remote_addr: axum::extract::ConnectInfo<std::net::SocketAddr>,
     TryExtractIdentity(identity_result): TryExtractIdentity,
     ExtractRequestId(request_id): ExtractRequestId,
     ExtractResolvedHostname(host): ExtractResolvedHostname,
@@ -222,7 +223,7 @@ async fn stream_http_response(
                 request_id,
                 http_request_metadata,
                 identity,
-                FunctionCaller::HttpEndpoint,
+                FunctionCaller::HttpEndpoint(Some(remote_addr.0)),
                 HttpActionResponseStreamer::new(http_response_sender),
             )
             .fuse();

--- a/crates/local_backend/src/http_actions.rs
+++ b/crates/local_backend/src/http_actions.rs
@@ -173,6 +173,7 @@ pub async fn http_any_method(
         http_request_metadata,
         identity,
         st.api.clone(),
+        remote_addr.0,
     );
     let head = http_response_stream.try_next().await?;
     let Some(HttpActionResponsePart::Head(response_head)) = head else {
@@ -213,6 +214,7 @@ async fn stream_http_response(
     http_request_metadata: HttpActionRequest,
     identity: Identity,
     application: Arc<dyn ApplicationApi>,
+    remote_addr: std::net::SocketAddr,
 ) {
     let (http_response_sender, http_response_receiver) = mpsc::unbounded_channel();
 
@@ -223,7 +225,7 @@ async fn stream_http_response(
                 request_id,
                 http_request_metadata,
                 identity,
-                FunctionCaller::HttpEndpoint(Some(remote_addr.0)),
+                FunctionCaller::HttpEndpoint(Some(remote_addr)),
                 HttpActionResponseStreamer::new(http_response_sender),
             )
             .fuse();

--- a/crates/local_backend/src/node_action_callbacks.rs
+++ b/crates/local_backend/src/node_action_callbacks.rs
@@ -716,6 +716,7 @@ impl<T: Sync> FromRequestParts<T> for ExtractExecutionContext {
             request_id,
             execution_id,
             parent_job_id.map(|id| (parent_component_id, id)),
+            None, // remote_ip not available in node action callbacks
             is_root,
         )))
     }

--- a/crates/local_backend/src/public_api.rs
+++ b/crates/local_backend/src/public_api.rs
@@ -421,7 +421,6 @@ pub async fn public_query_post(
 
 pub async fn public_get_query_ts(
     State(st): State<RouterState>,
-    remote_addr: axum::extract::ConnectInfo<std::net::SocketAddr>,
     ExtractResolvedHostname(host): ExtractResolvedHostname,
     ExtractRequestId(request_id): ExtractRequestId,
 ) -> Result<impl IntoResponse, HttpResponseError> {

--- a/crates/local_backend/src/subs/mod.rs
+++ b/crates/local_backend/src/subs/mod.rs
@@ -244,6 +244,7 @@ async fn run_sync_socket_with_remote_ip(
     let mut identity_version: Option<IdentityVersion> = None;
     let sync_worker_go = async {
         let _sync_worker_drop_token = DebugSyncSocketDropToken::new("sync_worker");
+        tracing::info!("🔍 Creating SyncWorker with remote IP: {:?}", remote_ip);
         let mut sync_worker = SyncWorker::new_with_remote_ip(
             st.api.clone(),
             st.runtime.clone(),
@@ -395,6 +396,7 @@ pub async fn sync(
     ExtractClientVersion(client_version): ExtractClientVersion,
     ws: WebSocketUpgrade,
 ) -> Result<impl IntoResponse, HttpResponseError> {
+    tracing::info!("🔍 WebSocket connection from remote IP: {}", remote_addr.0);
     sync_handler_with_remote_ip(st, Some(remote_addr.0), host, client_version, ws, Box::new(|_session_id| ())).await
 }
 

--- a/crates/local_backend/src/subs/mod.rs
+++ b/crates/local_backend/src/subs/mod.rs
@@ -244,7 +244,6 @@ async fn run_sync_socket_with_remote_ip(
     let mut identity_version: Option<IdentityVersion> = None;
     let sync_worker_go = async {
         let _sync_worker_drop_token = DebugSyncSocketDropToken::new("sync_worker");
-        tracing::info!("🔍 Creating SyncWorker with remote IP: {:?}", remote_ip);
         let mut sync_worker = SyncWorker::new_with_remote_ip(
             st.api.clone(),
             st.runtime.clone(),
@@ -396,7 +395,6 @@ pub async fn sync(
     ExtractClientVersion(client_version): ExtractClientVersion,
     ws: WebSocketUpgrade,
 ) -> Result<impl IntoResponse, HttpResponseError> {
-    tracing::info!("🔍 WebSocket connection from remote IP: {}", remote_addr.0);
     sync_handler_with_remote_ip(st, Some(remote_addr.0), host, client_version, ws, Box::new(|_session_id| ())).await
 }
 

--- a/crates/local_backend/src/subs/mod.rs
+++ b/crates/local_backend/src/subs/mod.rs
@@ -130,16 +130,7 @@ impl Drop for DebugSyncSocketDropToken {
 // on a close frame and close the WebSocket. They can also signal clean shutdown
 // by returning `Ok(())`, and once all of them have cleanly exited, we'll
 // gracefully close the socket.
-async fn run_sync_socket(
-    st: RouterState,
-    host: ResolvedHostname,
-    config: SyncWorkerConfig,
-    socket: WebSocket,
-    sentry_scope: sentry::Scope,
-    on_connect: Box<dyn FnOnce(SessionId) + Send>,
-) {
-    run_sync_socket_with_remote_ip(st, None, host, config, socket, sentry_scope, on_connect).await
-}
+
 
 async fn run_sync_socket_with_remote_ip(
     st: RouterState,

--- a/crates/local_backend/src/subs/mod.rs
+++ b/crates/local_backend/src/subs/mod.rs
@@ -138,6 +138,18 @@ async fn run_sync_socket(
     sentry_scope: sentry::Scope,
     on_connect: Box<dyn FnOnce(SessionId) + Send>,
 ) {
+    run_sync_socket_with_remote_ip(st, None, host, config, socket, sentry_scope, on_connect).await
+}
+
+async fn run_sync_socket_with_remote_ip(
+    st: RouterState,
+    remote_ip: Option<std::net::SocketAddr>,
+    host: ResolvedHostname,
+    config: SyncWorkerConfig,
+    socket: WebSocket,
+    sentry_scope: sentry::Scope,
+    on_connect: Box<dyn FnOnce(SessionId) + Send>,
+) {
     let _drop_token = SyncSocketDropToken::new();
 
     let (mut tx, mut rx) = socket.split();
@@ -232,10 +244,11 @@ async fn run_sync_socket(
     let mut identity_version: Option<IdentityVersion> = None;
     let sync_worker_go = async {
         let _sync_worker_drop_token = DebugSyncSocketDropToken::new("sync_worker");
-        let mut sync_worker = SyncWorker::new(
+        let mut sync_worker = SyncWorker::new_with_remote_ip(
             st.api.clone(),
             st.runtime.clone(),
             host,
+            remote_ip,
             config.clone(),
             client_rx,
             server_tx,
@@ -349,6 +362,17 @@ pub async fn sync_handler(
     ws: WebSocketUpgrade,
     on_connect: Box<dyn FnOnce(SessionId) + Send>,
 ) -> Result<impl IntoResponse, HttpResponseError> {
+    sync_handler_with_remote_ip(st, None, host, client_version, ws, on_connect).await
+}
+
+pub async fn sync_handler_with_remote_ip(
+    st: RouterState,
+    remote_ip: Option<std::net::SocketAddr>,
+    host: ResolvedHostname,
+    client_version: ClientVersion,
+    ws: WebSocketUpgrade,
+    on_connect: Box<dyn FnOnce(SessionId) + Send>,
+) -> Result<impl IntoResponse, HttpResponseError> {
     let config = new_sync_worker_config(client_version)?;
     // Make a copy of the Sentry scope, which contains the request metadata.
     let sentry_scope = sentry::configure_scope(move |s| s.clone());
@@ -359,18 +383,19 @@ pub async fn sync_handler(
         upgrade_timer.finish();
         let monitor = ProdRuntime::task_monitor("sync_socket");
         monitor.instrument(
-            run_sync_socket(st, host, config, ws, sentry_scope, on_connect).bind_hub(hub),
+            run_sync_socket_with_remote_ip(st, remote_ip, host, config, ws, sentry_scope, on_connect).bind_hub(hub),
         )
     }))
 }
 
 pub async fn sync(
     State(st): State<RouterState>,
+    remote_addr: axum::extract::ConnectInfo<std::net::SocketAddr>,
     ExtractResolvedHostname(host): ExtractResolvedHostname,
     ExtractClientVersion(client_version): ExtractClientVersion,
     ws: WebSocketUpgrade,
 ) -> Result<impl IntoResponse, HttpResponseError> {
-    sync_handler(st, host, client_version, ws, Box::new(|_session_id| ())).await
+    sync_handler_with_remote_ip(st, Some(remote_addr.0), host, client_version, ws, Box::new(|_session_id| ())).await
 }
 
 #[cfg(test)]

--- a/crates/pb/protos/common.proto
+++ b/crates/pb/protos/common.proto
@@ -98,6 +98,7 @@ message ExecutionContext {
     optional string request_id = 2;
     optional string execution_id = 3;
     optional bool is_root = 4;
+    optional string remote_ip = 6;
 }
 
 enum UdfType {

--- a/crates/sync/src/tests.rs
+++ b/crates/sync/src/tests.rs
@@ -873,7 +873,7 @@ async fn test_udf_cache_out_of_order(rt: TestRuntime) -> anyhow::Result<()> {
             Identity::Unknown(None),
             ts2,
             None,
-            FunctionCaller::SyncWorker(ClientVersion::unknown()),
+            FunctionCaller::SyncWorker(ClientVersion::unknown(), None),
         )
         .await?;
     assert_eq!(result1.result?.unpack(), ConvexValue::from(5.0));
@@ -887,7 +887,7 @@ async fn test_udf_cache_out_of_order(rt: TestRuntime) -> anyhow::Result<()> {
             Identity::Unknown(None),
             ts1,
             None,
-            FunctionCaller::SyncWorker(ClientVersion::unknown()),
+            FunctionCaller::SyncWorker(ClientVersion::unknown(), None),
         )
         .await?;
     assert_eq!(result2.result?.unpack(), ConvexValue::from(0.0));

--- a/crates/sync/src/worker.rs
+++ b/crates/sync/src/worker.rs
@@ -810,7 +810,6 @@ impl<RT: Runtime> SyncWorker<RT> {
                                 // We failed to refresh the subscription or it was invalid to start
                                 // with. Rerun the query.
                                 let caller = FunctionCaller::SyncWorker(client_version, remote_ip);
-                                tracing::info!("🔍 About to execute query with FunctionCaller containing remote IP: {:?}", remote_ip);
                                 let ts = ExecuteQueryTimestamp::At(new_ts);
 
                                 // This query run might have been triggered due to invalidation

--- a/crates/sync/src/worker.rs
+++ b/crates/sync/src/worker.rs
@@ -810,6 +810,7 @@ impl<RT: Runtime> SyncWorker<RT> {
                                 // We failed to refresh the subscription or it was invalid to start
                                 // with. Rerun the query.
                                 let caller = FunctionCaller::SyncWorker(client_version, remote_ip);
+                                tracing::info!("🔍 About to execute query with FunctionCaller containing remote IP: {:?}", remote_ip);
                                 let ts = ExecuteQueryTimestamp::At(new_ts);
 
                                 // This query run might have been triggered due to invalidation

--- a/crates/sync/src/worker.rs
+++ b/crates/sync/src/worker.rs
@@ -514,7 +514,8 @@ impl<RT: Runtime> SyncWorker<RT> {
                 let timer = mutation_queue_timer();
                 let api = self.api.clone();
                 let host = self.host.clone();
-                let caller = FunctionCaller::SyncWorker(client_version, self.remote_ip);
+                let remote_ip = self.remote_ip;
+                let caller = FunctionCaller::SyncWorker(client_version, remote_ip);
 
                 let mutation_queue_size =
                     self.mutation_sender.max_capacity() - self.mutation_sender.capacity();
@@ -602,6 +603,7 @@ impl<RT: Runtime> SyncWorker<RT> {
                 let api = self.api.clone();
                 let host = self.host.clone();
                 let client_version = self.config.client_version.clone();
+                let remote_ip = self.remote_ip;
                 let server_request_id = match self.state.session_id() {
                     Some(id) => RequestId::new_for_ws_session(id, request_id),
                     None => RequestId::new(),
@@ -616,7 +618,7 @@ impl<RT: Runtime> SyncWorker<RT> {
                     },
                 );
                 let future = async move {
-                    let caller = FunctionCaller::SyncWorker(client_version, self.remote_ip);
+                    let caller = FunctionCaller::SyncWorker(client_version, remote_ip);
                     let result = match component_path {
                         None => {
                             api.execute_public_action(
@@ -779,6 +781,7 @@ impl<RT: Runtime> SyncWorker<RT> {
         let need_fetch: Vec<_> = self.state.need_fetch().collect();
         let host = self.host.clone();
         let client_version = self.config.client_version.clone();
+        let remote_ip = self.remote_ip;
         Ok(async move {
             let future_results: anyhow::Result<Vec<_>> = try_join_buffer_unordered(
                 "update_query",
@@ -806,7 +809,7 @@ impl<RT: Runtime> SyncWorker<RT> {
                             None => {
                                 // We failed to refresh the subscription or it was invalid to start
                                 // with. Rerun the query.
-                                let caller = FunctionCaller::SyncWorker(client_version, self.remote_ip);
+                                let caller = FunctionCaller::SyncWorker(client_version, remote_ip);
                                 let ts = ExecuteQueryTimestamp::At(new_ts);
 
                                 // This query run might have been triggered due to invalidation

--- a/crates/sync/src/worker.rs
+++ b/crates/sync/src/worker.rs
@@ -216,6 +216,7 @@ pub struct SyncWorker<RT: Runtime> {
     rt: RT,
     state: SyncState,
     host: ResolvedHostname,
+    remote_ip: Option<std::net::SocketAddr>,
 
     rx: mpsc::UnboundedReceiver<(ClientMessage, tokio::time::Instant)>,
     tx: SingleFlightSender,
@@ -266,6 +267,19 @@ impl<RT: Runtime> SyncWorker<RT> {
         tx: SingleFlightSender,
         on_connect: Box<dyn FnOnce(SessionId) + Send>,
     ) -> Self {
+        Self::new_with_remote_ip(api, rt, host, None, config, rx, tx, on_connect)
+    }
+
+    pub fn new_with_remote_ip(
+        api: Arc<dyn ApplicationApi>,
+        rt: RT,
+        host: ResolvedHostname,
+        remote_ip: Option<std::net::SocketAddr>,
+        config: SyncWorkerConfig,
+        rx: mpsc::UnboundedReceiver<(ClientMessage, tokio::time::Instant)>,
+        tx: SingleFlightSender,
+        on_connect: Box<dyn FnOnce(SessionId) + Send>,
+    ) -> Self {
         let (mutation_sender, receiver) = mpsc::channel(OPERATION_QUEUE_BUFFER_SIZE);
         let mutation_futures = ReceiverStream::new(receiver).buffered(1); // Execute at most one operation at a time.
         SyncWorker {
@@ -274,6 +288,7 @@ impl<RT: Runtime> SyncWorker<RT> {
             rt,
             state: SyncState::new(),
             host,
+            remote_ip,
             rx,
             tx,
             mutation_futures,
@@ -499,7 +514,7 @@ impl<RT: Runtime> SyncWorker<RT> {
                 let timer = mutation_queue_timer();
                 let api = self.api.clone();
                 let host = self.host.clone();
-                let caller = FunctionCaller::SyncWorker(client_version);
+                let caller = FunctionCaller::SyncWorker(client_version, self.remote_ip);
 
                 let mutation_queue_size =
                     self.mutation_sender.max_capacity() - self.mutation_sender.capacity();
@@ -601,7 +616,7 @@ impl<RT: Runtime> SyncWorker<RT> {
                     },
                 );
                 let future = async move {
-                    let caller = FunctionCaller::SyncWorker(client_version);
+                    let caller = FunctionCaller::SyncWorker(client_version, self.remote_ip);
                     let result = match component_path {
                         None => {
                             api.execute_public_action(
@@ -791,7 +806,7 @@ impl<RT: Runtime> SyncWorker<RT> {
                             None => {
                                 // We failed to refresh the subscription or it was invalid to start
                                 // with. Rerun the query.
-                                let caller = FunctionCaller::SyncWorker(client_version);
+                                let caller = FunctionCaller::SyncWorker(client_version, self.remote_ip);
                                 let ts = ExecuteQueryTimestamp::At(new_ts);
 
                                 // This query run might have been triggered due to invalidation

--- a/npm-packages/convex/src/server/impl/registration_impl.ts
+++ b/npm-packages/convex/src/server/impl/registration_impl.ts
@@ -52,34 +52,23 @@ declare const Convex: {
 async function getExecutionContext(): Promise<any> {
   try {
     if (typeof Convex === "undefined" || Convex.op === undefined) {
-      console.log("❌ Convex.op not available");
       throw new Error("Convex.op not available");
     }
-    console.log("✅ Calling getExecutionContext op...");
     const context = Convex.op("getExecutionContext");
-    console.log("✅ Got execution context:", JSON.stringify(context, null, 2));
     return context;
   } catch (error) {
-    console.log("❌ Error getting execution context:", error);
-    return {
-      testValue: "FALLBACK_CONTEXT_EXECUTED", // Make this very obvious
-      remoteIp: "DEBUG_FALLBACK", // Change null to a string so it's obvious
-      debugInfo: "getExecutionContext was called but failed",
-    };
+    return {};
   }
 }
 
 async function invokeMutation<
   F extends (ctx: GenericMutationCtx<GenericDataModel>, ...args: any) => any,
 >(func: F, argsStr: string) {
-  console.log("🔍 TypeScript: invokeMutation called!");
   // TODO(presley): Change the function signature and propagate the requestId from Rust.
   // Ok, to mock it out for now, since queries are only running in V8.
   const requestId = "";
   const args = jsonToConvex(JSON.parse(argsStr));
-  console.log("🔍 TypeScript: About to call getExecutionContext for mutation");
   const executionContext = await getExecutionContext();
-  console.log("🔍 TypeScript: Mutation execution context:", executionContext);
   const mutationCtx = {
     db: setupWriter(),
     auth: setupAuth(requestId),
@@ -91,7 +80,6 @@ async function invokeMutation<
       runUdf("mutation", reference, args),
     ...executionContext,
   };
-  console.log("🔍 TypeScript: Final mutation context:", mutationCtx);
   const result = await invokeFunction(func, mutationCtx, args as any);
   validateReturnValue(result);
   return JSON.stringify(convexToJson(result === undefined ? null : result));
@@ -286,15 +274,11 @@ export const internalMutationGeneric: MutationBuilder<any, "internal"> = ((
 async function invokeQuery<
   F extends (ctx: GenericQueryCtx<GenericDataModel>, ...args: any) => any,
 >(func: F, argsStr: string) {
-  INTENTIONAL_SYNTAX_ERROR_TO_FORCE_FAILURE;
-  console.log("🔍 TypeScript: invokeQuery called!");
   // TODO(presley): Change the function signature and propagate the requestId from Rust.
   // Ok, to mock it out for now, since queries are only running in V8.
   const requestId = "";
   const args = jsonToConvex(JSON.parse(argsStr));
-  console.log("🔍 TypeScript: About to call getExecutionContext for query");
   const executionContext = await getExecutionContext();
-  console.log("🔍 TypeScript: Query execution context:", executionContext);
   const queryCtx = {
     db: setupReader(),
     auth: setupAuth(requestId),
@@ -302,7 +286,6 @@ async function invokeQuery<
     runQuery: (reference: any, args?: any) => runUdf("query", reference, args),
     ...executionContext,
   };
-  console.log("🔍 TypeScript: Final query context:", queryCtx);
   const result = await invokeFunction(func, queryCtx, args as any);
   validateReturnValue(result);
   return JSON.stringify(convexToJson(result === undefined ? null : result));


### PR DESCRIPTION
## PURPOSE

- Enrich the context-object with `getRemoteIp()` for `query`/`mutation`/`action`, returning the remote IP on the connection
- "Zero cost" if not used, called synchronously for speed
- Opens for application level audit-logging, IP-based feature-blocking/rate-limiting, etc

## CAVEAT

Depending on how Convex Cloud is load-balanced, this might or might not work. If the service is setup using Layer 7 load balancers, this will not work as it relies on `X-Forwarded-For` being set, which this PR doesn't honor (but can be made to, conceptually).

If it is balanced using Layer 4 with NLB, this will _probably work with Convex Cloud_ as it usually passes on the source IP-address directly.

_It will very likely work_ for standalone backend.

**Also:** I am not sure it needs to be implemented as a function call, but it was not obvious how to have this available when V8 is initialized. Implementing it as a property directly on `ctx` would incur some unwanted overhead as JavaScript needs to call back into Rust, which we want to avoid in the common case.

## USAGE

```typescript
  // In your Convex functions:
  export const logClientInfo = mutation({
    handler: async (ctx, args) => {
      // Only pays cost when you actually need it
      const clientIp = ctx.getRemoteIp();
      console.log("Request from: ", clientIp);

      // Functions that don't call getRemoteIp() have "zero overhead"
      return { success: true };
    }
  });
```

## TEST RUN

```
test result: FAILED. 154 passed; 3 failed; 5 ignored; 0 measured; 0 filtered out; finished in 10.62s
```

For me, this is currently _the same_ as the `main`-branch, so I don't think errors are introduced that tests would catch.

## CODE QUALITY

This PR needs to be looked after by a seasoned Convex developer as it is my first attempt at making something in Convex core. If it is rejected, feel free to use it as inspiration for a proper implementation.

## IMPROVEMENTS (potential)

- Split into `getRemoteIp` and `getRemotePort`, perhaps, currently the port is returned with `getRemoteIp` on the format `127.0.0.1:57345`.
----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
