### PR TITLE
Fix incorrect "Next" button navigation on Next.js App Router docs page

### DIFF
--- a/npm-packages/docs/docs/client/nextjs/app-router/index.mdx
+++ b/npm-packages/docs/docs/client/nextjs/app-router/index.mdx
@@ -3,6 +3,7 @@ title: "Next.js"
 sidebar_label: "Next.js App Router"
 sidebar_position: 200
 description: "How Convex works in a Next.js app"
+pagination_next: client/nextjs/app-router/server-rendering
 ---
 
 import Config from "!!raw-loader!@site/../private-demos/quickstarts/nextjs-app-dir-14/app/_ConvexClientProviderAuth.tsx";


### PR DESCRIPTION
### Problem
The "Next" button on the Next.js App Router documentation page (https://docs.convex.dev/client/nextjs/app-router/) was linking back to the same page instead of advancing to the Server Rendering section.

### Cause
Docusaurus determines pagination automatically based on `sidebar_position` values. The app-router directory had:
- `server-rendering.mdx` with `sidebar_position: 10` (appears first)
- `index.mdx` with `sidebar_position: 200` (appears second)

Without explicit pagination configuration, the "Next" button from the index page (being the last item in the category) didn't navigate correctly.

### Solution
Added explicit `pagination_next: client/nextjs/app-router/server-rendering` to the frontmatter of `app-router/index.mdx`.

Fixes #285
----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
