### PR TITLE
Replace ProxyAgent with EnvHttpProxyAgent in cli

### DIFF
--- a/npm-packages/convex/src/cli/index.ts
+++ b/npm-packages/convex/src/cli/index.ts
@@ -32,7 +32,7 @@ import { mcp } from "./mcp.js";
 import dns from "node:dns";
 import net from "node:net";
 import { integration } from "./integration.js";
-import { setGlobalDispatcher, ProxyAgent } from "undici";
+import { setGlobalDispatcher, EnvHttpProxyAgent } from "undici";
 import { logVerbose } from "../bundler/log.js";
 
 const MINIMUM_MAJOR_VERSION = 16;
@@ -50,7 +50,7 @@ async function main() {
 
   const proxy = process.env.HTTPS_PROXY || process.env.HTTP_PROXY;
   if (proxy) {
-    setGlobalDispatcher(new ProxyAgent(proxy));
+    setGlobalDispatcher(new EnvHttpProxyAgent());
     logVerbose(`[proxy-bootstrap] Using proxy: ${proxy}`);
   }
 


### PR DESCRIPTION
I have an issue with using Convex local deployments with "Claude code on the web", that I think I solved🤞

My issue is that the Convex CLI would hang when running `npx convex dev --once` on "Claude code on the web". This is an issue because it makes using Convex with agentic background agents unusable (Claude code on the web in this case). 

What I want is to setup a local isolated Convex deployment for Claude that would have all the same features as a normal cloud deployment, but mainly the codegen.

I did some debugging with the help from Claude and found out the Convex CLI does not respect the `NO_PROXY` environment variable that is set in "Claude code on the web" environment. From this we suspected that Convex would incorrectly try to proxy localhost.

Our quick fix was to use the pnpm patch feature and patch `npm-packages/convex/src/cli/index.ts` to use `EnvHttpProxyClient` because this class would automatically setup the proxy agent based on the environment variables available ([undici docs](https://undici.nodejs.org/#/docs/api/EnvHttpProxyAgent?id=class-envhttpproxyagent)). This seemingly fixed the issue.

To reproduce the issue, I forked the [convex-tutorial](https://github.com/get-convex/convex-tutorial) repo and asked "Claude code on the web":
> Please run:
>
> - pnpm install
> - CONVEX_AGENT_MODE=anonymous pnpm convex dev --once --configure new --project foo --dev-deployment local --team bar
>
> And tell me what happens

and it hanged at the second step "waiting for local backend to start...".

Lastly to verify that I had a fix, I patched `ProxyAgent` to `EnvHttpProxyAgent` (exact PR [here](https://github.com/kristofferaas/convex-tutorial/pull/1/files)) and asked "Claude code on the web", in the same thread:

> I want you to pull the latest main and run:
> - pnpm install
> - CONVEX_AGENT_MODE=anonymous pnpm convex dev --once --configure new --project foo --dev-deployment local --team bar
>
> And tell me what happens

Claude responded with:

> What Happened:
> The pnpm install completed in 11.3 seconds, installing Convex 1.28.2 with the patch applied.
>
> Then the CONVEX_AGENT_MODE=anonymous pnpm convex dev --once command ran and completed  successfully with exit code 0! Here's what it did:
>
> ✅ Successful output:
>
> Started a local deployment at http://127.0.0.1:3210
> Saved deployment configuration to .env.local:
> CONVEX_DEPLOYMENT variable
> VITE_CONVEX_URL variable
> Prepared Convex functions in ~1.12 seconds
> Convex dashboard available at http://127.0.0.1:6790/?d=anonymous-agent-2
> Key difference from before: Previously, the command hung at "waiting for local backend to > start..." for over 2 minutes. Now it completes successfully in seconds. The patch that fixes NO_PROXY environment variable handling appears to have resolved the issue that was causing the CLI to hang!

Proving to me that this solved the issue! 

Everything works as I would expect with this and I'm currently using a patched version of convex in my project. Would be awesome if this was a suitable contribution for the team! Love the product btw 🫶

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
