### PR TITLE
Clarify documentation regarding instance names / connection strings

### DIFF
--- a/self-hosted/README.md
+++ b/self-hosted/README.md
@@ -327,6 +327,18 @@ export MYSQL_URL=mysql://<your-username>:<your-password>@aws.connect.psdb.cloud
 docker compose up
 ```
 
+### Database Names
+
+The database name that the Convex backend uses is equivalent to the instance name (replacing `-` with `_`). If no instance name is set, the Docker image defaults to `convex-self-hosted`, and the Convex backend will connect to the database `convex_self_hosted`.
+
+For the docker container, you can set the instance name via the `INSTANCE_NAME` envrionment variable.
+
+```sh
+export POSTGRES_URL='<connection string>'
+export INSTANCE_NAME='your-instance-name'
+psql $POSTGRES_URL -c "CREATE DATABASE your_instance_name;"
+```
+
 ## Using S3 Storage
 
 By default, the backend stores file data on the filesystem within the docker


### PR DESCRIPTION
Clarifies the documentation regarding the instance name and db connection strings.

---

There's more detail to cover outside of `--instance-name`, e.g. I've entirely ignored `multi-schema` - a rather useful abstraction layer to quickly bring test envrionments up and down. 

Alas, I couldn't run prettier on this because I'm using the github webui for this PR. I might come back tomorrow to fix it and/or address feedback.

I'm neither married to the wording nor the location of these settings, but because they're (atm) entirely undocumented and I could only find out the behavior after reading through your rust code for a while, I think it makes sense to have some config here. 

Perhaps it might make sense to create a longer, more detailed markdown file that goes into the specifics. At the same time, it would be useful to expose the the `--db` flag directly via the docker image. 

Anyway, I hope this contribution is useful - at least to inspire contributions by the core maintainers :)




<!--
  The following applies to third-party contributors.
  Convex employees and contractors can delete or ignore.
-->

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
