### PR TITLE
Docs: Remove 'await' from usePreloadedQuery hook reference

### DIFF
--- a/npm-packages/convex/src/nextjs/index.ts
+++ b/npm-packages/convex/src/nextjs/index.ts
@@ -35,7 +35,7 @@
  * export function ClientComponent(props: {
  *   preloaded: Preloaded<typeof api.foo.baz>;
  * }) {
- *   const data = await usePreloadedQuery(props.preloaded);
+ *   const data = usePreloadedQuery(props.preloaded);
  *   // render `data`...
  * }
  * ```


### PR DESCRIPTION
<!-- Describe your PR here. -->
Simple Change.
Removing usage of await for usePreloadedQuery hook in Docs.

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
