### PR TITLE
Dont require https for auth provider issuer url

### DIFF
--- a/crates/common/src/auth.rs
+++ b/crates/common/src/auth.rs
@@ -207,17 +207,8 @@ fn deserialize_issuer_url(original_url: String) -> anyhow::Result<IssuerUrl> {
     };
     if url.starts_with("http://") {
         let parsed_url = IssuerUrl::new(url)?;
-        if parsed_url.url().host_str() == Some("localhost")
-            || parsed_url.url().host_str() == Some("127.0.0.1")
-        {
-            return Ok(parsed_url);
-        } else {
-            anyhow::bail!("Invalid provider domain URL \"{original_url}\": must use HTTPS");
-        }
+        return Ok(parsed_url);
     };
-    if !url.starts_with("https://") {
-        anyhow::bail!("Invalid provider domain URL \"{original_url}\": must use HTTPS");
-    }
     let parsed_url = IssuerUrl::new(url)?;
     // Check if the input really looks like a URL,
     // to catch mistakes (e.g. putting random tokens in the domain field)


### PR DESCRIPTION
When deploying to kubernetes and using internal URLs we cannot use https. Remove the https check.

This check is here for spec compliance (I think?), removing it does not pose any security risk, as long as people continue configuring https addresses (I don't really see how they would realistically not do it in real-world scenarios, ie when using Clerk et.al.).

cc @gautamg795 

Example of what the URL looks like in our setup: `http://foo-service.bla-namespace.svc.cluster.local:3210/http`

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
