### PR TITLE
Log Streaming Webhook sink: add basic auth

### DIFF
--- a/crates/local_backend/src/log_sinks.rs
+++ b/crates/local_backend/src/log_sinks.rs
@@ -92,6 +92,7 @@ pub async fn add_datadog_sink(
 pub struct WebhookSinkPostArgs {
     url: String,
     format: WebhookFormat,
+    basic_auth: Option<SerializedBasicAuth>,
 }
 
 impl TryFrom<WebhookSinkPostArgs> for WebhookConfig {
@@ -107,8 +108,19 @@ impl TryFrom<WebhookSinkPostArgs> for WebhookConfig {
         Ok(WebhookConfig {
             url,
             format: value.format,
+            basic_auth: value.basic_auth.map(|b| model::log_sinks::types::webhook::BasicAuth {
+                username: b.username,
+                password: common::pii::PII(b.password),
+            }),
         })
     }
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SerializedBasicAuth {
+    pub username: String,
+    pub password: String,
 }
 
 #[debug_handler]

--- a/npm-packages/dashboard-common/src/features/settings/components/integrations/WebhookConfigurationForm.tsx
+++ b/npm-packages/dashboard-common/src/features/settings/components/integrations/WebhookConfigurationForm.tsx
@@ -10,6 +10,17 @@ import { Combobox } from "@ui/Combobox";
 const webhookValidationSchema = Yup.object().shape({
   url: Yup.string().url().required("URL required"),
   format: Yup.string().oneOf(["json", "jsonl"]).required("Format required"),
+  authType: Yup.string().oneOf(["none", "basic"]).required(),
+  username: Yup.string().when("authType", {
+    is: "basic",
+    then: (schema) => schema.required("Username required"),
+    otherwise: (schema) => schema.notRequired(),
+  }),
+  password: Yup.string().when("authType", {
+    is: "basic",
+    then: (schema) => schema.required("Password required"),
+    otherwise: (schema) => schema.notRequired(),
+  }),
 });
 
 export function WebhookConfigurationForm({
@@ -25,9 +36,25 @@ export function WebhookConfigurationForm({
     initialValues: {
       url: existingIntegration?.url ?? "",
       format: existingIntegration?.format ?? "jsonl",
+      authType: existingIntegration?.auth?.type ?? "none",
+      username:
+        existingIntegration?.auth?.type === "basic"
+          ? existingIntegration.auth.username
+          : "",
+      password: "",
     },
     onSubmit: async (values) => {
-      await createWebhookIntegration(values.url, values.format);
+      const body: any = {
+        url: values.url,
+        format: values.format,
+      };
+      if (values.authType === "basic") {
+        body.basicAuth = {
+          username: values.username,
+          password: values.password,
+        };
+      }
+      await createWebhookIntegration(body);
       onClose();
     },
     validationSchema: webhookValidationSchema,
@@ -58,6 +85,42 @@ export function WebhookConfigurationForm({
         disableSearch
         buttonClasses="w-full bg-inherit"
       />
+      <Combobox
+        label="Authentication"
+        labelHidden={false}
+        options={[
+          { value: "none", label: "None" },
+          { value: "basic", label: "Basic" },
+        ]}
+        selectedOption={formState.values.authType}
+        setSelectedOption={async (v) => {
+          await formState.setFieldValue("authType", v);
+        }}
+        allowCustomValue={false}
+        disableSearch
+        buttonClasses="w-full bg-inherit"
+      />
+      {formState.values.authType === "basic" && (
+        <>
+          <TextInput
+            value={formState.values.username}
+            onChange={formState.handleChange}
+            id="username"
+            label="Username"
+            placeholder="Enter username"
+            error={formState.errors.username as string | undefined}
+          />
+          <TextInput
+            value={formState.values.password}
+            onChange={formState.handleChange}
+            id="password"
+            type="password"
+            label="Password"
+            placeholder="Enter password"
+            error={formState.errors.password as string | undefined}
+          />
+        </>
+      )}
       <div className="flex justify-end">
         <Button
           variant="primary"

--- a/npm-packages/dashboard-common/src/lib/integrationsApi.ts
+++ b/npm-packages/dashboard-common/src/lib/integrationsApi.ts
@@ -46,15 +46,23 @@ export function useCreateDatadogIntegration(): (
 }
 
 export function useCreateWebhookIntegration(): (
-  url: string,
-  format: "json" | "jsonl",
+  body:
+    | {
+        url: string;
+        format: "json" | "jsonl";
+      }
+    | {
+        url: string;
+        format: "json" | "jsonl";
+        basicAuth: { username: string; password: string };
+      },
 ) => Promise<void> {
   const deploymentUrl = useDeploymentUrl();
   const adminKey = useAdminKey();
   const { reportHttpError } = useContext(DeploymentInfoContext);
 
-  return async (url: string, format: "json" | "jsonl") => {
-    const body = JSON.stringify({ url, format });
+  return async (bodyArg) => {
+    const body = JSON.stringify(bodyArg);
     await createIntegration(
       "webhook",
       body,

--- a/npm-packages/docs/docs/production/integrations/log-streams/log-streams.mdx
+++ b/npm-packages/docs/docs/production/integrations/log-streams/log-streams.mdx
@@ -67,11 +67,24 @@ Configuring a Datadog log stream requires specifying:
 ### Webhook
 
 A webhook log stream is the simplest and most generic stream, allowing piping
-logs via POST requests to any URL you configure. The only parameter required to
-set up this stream is the desired webhook URL.
+logs via POST requests to any URL you configure.
+
+You can optionally configure Basic authentication so Convex will send an
+`Authorization: Basic <base64(username:password)>` header with each request.
+This is useful for services that protect ingestion endpoints with HTTP auth.
 
 A request to this webhook contains as its body a JSON array of events in the
-schema defined below.
+schema defined below. Alternatively, you can choose JSONL to send one JSON
+object per line.
+
+Example (ClickHouse Cloud):
+
+- URL:
+  `https://<host>:8443/?query=INSERT%20INTO%20<db>.<table>%20FORMAT%20JSONEachRow&input_format_skip_unknown_fields=1`
+- Format: JSONL
+- Authentication: Basic (username/password)
+
+ClickHouse HTTP interface and formats: https://clickhouse.com/docs/interfaces/http
 
 ## Log event schema
 

--- a/npm-packages/system-udfs/convex/schema.ts
+++ b/npm-packages/system-udfs/convex/schema.ts
@@ -206,6 +206,16 @@ export const webhookConfig = v.object({
   type: v.literal("webhook"),
   url: v.string(),
   format: v.union(v.literal("json"), v.literal("jsonl")),
+  auth: v.optional(
+    v.union(
+      v.object({ type: v.literal("none") }),
+      v.object({
+        type: v.literal("basic"),
+        username: v.string(),
+        password: v.string(),
+      }),
+    ),
+  ),
 });
 
 export const axiomConfig = v.object({


### PR DESCRIPTION
Add Basic HTTP auth to webhook logs sink.

The main objective is streaming logs to ClickHouse: https://clickhouse.com/docs/interfaces/http

Cf. this Discord discussion: https://discord.com/channels/1019350475847499849/1296860730104217610

P.S. This patch is vibe-coded, I'm not an expert in Rust. I didn't test this patch.

<!--
  The following applies to third-party contributors.
  Convex employees and contractors can delete or ignore.
-->

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
