### PR TITLE
Fixes typo on projects dashboard

### DIFF
--- a/npm-packages/dashboard/src/pages/t/[team]/index.tsx
+++ b/npm-packages/dashboard/src/pages/t/[team]/index.tsx
@@ -199,7 +199,7 @@ function ProjectGrid({ projects }: { projects: ProjectDetails[] }) {
           body={
             <>
               <p className="text-sm">
-                This team doesn't have an projects yet.{" "}
+                This team doesn't have any projects yet.{" "}
               </p>
               <p className="text-sm">Get started by following the tutorial.</p>
             </>


### PR DESCRIPTION
This fixes a small typo I just noticed on the projects dashboard (only visible when the user's team does not have any projects).

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
