### PR TITLE
Skip .env.local creation when environment variables exist in process.env

### DIFF
--- a/npm-packages/convex/src/cli/lib/deployment.ts
+++ b/npm-packages/convex/src/cli/lib/deployment.ts
@@ -49,6 +49,17 @@ export async function writeDeploymentEnvVar(
   },
   existingValue: string | null,
 ): Promise<{ wroteToGitIgnore: boolean; changedDeploymentEnvVar: boolean }> {
+  const deploymentEnvVarValue =
+    deploymentType + ":" + deployment.deploymentName;
+
+  // Check if the correct value already exists in process.env
+  if (process.env[CONVEX_DEPLOYMENT_ENV_VAR_NAME] === deploymentEnvVarValue) {
+    return {
+      wroteToGitIgnore: false,
+      changedDeploymentEnvVar: false,
+    };
+  }
+
   const existingFile = ctx.fs.exists(ENV_VAR_FILE_PATH)
     ? ctx.fs.readUtf8File(ENV_VAR_FILE_PATH)
     : null;
@@ -57,8 +68,6 @@ export async function writeDeploymentEnvVar(
     deploymentType,
     deployment,
   );
-  const deploymentEnvVarValue =
-    deploymentType + ":" + deployment.deploymentName;
 
   if (changedFile !== null) {
     ctx.fs.writeUtf8File(ENV_VAR_FILE_PATH, changedFile);

--- a/npm-packages/convex/src/cli/lib/envvars.test.ts
+++ b/npm-packages/convex/src/cli/lib/envvars.test.ts
@@ -1,0 +1,66 @@
+import {afterEach, beforeEach, expect, test, vi} from "vitest";
+import {writeConvexUrlToEnvFile} from "./envvars.js";
+import {Context} from "../../bundler/context.js";
+
+vi.mock("./utils/utils.js", () => ({
+	loadPackageJson: vi.fn().mockResolvedValue({name: "test-project"}),
+	ENV_VAR_FILE_PATH: ".env.local",
+}));
+
+const mockContext = {
+	fs: {
+		exists: vi.fn() as any,
+		readUtf8File: vi.fn() as any,
+		writeUtf8File: vi.fn() as any,
+	},
+	crash: vi.fn() as any,
+} as unknown as Context;
+
+const originalProcessEnv = process.env;
+
+beforeEach(() => {
+	vi.clearAllMocks();
+	process.env = {...originalProcessEnv};
+});
+
+afterEach(() => {
+	process.env = originalProcessEnv;
+});
+
+test("writeConvexUrlToEnvFile process.env behavior", async () => {
+	// Test core functionality: skip file creation when env var exists with correct value
+	process.env.CONVEX_URL = "https://test.convex.cloud";
+	(mockContext.fs.exists as any).mockReturnValue(false);
+
+	let result = await writeConvexUrlToEnvFile(mockContext, "https://test.convex.cloud");
+	expect(result).toBeNull(); // Should skip file creation
+	expect(mockContext.fs.writeUtf8File).not.toHaveBeenCalled();
+
+	// Test different value - should create file
+	vi.clearAllMocks();
+	process.env.CONVEX_URL = "https://different.convex.cloud";
+
+	result = await writeConvexUrlToEnvFile(mockContext, "https://test.convex.cloud");
+	expect(result).not.toBeNull(); // Should create file
+	expect(mockContext.fs.writeUtf8File).toHaveBeenCalled();
+
+	// Test missing env var - should create file
+	vi.clearAllMocks();
+	delete process.env.CONVEX_URL;
+
+	result = await writeConvexUrlToEnvFile(mockContext, "https://test.convex.cloud");
+	expect(result).not.toBeNull(); // Should create file
+	expect(mockContext.fs.writeUtf8File).toHaveBeenCalled();
+
+	// Empty string should trigger file creation
+	vi.clearAllMocks();
+	process.env.CONVEX_URL = "";
+	result = await writeConvexUrlToEnvFile(mockContext, "https://test.convex.cloud");
+	expect(result).not.toBeNull();
+
+	// Whitespace should trigger file creation
+	vi.clearAllMocks();
+	process.env.CONVEX_URL = "  ";
+	result = await writeConvexUrlToEnvFile(mockContext, "https://test.convex.cloud");
+	expect(result).not.toBeNull();
+});

--- a/npm-packages/convex/src/cli/lib/envvars.ts
+++ b/npm-packages/convex/src/cli/lib/envvars.ts
@@ -29,6 +29,16 @@ export async function writeConvexUrlToEnvFile(
   ctx: Context,
   value: string,
 ): Promise<ConvexUrlWriteConfig> {
+  // Check if any of the expected environment variables already has the correct value
+  const { envVar: suggestedEnvVar } = await suggestedEnvVarName(ctx);
+  
+  // Check process.env for the suggested env var or any of the expected names
+  for (const envVarName of [suggestedEnvVar, ...EXPECTED_NAMES]) {
+    if (process.env[envVarName] === value) {
+      return null;
+    }
+  }
+
   const writeConfig = await envVarWriteConfig(ctx, value);
 
   if (writeConfig === null) {


### PR DESCRIPTION
## Summary

Fixes issue where Convex CLI always creates `.env.local` files even when required environment variables (`CONVEX_DEPLOYMENT`, `CONVEX_URL`, etc.) are already available in the shell environment. This was problematic for users who manage secrets with external tools, use `direnv`, or deploy in CI/CD environments.

This PR contains two commits that together resolve the issue:

1. **Skip .env.local creation when environment variables exist** - Modified the core logic to check `process.env` before creating `.env.local` files
2. **Fix misleading log messages** - Updated logging to only show file creation messages when files are actually written to disk

## Problem Solved

**Root Cause**: The CLI only checked for environment variables in files (`.env.local`, `.env`) but not in the shell environment (`process.env`).

**Before**: 
- CLI always created `.env.local` even when `CONVEX_DEPLOYMENT` was set via `direnv`, CI/CD, or shell exports
- Users saw misleading "Saved deployment details to .env.local" messages even when no file was needed
- Problematic for users who avoid leaving environment settings in local filesystem

**After**: 
- CLI detects existing environment variables in `process.env` and skips file creation
- Users only see file creation messages when files are actually written
- Respects users' preferred environment management workflows

Fixes #191 
----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
