### PR TITLE
Update using-cursor.mdx

### DIFF
--- a/npm-packages/docs/docs/ai/using-cursor.mdx
+++ b/npm-packages/docs/docs/ai/using-cursor.mdx
@@ -106,8 +106,8 @@ projects.
 Adding Convex docs can let you specifically refer to Convex features when
 building your app.
 
-From **`Cursor Settings`** > **`Features`** > **`Docs`** add new doc, use the
-URL "https://docs.convex.dev/"
+From **`Cursor Settings`** > **`Indexing & Docs`** add new doc, use the
+URL "https://docs.convex.dev/home"
 
 ![Chat UI](/img/cursor-with-convex/adding_convex_docs.webp)
 


### PR DESCRIPTION
Hey!

Noticed the documentation for adding Convex docs to cursor is a bit outdated and do not properly reflect the current state of how it should be done.

1. The way to add to docs is now under a different menu `Cursor settings` > `Indexing & Docs` > `Docs`

<img width="981" height="453" alt="image" src="https://github.com/user-attachments/assets/77d04f93-037d-41af-919c-355baf65f8a9" />

2. It seems that you guys redirect `https://docs.convex.dev/` to `https://docs.convex.dev/home` and therefore when adding the url currently showcased in the docs, cursor its not able to index the documentation. The proposed url makes cursor able to correctly index the 278 pages of docs.

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
