### PR TITLE
Docs: adding correct Clerk Domain URL naming in Clerk/Nextjs docs

### DIFF
--- a/npm-packages/docs/docs/auth/clerk.mdx
+++ b/npm-packages/docs/docs/auth/clerk.mdx
@@ -242,7 +242,11 @@ follow the [Convex Next.js Quickstart](/quickstart/nextjs.mdx) first. Then:
     export default {
       providers: [
         {
-          domain: process.env.NEXT_PUBLIC_CLERK_FRONTEND_API_URL,
+          // Replace with your own Clerk Issuer URL from your "convex" JWT template
+          // or with `process.env.CLERK_JWT_ISSUER_DOMAIN`
+          // and configure CLERK_JWT_ISSUER_DOMAIN on the Convex Dashboard
+          // See https://docs.convex.dev/auth/clerk#configuring-dev-and-prod-instances
+          domain: process.env.CLERK_JWT_ISSUER_DOMAIN,
           applicationID: "convex",
         },
       ]


### PR DESCRIPTION
<!-- Describe your PR here. -->

Simple env naming change.
Since `NEXT_PUBLIC_CLERK_FRONTEND_API_URL` is confused with a local env, while the env should be set on the convex dashboard.

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
