### PR TITLE
feat(aws_s3): Add S3 compatibility environment variables for non-AWS services

### DIFF
--- a/crates/aws_s3/src/storage.rs
+++ b/crates/aws_s3/src/storage.rs
@@ -26,6 +26,8 @@ use aws_sdk_s3::{
     Client,
 };
 use aws_utils::{
+    are_checksums_disabled,
+    is_sse_disabled,
     must_s3_config_from_env,
     s3::S3Client,
 };
@@ -216,15 +218,25 @@ impl<RT: Runtime> Storage for S3Storage<RT> {
     async fn start_upload(&self) -> anyhow::Result<Box<BufferedUpload>> {
         let key: ObjectKey = self.runtime.new_uuid_v4().to_string().try_into()?;
         let s3_key = S3Key(self.key_prefix.clone() + &key);
-        let output = self
+        let mut upload_builder = self
             .client
             .create_multipart_upload()
             .bucket(self.bucket.clone())
-            .key(&s3_key.0)
-            .server_side_encryption(ServerSideEncryption::Aes256)
+            .key(&s3_key.0);
+        
+        // Add server-side encryption if not disabled for S3 compatibility
+        if !is_sse_disabled() {
+            upload_builder = upload_builder.server_side_encryption(ServerSideEncryption::Aes256);
+        }
+        
+        // Add checksum algorithm if not disabled for S3 compatibility
+        if !are_checksums_disabled() {
             // Because we're using multipart uploads, we're really specifying the part checksum
             // algorithm here, so it needs to match what we use for each part.
-            .checksum_algorithm(ChecksumAlgorithm::Crc32)
+            upload_builder = upload_builder.checksum_algorithm(ChecksumAlgorithm::Crc32);
+        }
+        
+        let output = upload_builder
             .send()
             .await
             .context("Failed to create multipart upload")?;
@@ -254,15 +266,25 @@ impl<RT: Runtime> Storage for S3Storage<RT> {
     async fn start_client_driven_upload(&self) -> anyhow::Result<ClientDrivenUploadToken> {
         let key: ObjectKey = self.runtime.new_uuid_v4().to_string().try_into()?;
         let s3_key = S3Key(self.key_prefix.clone() + &key);
-        let output = self
+        let mut upload_builder = self
             .client
             .create_multipart_upload()
             .bucket(self.bucket.clone())
-            .key(&s3_key.0)
-            .server_side_encryption(ServerSideEncryption::Aes256)
+            .key(&s3_key.0);
+        
+        // Add server-side encryption if not disabled for S3 compatibility
+        if !is_sse_disabled() {
+            upload_builder = upload_builder.server_side_encryption(ServerSideEncryption::Aes256);
+        }
+        
+        // Add checksum algorithm if not disabled for S3 compatibility
+        if !are_checksums_disabled() {
             // Because we're using multipart uploads, we're really specifying the part checksum
             // algorithm here, so it needs to match what we use for each part.
-            .checksum_algorithm(ChecksumAlgorithm::Crc32)
+            upload_builder = upload_builder.checksum_algorithm(ChecksumAlgorithm::Crc32);
+        }
+        
+        let output = upload_builder
             .send()
             .await
             .context("Failed to create multipart upload")?;
@@ -565,15 +587,20 @@ impl<RT: Runtime> S3Upload<RT> {
         let part_number = self.next_part_number()?;
         crate::metrics::log_aws_s3_part_upload_size_bytes(data.len());
 
-        let builder = self
+        let mut builder = self
             .client
             .upload_part()
-            .checksum_algorithm(ChecksumAlgorithm::Crc32)
             .body(ByteStream::from(data))
             .bucket(self.bucket.clone())
             .key(&self.s3_key.0)
             .part_number(Into::<u16>::into(part_number) as i32)
             .upload_id(self.upload_id.to_string());
+        
+        // Add checksum algorithm if not disabled for S3 compatibility
+        if !are_checksums_disabled() {
+            builder = builder.checksum_algorithm(ChecksumAlgorithm::Crc32);
+        }
+        
         Ok(UploadPart {
             part_number,
             builder,

--- a/crates/aws_utils/src/lib.rs
+++ b/crates/aws_utils/src/lib.rs
@@ -33,6 +33,20 @@ static AWS_S3_FORCE_PATH_STYLE: LazyLock<bool> = LazyLock::new(|| {
         .unwrap_or_default()
 });
 
+static AWS_S3_DISABLE_SSE: LazyLock<bool> = LazyLock::new(|| {
+    env::var("AWS_S3_DISABLE_SSE")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or_default()
+});
+
+static AWS_S3_DISABLE_CHECKSUMS: LazyLock<bool> = LazyLock::new(|| {
+    env::var("AWS_S3_DISABLE_CHECKSUMS")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or_default()
+});
+
 /// Similar aws_config::from_env but returns an error if credentials or
 /// region is are not. It also doesn't spew out log lines every time
 /// credentials are accessed.
@@ -61,4 +75,14 @@ pub async fn must_s3_config_from_env() -> anyhow::Result<S3ConfigBuilder> {
     }
     s3_config_builder = s3_config_builder.force_path_style(*AWS_S3_FORCE_PATH_STYLE);
     Ok(s3_config_builder)
+}
+
+/// Returns true if server-side encryption headers should be disabled
+pub fn is_sse_disabled() -> bool {
+    *AWS_S3_DISABLE_SSE
+}
+
+/// Returns true if checksum headers should be disabled
+pub fn are_checksums_disabled() -> bool {
+    *AWS_S3_DISABLE_CHECKSUMS
 }


### PR DESCRIPTION
## Summary
- Add environment variables to disable AWS-specific S3 headers for compatibility with non-AWS S3 services like MinIO and Rook Ceph RGW
- `AWS_S3_DISABLE_SSE=true` disables server-side encryption headers (`x-amz-server-side-encryption`)
- `AWS_S3_DISABLE_CHECKSUMS=true` disables checksum algorithm headers (`x-amz-checksum-algorithm`)

## Problem
The current Convex backend hard-codes AWS-specific headers in S3 multipart upload operations:
- `ServerSideEncryption::Aes256` 
- `ChecksumAlgorithm::Crc32`

These headers cause compatibility issues with S3-compatible services that don't support AWS-specific features, leading to multipart upload failures.

## Solution
- Added two new environment variables in `aws_utils` crate for S3 compatibility configuration
- Modified `aws_s3` storage implementation to conditionally add AWS headers based on environment variables
- Maintains backward compatibility (headers are added by default when variables are not set)

## Files Changed
- `crates/aws_utils/src/lib.rs`: Added environment variable configuration and accessor functions
- `crates/aws_s3/src/storage.rs`: Updated multipart upload methods to conditionally add headers

## Testing
- Code compiles successfully with all dependencies
- Backward compatibility maintained (default behavior unchanged)
- Ready for testing with MinIO and other S3-compatible services

## Benefits
- Enables self-hosted Convex to work with a wider range of S3-compatible storage backends
- Improves compatibility with MinIO, Rook Ceph RGW, and other S3 implementations
- Maintains full backward compatibility with existing AWS S3 deployments

🤖 Generated with [Claude Code](https://claude.ai/code)