### PR TITLE
Fix: Respect port settings from .env.local for local deployments

### DIFF
--- a/npm-packages/convex/src/cli/lib/localDeployment/anonymous.ts
+++ b/npm-packages/convex/src/cli/lib/localDeployment/anonymous.ts
@@ -33,6 +33,7 @@ import {
   isOffline,
   generateInstanceSecret,
   choosePorts,
+  getPortsFromEnvFile,
   LOCAL_BACKEND_INSTANCE_SECRET,
 } from "./utils.js";
 import { handleDashboard } from "./dashboard.js";
@@ -141,10 +142,16 @@ export async function handleAnonymousDeployment(
     adminKey = data.adminKey;
   }
 
+  // Read port settings from .env.local if not explicitly provided via CLI options
+  const portsFromEnv = options.ports ? { cloud: null, site: null } : await getPortsFromEnvFile(ctx);
+
   const [cloudPort, sitePort] = await choosePorts(ctx, {
     count: 2,
     startPort: 3210,
-    requestedPorts: [options.ports?.cloud ?? null, options.ports?.site ?? null],
+    requestedPorts: [
+      options.ports?.cloud ?? portsFromEnv.cloud ?? null,
+      options.ports?.site ?? portsFromEnv.site ?? null,
+    ],
   });
   const onActivity = async (isOffline: boolean, _wasOffline: boolean) => {
     await ensureBackendRunning(ctx, {


### PR DESCRIPTION
### Problem #288 
Local deployments always use port 3210/3211, ignoring ports specified in `.env.local`. This prevents running multiple worktrees simultaneously.

### Solution
Read port settings from framework-specific environment variables (NEXT_PUBLIC_CONVEX_URL, VITE_CONVEX_URL, etc.) in .env.local when starting local Convex deployments.

This allows running multiple worktrees on the same machine by specifying different ports in each worktree's .env.local file.

Changes:
- Add getPortsFromEnvFile() to extract ports from .env.local
- Update handleLocalDeployment() to use ports from env vars
- Update handleOffline() to use ports from env vars
- Update handleAnonymousDeployment() to use ports from env vars

Example .env.local:
  NEXT_PUBLIC_CONVEX_URL=http://127.0.0.1:3220 
  NEXT_PUBLIC_CONVEX_SITE_URL=http://127.0.0.1:3222

Backward compatible: defaults to 3210/3211 if not specified. CLI options take precedence over .env.local settings.

Fixes: Multiple worktrees can now run simultaneously without port conflicts

<!-- Describe your PR here. -->



<!--
  The following applies to third-party contributors.
  Convex employees and contractors can delete or ignore.
-->

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
