### PR TITLE
fix: playground docs

### DIFF
--- a/npm-packages/docs/docs/agents/playground.mdx
+++ b/npm-packages/docs/docs/agents/playground.mdx
@@ -24,13 +24,17 @@ There is also a [hosted version here](https://get-convex.github.io/agent/).
 **Note**: You must already have a Convex project set up with the Agent. See the
 [docs](./getting-started.mdx) for setup instructions.
 
+```sh
+npm i @convex-dev/agent-playground
+```
+
 In your agent Convex project, make a file `convex/playground.ts` with:
 
 ```ts
-import { definePlaygroundAPI } from "@convex-dev/agent";
+import { definePlaygroundAPI } from "@convex-dev/agent-playground";
 import { components } from "./_generated/api";
 import { weatherAgent, fashionAgent } from "./example";
-
+`
 /**
  * Here we expose the API so the frontend can access it.
  * Authorization is handled by passing up an apiKey that can be generated


### PR DESCRIPTION
<!-- Describe your PR here. -->

Few weeks ago there was a change in the Playground docs where instead of (agent-playground) only (agent) was selected to import the definePlaygroundAPI. Previous version of the docs was working fine. Hence I am making this PR to reverse that change. 

I have tested agent package & I couldn't find any supporting changing which can help us import the definePlaygroundAPI.
Also I see no updates for the same on the Official Convex Playground page as shown below.

<img width="750" height="839" alt="Screenshot 2025-08-26 at 6 02 39 PM" src="https://github.com/user-attachments/assets/713cdc7b-a5cb-40b9-93c0-8e7544fd4cd2" />

<!--
  The following applies to third-party contributors.
  Convex employees and contractors can delete or ignore.
-->

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
