### PR TITLE
Update TanStack Start with Convex and Clerk example link to correct template

### DIFF
--- a/npm-packages/docs/docs/auth/clerk.mdx
+++ b/npm-packages/docs/docs/auth/clerk.mdx
@@ -432,7 +432,7 @@ follow the [Convex Next.js Quickstart](/quickstart/nextjs.mdx) first. Then:
 ### TanStack Start
 
 **Example:**
-[TanStack Start with Convex and Clerk](https://github.com/get-convex/templates/tree/main/template-tanstack-start)
+[TanStack Start with Convex and Clerk](https://github.com/get-convex/templates/tree/main/template-tanstack-start-clerk)
 
 See the
 [TanStack Start with Clerk guide](/client/tanstack/tanstack-start/clerk.mdx) for


### PR DESCRIPTION
This pull request updates the example link in the TanStack Start documentation.
Previously, the example pointed to the generic TanStack Start template.
It now correctly links to the TanStack Start with Convex and Clerk template.

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
