### PR TITLE
Feature stdin env cli

### DIFF
--- a/npm-packages/convex/src/cli/env.ts
+++ b/npm-packages/convex/src/cli/env.ts
@@ -23,6 +23,7 @@ const envSet = new Command("set")
   .summary("Set a variable")
   .description(
     "Set a variable: `npx convex env set NAME value`\n" +
+      "Read from stdin: `echo 'value' | npx convex env set NAME`\n" +
       "If the variable already exists, its value is updated.\n\n" +
       "A single `NAME=value` argument is also supported.",
   )

--- a/npm-packages/convex/src/cli/lib/utils/stdin.ts
+++ b/npm-packages/convex/src/cli/lib/utils/stdin.ts
@@ -1,22 +1,22 @@
 export async function readFromStdin(): Promise<string> {
   return new Promise((resolve, reject) => {
-    let data = '';
-    
-    process.stdin.setEncoding('utf8');
-    
-    process.stdin.on('readable', () => {
+    let data = "";
+
+    process.stdin.setEncoding("utf8");
+
+    process.stdin.on("readable", () => {
       let chunk;
       while (null !== (chunk = process.stdin.read())) {
         data += chunk;
       }
     });
-    
-    process.stdin.on('end', () => {
+
+    process.stdin.on("end", () => {
       // Remove trailing newline if present
-      resolve(data.replace(/\n$/, ''));
+      resolve(data.replace(/\n$/, ""));
     });
-    
-    process.stdin.on('error', (err) => {
+
+    process.stdin.on("error", (err) => {
       reject(err);
     });
   });

--- a/npm-packages/convex/src/cli/lib/utils/stdin.ts
+++ b/npm-packages/convex/src/cli/lib/utils/stdin.ts
@@ -1,0 +1,23 @@
+export async function readFromStdin(): Promise<string> {
+  return new Promise((resolve, reject) => {
+    let data = '';
+    
+    process.stdin.setEncoding('utf8');
+    
+    process.stdin.on('readable', () => {
+      let chunk;
+      while (null !== (chunk = process.stdin.read())) {
+        data += chunk;
+      }
+    });
+    
+    process.stdin.on('end', () => {
+      // Remove trailing newline if present
+      resolve(data.replace(/\n$/, ''));
+    });
+    
+    process.stdin.on('error', (err) => {
+      reject(err);
+    });
+  });
+}


### PR DESCRIPTION
<!-- Describe your PR here. -->

Setting JWTs from the command line is a little tedious and difficult to get right (specifically because they are multi-line files). This allows the user to echo/pipe/etc the value into the value into the cli.

`cat keys/my-private-key.txt | npx convex env set JWT_PRIVATE_KEY`

<!--
  The following applies to third-party contributors.
  Convex employees and contractors can delete or ignore.
-->

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
