### PR TITLE
Fix npm create command for npm 11 compatibility

### DIFF
--- a/npm-packages/components/ratelimiter/README.md
+++ b/npm-packages/components/ratelimiter/README.md
@@ -10,7 +10,7 @@ https://github.com/get-convex/templates/tree/main/template-component for the
 template that powers
 
 ```
-npx create-convex@latest  --component
+npx create-convex@latest --component
 ```
 
 # Structure of a Convex Component

--- a/npm-packages/docs/docs/auth/authkit/index.mdx
+++ b/npm-packages/docs/docs/auth/authkit/index.mdx
@@ -21,7 +21,7 @@ The quickest way to get started is to create an
 Convex CLI.
 
 ```bash
-npx create-convex@latest  -t react-vite-authkit
+npx create-convex@latest -t react-vite-authkit
 cd my-app  # or whatever you name the directory
 npm run dev
 ```

--- a/npm-packages/docs/docs/client/nextjs/app-router/index.mdx
+++ b/npm-packages/docs/docs/client/nextjs/app-router/index.mdx
@@ -94,7 +94,7 @@ For an example of using Convex and with Next.js 15, run
 
 <p>
   <b>
-    <CodeWithCopyButton text="npx create-convex@latest  -t nextjs-clerk" />
+    <CodeWithCopyButton text="npx create-convex@latest -t nextjs-clerk" />
   </b>
 </p>
 

--- a/npm-packages/docs/docs/components/authoring.mdx
+++ b/npm-packages/docs/docs/components/authoring.mdx
@@ -89,7 +89,7 @@ Get started with a new project using the
 [component template](https://github.com/get-convex/templates/tree/main/template-component):
 
 ```bash
-npx create-convex@latest  --component
+npx create-convex@latest --component
 ```
 
 Follow the CLI's instructions to get started and keep the component's generated

--- a/npm-packages/docs/docs/quickstart/tanstack-start.mdx
+++ b/npm-packages/docs/docs/quickstart/tanstack-start.mdx
@@ -24,7 +24,7 @@ To get setup quickly with Convex and TanStack Start run
 
 <p>
   <b>
-    <CodeWithCopyButton text="npx create-convex@latest  -t tanstack-start" />
+    <CodeWithCopyButton text="npx create-convex@latest -t tanstack-start" />
   </b>
 </p>
 


### PR DESCRIPTION
npm 11 broke passing through config flags with npm create.
Replaced 'npm create convex@latest --' with 'npx create-convex@latest'
and 'npm create convex --' with 'npx create-convex'.