### PR TITLE
correct link to actions docs

### DIFF
--- a/npm-packages/docs/docs/scheduling/scheduled-functions.mdx
+++ b/npm-packages/docs/docs/scheduling/scheduled-functions.mdx
@@ -55,7 +55,7 @@ scheduling call.
 
 ### Scheduling from actions
 
-Unlike mutations, [actions](//docs/functions/actions.mdx) don't execute as a
+Unlike mutations, [actions](/functions/actions.mdx) don't execute as a
 single database transaction and can have side effects. Thus, scheduling from
 actions does not depend on the outcome of the function. This means that an
 action might succeed to schedule some functions and later fail due to transient


### PR DESCRIPTION
<!-- Describe your PR here. -->
Docs currently link to nowhere, I'm mostly confident this is intended to redirect to the actions documentation (similar to the mutations documentation referenced in the previous section).

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
