### PR TITLE
React: Optionally treat loading as unauthenticated

### DIFF
--- a/npm-packages/convex/src/react/auth_helpers.test.tsx
+++ b/npm-packages/convex/src/react/auth_helpers.test.tsx
@@ -1,9 +1,22 @@
 /**
  * @vitest-environment custom-vitest-environment.ts
  */
-import { test } from "vitest";
+import { render, screen } from "@testing-library/react";
 import React from "react";
+import { describe, expect, test } from "vitest";
 import { Authenticated, AuthLoading, Unauthenticated } from "./auth_helpers.js";
+import { ConvexReactClient } from "./client.js";
+import { ConvexProviderWithAuth } from "./index.js";
+
+function mockUseAuth(isLoading = true, isAuthenticated = false) {
+  return () => {
+    return {
+      isAuthenticated: isAuthenticated,
+      isLoading: isLoading,
+      fetchAccessToken: async () => null,
+    };
+  };
+}
 
 test("Helpers are valid children", () => {
   const _element = (
@@ -32,4 +45,36 @@ test("Helpers can take many children", () => {
       </AuthLoading>
     </div>
   );
+});
+
+describe("<Unauthenticated />", () => {
+  test("renders children when loading and prop loadingEqualsUnauthenticated is true", () => {
+    const convex = new ConvexReactClient("https://127.0.0.1:3001");
+
+    const { unmount } = render(
+      <ConvexProviderWithAuth client={convex} useAuth={mockUseAuth(true)}>
+        <Unauthenticated loadingEqualsUnauthenticated>
+          <div>Yay</div>
+        </Unauthenticated>
+      </ConvexProviderWithAuth>,
+    );
+
+    expect(screen.getByText("Yay")).toBeTruthy();
+    unmount();
+  });
+
+  test("shows no children when loading", () => {
+    const convex = new ConvexReactClient("https://127.0.0.1:3001");
+
+    const { unmount } = render(
+      <ConvexProviderWithAuth client={convex} useAuth={mockUseAuth(true)}>
+        <Unauthenticated>
+          <div>Yay</div>
+        </Unauthenticated>
+      </ConvexProviderWithAuth>,
+    );
+
+    expect(screen.queryByText("Yay")).toBeNull();
+    unmount();
+  });
 });

--- a/npm-packages/convex/src/react/auth_helpers.tsx
+++ b/npm-packages/convex/src/react/auth_helpers.tsx
@@ -1,5 +1,4 @@
-import React from "react";
-import { ReactNode } from "react";
+import React, { ReactNode } from "react";
 import { useConvexAuth } from "./ConvexAuthState.js";
 
 /**
@@ -17,12 +16,20 @@ export function Authenticated({ children }: { children: ReactNode }) {
 
 /**
  * Renders children if the client is using authentication but is not authenticated.
+ * If `loadingEqualsUnauthenticated` is `true`, also renders children while the
+ * client is authenticating.
  *
  * @public
  */
-export function Unauthenticated({ children }: { children: ReactNode }) {
+export function Unauthenticated({
+  children,
+  loadingEqualsUnauthenticated = false,
+}: {
+  children: ReactNode;
+  loadingEqualsUnauthenticated?: boolean;
+}) {
   const { isLoading, isAuthenticated } = useConvexAuth();
-  if (isLoading || isAuthenticated) {
+  if ((isLoading && !loadingEqualsUnauthenticated) || isAuthenticated) {
     return null;
   }
   return <>{children}</>;


### PR DESCRIPTION
Hey all, I used convex for some weeks now and came across the `<Unauthenticated />` react component.
I noticed when using SSR in NextJS there is a short time window where the page renders nothing when using said component together with `<Authenticated />`. I looked into the code and found out, that when the authentication state is loading, neither of said components render anything.

To have more control over this and to fix this small issue I want to introduce a prop on the `<Unauthenticated />` component.

How does it work?
With the prop `loadingEqualsUnauthenticated` developers can decide wether they want to treat the loading state as unauthenticated or not. So when this gets set to `true`, the loading state is ignored and the children are rendered to the DOM. 
This option defaults to `false`, so this should not be a breaking change. This is something similar to what Clerk provides through their built-in components: [loadingEqualsUnauthenticated](https://clerk.com/docs/nextjs/components/control/signed-in#properties)

Please let me know what you think of this change. Any feedback is welcome.

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
