### PR TITLE
fix(cli): normalize Windows paths for module identifiers and add test…

### DIFF
--- a/npm-packages/convex/src/bundler/index.test.ts
+++ b/npm-packages/convex/src/bundler/index.test.ts
@@ -182,13 +182,16 @@ test("must use isolate", () => {
   expect(mustBeIsolate("schema/http.js")).not.toBeTruthy();
 });
 
-test("normalizeModulePath removes Windows drive letter and normalizes slashes", () => {
-  // Windows drive letter with forward slashes
-  expect(normalizeModulePath("C:/Users/test/out/convex/foo.js")).toBe("Users/test/out/convex/foo.js");
-  // Windows drive letter with backslashes
-  expect(normalizeModulePath("D:\\project\\out\\convex\\bar.js")).toBe("project/out/convex/bar.js");
-  // Already relative path
-  expect(normalizeModulePath("convex/foo.js")).toBe("convex/foo.js");
-  // No drive letter, just slashes
-  expect(normalizeModulePath("/convex/foo.js")).toBe("/convex/foo.js");
+test("normalizeModulePath creates valid module identifiers from output paths", () => {
+  // Test typical case: esbuild output in out/ directory
+  expect(normalizeModulePath("out/convex/myFunction.js")).toBe("convex/myFunction.js");
+  expect(normalizeModulePath("out\\actions\\myAction.js")).toBe("actions/myAction.js");
+  
+  // Test Windows absolute paths (typical Windows scenario)
+  expect(normalizeModulePath("C:\\project\\out\\convex\\foo.js")).toBe("convex/foo.js");
+  expect(normalizeModulePath("D:/Users/dev/myapp/out/convex/bar.js")).toBe("convex/bar.js");
+  
+  // Test custom base directory
+  expect(normalizeModulePath("build/convex/test.js", "build")).toBe("convex/test.js");
+  expect(normalizeModulePath("C:/project/dist/actions/upload.js", "dist")).toBe("actions/upload.js");
 });


### PR DESCRIPTION
… (#140)

<!-- Describe your PR here. -->
fix(cli): issue #140 - normalize Windows paths for module identifiers and added tests for windows paths. 

<!--
  The following applies to third-party contributors.
  Convex employees and contractors can delete or ignore.
-->

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
