### PR TITLE
Fix patch when exactOptionalPropertyTypes is enabled

### DIFF
--- a/npm-packages/convex/src/server/database.ts
+++ b/npm-packages/convex/src/server/database.ts
@@ -191,7 +191,7 @@ export interface GenericDatabaseWriter<DataModel extends GenericDataModel>
   patch<TableName extends TableNamesInDataModel<DataModel>>(
     table: NonUnion<TableName>,
     id: GenericId<TableName>,
-    value: Partial<DocumentByName<DataModel, TableName>>,
+    value: PatchValue<DocumentByName<DataModel, TableName>>,
   ): Promise<void>;
 
   /**
@@ -207,7 +207,7 @@ export interface GenericDatabaseWriter<DataModel extends GenericDataModel>
    */
   patch<TableName extends TableNamesInDataModel<DataModel>>(
     id: GenericId<TableName>,
-    value: Partial<DocumentByName<DataModel, TableName>>,
+    value: PatchValue<DocumentByName<DataModel, TableName>>,
   ): Promise<void>;
 
   /**
@@ -311,7 +311,7 @@ export interface BaseTableWriter<
    */
   patch(
     id: GenericId<TableName>,
-    value: Partial<DocumentByName<DataModel, TableName>>,
+    value: PatchValue<DocumentByName<DataModel, TableName>>,
   ): Promise<void>;
 
   /**
@@ -341,3 +341,11 @@ export interface BaseTableWriter<
 type NonUnion<T> = T extends never // `never` is the bottom type for TypeScript unions
   ? never
   : T;
+
+/**
+ * This is like Partial, but it also allows undefined to be passed to optional
+ * fields when `exactOptionalPropertyTypes` is enabled in the tsconfig.
+ */
+type PatchValue<T> = {
+  [P in keyof T]?: undefined extends T[P] ? T[P] | undefined : T[P];
+};


### PR DESCRIPTION
<!-- Describe your PR here. -->

A false Typescript error is generated when setting an optional field to `undefined` if `exactOptionalPropertyTypes` is enabled in the tsconfig.

This PR fixes that by allowing `undefined` to be passed to optional fields when doing a patch.

Example:

```jsonc
// tsconfig.json
{
  "compilerOptions": {
    "exactOptionalPropertyTypes": true,
    "strict": true
  }
}
```

```ts
// schema.ts
export default defineSchema({
  things: defineTable({
    name: v.string(),
    other: v.optional(v.string()),
  }),
});

// things.ts
import { v } from "convex/values";
import { internalMutation } from "./_generated/server";
export const thingMutation = internalMutation({
  args: { id: v.id("things") },
  handler: async (ctx, args) => {
    await ctx.db.patch(args.id, {
      name: "abc",
      other: undefined,
    });
    // Error: Argument of type '...' is not assignable to parameter of type 'Partial<...>' with 'exactOptionalPropertyTypes: true'
  },
});
```

<!--
  The following applies to third-party contributors.
  Convex employees and contractors can delete or ignore.
-->

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
