### PR TITLE
Fix: JSON import UTF-8 BOM handling issue

### DIFF
--- a/crates/application/src/snapshot_import/import_error.rs
+++ b/crates/application/src/snapshot_import/import_error.rs
@@ -31,6 +31,9 @@ pub enum ImportError {
     #[error("Import wasn't valid UTF8: {0}")]
     NotUtf8(std::io::Error),
 
+    #[error("UTF-8 BOM is not supported. Please save your file without BOM.")]
+    Utf8BomNotSupported,
+
     #[error(
         "Import is too large for JSON ({0} bytes > maximum {limit}). Consider converting data to JSONLines",
         limit=*IMPORT_SIZE_LIMIT

--- a/crates/application/src/snapshot_import/parse.rs
+++ b/crates/application/src/snapshot_import/parse.rs
@@ -198,11 +198,6 @@ pub async fn parse_objects<'a, Fut>(
                         anyhow::bail!(ImportError::Utf8BomNotSupported);
                     }
                 }
-                if line.trim().is_empty() {
-                    line.clear();
-                    lineno += 1;
-                    continue;
-                }
                 let v: serde_json::Value = serde_json::from_str(&line)
                     .map_err(|e| ImportError::JsonInvalidRow(lineno, e))?;
                 yield ImportUnit::Object(v);


### PR DESCRIPTION
Fix JSON import UTF-8 BOM handling issue

- Add strip_utf8_bom() function to remove UTF-8 BOM (EF BB BF) from file content
- Apply BOM stripping to JsonLines and JsonArray import formats
- Add comprehensive tests for UTF-8 BOM handling across all import formats
- Ensure backward compatibility with files without BOM
- Fix 'Not valid JSON: expected value at line 1 column 1' error for BOM files

fix #138 

<!--
  The following applies to third-party contributors.
  Convex employees and contractors can delete or ignore.
-->

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
