### PR TITLE
Add getSetCookie to Headers interface

### DIFF
--- a/npm-packages/udf-runtime/src/20_headers.ts
+++ b/npm-packages/udf-runtime/src/20_headers.ts
@@ -124,6 +124,20 @@ class Headers {
     }
     return `Headers ${inspect(headers)}`;
   }
+
+  getSetCookie() {
+    const normalizedName = this._normalizeName(
+      "set-cookie",
+      "Failed to execute 'getSetCookie' on 'Headers",
+    );
+    const values: string[] = [];
+    for (const [key, value] of this._headersList) {
+      if (key === normalizedName) {
+        values.push(value);
+      }
+    }
+    return values;
+  }
 }
 
 export const setupHeaders = (global: any) => {

--- a/npm-packages/udf-tests/convex/js_builtins/headers.ts
+++ b/npm-packages/udf-tests/convex/js_builtins/headers.ts
@@ -241,6 +241,18 @@ function toStringShouldBeWebCompatibility() {
   assert.strictEqual(headers.toString(), "[object Headers]");
 }
 
+function headerGetSetCookieSuccess() {
+  const headers = new Headers();
+
+  assert.deepEqual(headers.getSetCookie(), []);
+
+  headers.append("set-cookie", "name1=value1");
+  assert.deepEqual(headers.getSetCookie(), ["name1=value1"]);
+
+  headers.append("set-cookie", "name2=value2");
+  assert.deepEqual(headers.getSetCookie(), ["name1=value1", "name2=value2"]);
+}
+
 // function invalidHeadersFlaky() {
 //   assertThrows(
 //     () => new Headers([["x", "\u0000x"]]),
@@ -277,6 +289,7 @@ export default query(async () => {
     // headerParamsArgumentsCheck,
 
     toStringShouldBeWebCompatibility,
+    headerGetSetCookieSuccess,
 
     // TODO: our bundler sometimes changes the class name, which we could
     // configure differently


### PR DESCRIPTION
<!-- Describe your PR here. -->

This PR adds the [getSetCookie method](https://developer.mozilla.org/en-US/docs/Web/API/Headers/getSetCookie) to the Headers interface. I ran into this missing method trying run hono with some middleware in `convex/http.ts`.

I haven't had time to get the convex backend or the tests running locally, but this implementation works when I patch this method in my convex instance.

<!--
  The following applies to third-party contributors.
  Convex employees and contractors can delete or ignore.
-->

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
