### PR TITLE
Fix: Respect `DISABLE_BEACON` env var in backend

### DIFF
--- a/crates/local_backend/src/config.rs
+++ b/crates/local_backend/src/config.rs
@@ -103,7 +103,7 @@ pub struct LocalConfig {
     /// self-hosted Convex will periodically communicate with a remote beacon
     /// server. This is to help Convex understand and improve the product.
     /// If set, the self-host beacon will not be sent.
-    #[clap(long)]
+    #[clap(long, env = "DISABLE_BEACON")]
     pub disable_beacon: bool,
 
     /// A tag to identify the self-hosted instance.

--- a/crates/local_backend/src/main.rs
+++ b/crates/local_backend/src/main.rs
@@ -47,7 +47,7 @@ fn main() -> Result<(), MainError> {
             "The self-host Convex backend will periodically communicate with a remote beacon \
              server. This is to help Convex understand and improve the product. You can disable \
              this telemetry by setting the --disable-beacon flag or the DISABLE_BEACON \
-             environment variable if you are self-hosting using the Docker image."
+             environment variable."
         );
     }
     let sentry = sentry::init(sentry::ClientOptions {


### PR DESCRIPTION
This change addresses issue #194  by making the backend binary directly obey the DISABLE_BEACON environment variable, in addition to the existing --disable-beacon flag.

Previously, the environment variable was only handled by the Docker Compose setup, which was confusing for users not using Docker.

This PR also clarifies the startup message to reflect that either the environment variable or the command-line flag can be used to disable telemetry.

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
