### PR TITLE
Docs: Clarified the behavior of message filtering in the query

### DIFF
--- a/npm-packages/docs/docs/database/reading-data/indexes/indexes.md
+++ b/npm-packages/docs/docs/database/reading-data/indexes/indexes.md
@@ -203,8 +203,8 @@ do:
 ```ts
 const messages = await ctx.db
   .query("messages")
-  .withIndex("by_channel", q => q.eq("channel", channel))
-  .filter(q => q.neq(q.field("user"), myUserId))
+  .withIndex("by_channel", (q) => q.eq("channel", channel))
+  .filter((q) => q.neq(q.field("user"), myUserId))
   .collect();
 ```
 


### PR DESCRIPTION
Hey there,

I noticed that the explanation on filtering indexed queries ("matches") does not correspond to the operator used in the example code (`.neq()`).
This also adds a missing closing parenthesis for `.filter(...)` in the same code block.

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
