### PR TITLE
docs: fix import from nextjs to react

### DIFF
--- a/npm-packages/convex/src/nextjs/index.ts
+++ b/npm-packages/convex/src/nextjs/index.ts
@@ -29,7 +29,7 @@
  *
  * And pass it to a Client Component:
  * ```typescript
- * import { Preloaded, usePreloadedQuery } from "convex/nextjs";
+ * import { Preloaded, usePreloadedQuery } from "convex/react";
  * import { api } from "@/convex/_generated/api";
  *
  * export function ClientComponent(props: {


### PR DESCRIPTION
Fixes incorrect imports in docs.`Preloaded, usePreloadedQuery` are exported from `convex/react` and not `convex/nextjs`

<!--
  The following applies to third-party contributors.
  Convex employees and contractors can delete or ignore.
-->

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
