### PR TITLE
Fix: Preserve numeric literal types in function spec

### DIFF
--- a/crates/common/src/schemas/json.rs
+++ b/crates/common/src/schemas/json.rs
@@ -646,6 +646,8 @@ pub enum ValidatorJson {
     Any,
     Literal {
         value: JsonValue,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        literal_type: Option<String>,
     },
     #[serde(rename_all = "camelCase")]
     Id {
@@ -682,7 +684,46 @@ impl TryFrom<ValidatorJson> for Validator {
             ValidatorJson::String => Ok(Validator::String),
             ValidatorJson::Bytes => Ok(Validator::Bytes),
             ValidatorJson::Any => Ok(Validator::Any),
-            ValidatorJson::Literal { value } => Ok(Validator::Literal(value.try_into()?)),
+            ValidatorJson::Literal {
+                value,
+                literal_type,
+            } => {
+                if let Some(type_hint) = literal_type {
+                    match type_hint.as_str() {
+                        "Int64" => {
+                            let convex_value: ConvexValue = value.try_into()?;
+                            match convex_value {
+                                ConvexValue::Int64(i) => {
+                                    Ok(Validator::Literal(LiteralValidator::Int64(i)))
+                                },
+                                ConvexValue::Float64(f) if f.fract() == 0.0 => {
+                                    Ok(Validator::Literal(LiteralValidator::Int64(f as i64)))
+                                },
+                                _ => Ok(Validator::Literal(convex_value.try_into()?)),
+                            }
+                        },
+                        "Float64" => {
+                            let convex_value: ConvexValue = value.try_into()?;
+                            match convex_value {
+                                ConvexValue::Float64(f) => {
+                                    Ok(Validator::Literal(LiteralValidator::Float64(f.into())))
+                                },
+                                ConvexValue::Int64(i) => Ok(Validator::Literal(
+                                    LiteralValidator::Float64((i as f64).into()),
+                                )),
+                                _ => Ok(Validator::Literal(convex_value.try_into()?)),
+                            }
+                        },
+                        _ => {
+                            let convex_value: ConvexValue = value.try_into()?;
+                            Ok(Validator::Literal(convex_value.try_into()?))
+                        },
+                    }
+                } else {
+                    let convex_value: ConvexValue = value.try_into()?;
+                    Ok(Validator::Literal(convex_value.try_into()?))
+                }
+            },
             ValidatorJson::Id { table_name } => Ok(Validator::Id(table_name.parse()?)),
             ValidatorJson::Array { value } => Ok(Validator::Array(Box::new((*value).try_into()?))),
             ValidatorJson::Record { keys, values } => {
@@ -742,8 +783,17 @@ impl TryFrom<Validator> for ValidatorJson {
             Validator::Boolean => ValidatorJson::Boolean,
             Validator::String => ValidatorJson::String,
             Validator::Bytes => ValidatorJson::Bytes,
-            Validator::Literal(literal) => ValidatorJson::Literal {
-                value: literal.try_into()?,
+            Validator::Literal(literal) => {
+                let literal_type = match &literal {
+                    LiteralValidator::Float64(_) => "Float64",
+                    LiteralValidator::Int64(_) => "Int64",
+                    LiteralValidator::Boolean(_) => "Boolean",
+                    LiteralValidator::String(_) => "String",
+                };
+                ValidatorJson::Literal {
+                    value: literal.try_into()?,
+                    literal_type: Some(literal_type.to_string()),
+                }
             },
             Validator::Array(t) => ValidatorJson::Array {
                 value: Box::new(ValidatorJson::try_from(*t)?),
@@ -791,7 +841,9 @@ impl TryFrom<LiteralValidator> for JsonValue {
                 ))?;
                 JsonValue::Number(n)
             },
-            LiteralValidator::Int64(i) => JsonValue::from(ConvexValue::Int64(i)),
+            LiteralValidator::Int64(i) => {
+                JsonValue::Number(serde_json::Number::from(i))
+            },
             LiteralValidator::Boolean(b) => JsonValue::Bool(b),
             LiteralValidator::String(s) => JsonValue::String(s.to_string()),
         };
@@ -876,6 +928,78 @@ mod tests {
             )?,
             ValidatorJson::Any
         );
+        Ok(())
+    }
+
+    #[test]
+    fn test_literal_int64_preserves_type() -> anyhow::Result<()> {
+        use crate::schemas::validator::Validator;
+
+        let literal = LiteralValidator::Int64(42);
+        let validator = Validator::Literal(literal.clone());
+        let json_val: ValidatorJson = validator.try_into()?;
+        
+        assert!(matches!(
+            json_val,
+            ValidatorJson::Literal {
+                literal_type: Some(ref t),
+                ..
+            } if t == "Int64"
+        ));
+
+        if let ValidatorJson::Literal { value, .. } = json_val {
+            assert_eq!(value, JsonValue::Number(serde_json::Number::from(42)));
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn test_literal_with_type_hint_int64() -> anyhow::Result<()> {
+        use crate::schemas::validator::Validator;
+
+        let validator_json = json!({
+            "type": "literal",
+            "value": 1,
+            "literalType": "Int64"
+        });
+        let validator: Validator = serde_json::from_value(validator_json)?;
+        
+        assert!(matches!(
+            validator,
+            Validator::Literal(LiteralValidator::Int64(1))
+        ));
+        Ok(())
+    }
+
+    #[test]
+    fn test_literal_with_type_hint_float64() -> anyhow::Result<()> {
+        use crate::schemas::validator::Validator;
+
+        let validator_json = json!({
+            "type": "literal",
+            "value": 1,
+            "literalType": "Float64"
+        });
+        let validator: Validator = serde_json::from_value(validator_json)?;
+        
+        assert!(matches!(
+            validator,
+            Validator::Literal(LiteralValidator::Float64(_))
+        ));
+        Ok(())
+    }
+
+    #[test]
+    fn test_literal_roundtrip_preserves_int64() -> anyhow::Result<()> {
+        use crate::schemas::validator::Validator;
+
+        let original = Validator::Literal(LiteralValidator::Int64(42));
+        let json: ValidatorJson = original.clone().try_into()?;
+        let serialized = serde_json::to_value(&json)?;
+        let deserialized: ValidatorJson = serde_json::from_value(serialized)?;
+        let back: Validator = deserialized.try_into()?;
+        
+        assert_eq!(original, back);
         Ok(())
     }
 }

--- a/npm-packages/convex/src/cli/lib/deployApi/validator.ts
+++ b/npm-packages/convex/src/cli/lib/deployApi/validator.ts
@@ -9,7 +9,11 @@ const baseConvexValidator = z.discriminatedUnion("type", [
   looseObject({ type: z.literal("string") }),
   looseObject({ type: z.literal("bytes") }),
   looseObject({ type: z.literal("any") }),
-  looseObject({ type: z.literal("literal"), value: z.any() }),
+  looseObject({ 
+    type: z.literal("literal"), 
+    value: z.any(),
+    literalType: z.enum(["Float64", "Int64", "Boolean", "String"]).optional(),
+  }),
   looseObject({ type: z.literal("id"), tableName: z.string() }),
 ]);
 export type ConvexValidator =

--- a/npm-packages/convex/src/values/validator.test.ts
+++ b/npm-packages/convex/src/values/validator.test.ts
@@ -159,6 +159,38 @@ describe("invalid validators fail when constructed obviously wrongly", () => {
         v.literal({} as any);
       }).toThrow();
     });
+
+    test("v.literal includes correct literalType", () => {
+      const intLiteral = v.literal(1);
+      expect(intLiteral.json).toMatchObject({
+        type: "literal",
+        literalType: "Int64",
+      });
+
+      const floatLiteral = v.literal(1.5);
+      expect(floatLiteral.json).toMatchObject({
+        type: "literal",
+        literalType: "Float64",
+      });
+
+      const stringLiteral = v.literal("hello");
+      expect(stringLiteral.json).toMatchObject({
+        type: "literal",
+        literalType: "String",
+      });
+
+      const boolLiteral = v.literal(true);
+      expect(boolLiteral.json).toMatchObject({
+        type: "literal",
+        literalType: "Boolean",
+      });
+
+      const bigintLiteral = v.literal(BigInt(42));
+      expect(bigintLiteral.json).toMatchObject({
+        type: "literal",
+        literalType: "Int64",
+      });
+    });
   });
 
   test("v.object", () => {

--- a/npm-packages/convex/src/values/validators.ts
+++ b/npm-packages/convex/src/values/validators.ts
@@ -452,9 +452,24 @@ export class VLiteral<
   }
   /** @internal */
   get json(): ValidatorJSON {
+    const value = this.value as string | boolean | number | bigint;
+    let literalType: "Float64" | "Int64" | "Boolean" | "String";
+    
+    if (typeof value === "string") {
+      literalType = "String";
+    } else if (typeof value === "boolean") {
+      literalType = "Boolean";
+    } else if (typeof value === "bigint") {
+      literalType = "Int64";
+    } else {
+      // number type - check if it's an integer
+      literalType = Number.isInteger(value) ? "Int64" : "Float64";
+    }
+    
     return {
       type: this.kind,
-      value: convexToJson(this.value as string | boolean | number | bigint),
+      value: convexToJson(value),
+      literalType,
     };
   }
   /** @internal */
@@ -754,7 +769,7 @@ export type ValidatorJSON =
   | { type: "string" }
   | { type: "bytes" }
   | { type: "any" }
-  | { type: "literal"; value: JSONValue }
+  | { type: "literal"; value: JSONValue; literalType?: "Float64" | "Int64" | "Boolean" | "String" }
   | { type: "id"; tableName: string }
   | { type: "array"; value: ValidatorJSON }
   | {

--- a/npm-packages/udf-tests/convex/args_validation.ts
+++ b/npm-packages/udf-tests/convex/args_validation.ts
@@ -35,3 +35,51 @@ export const recordArg = query({
     return arg;
   },
 });
+
+export const literalIntArg = query({
+  args: {
+    value: v.literal(1),
+  },
+  returns: v.object({
+    value: v.literal(1),
+  }),
+  handler: (_, args) => {
+    return args;
+  },
+});
+
+export const literalFloatArg = query({
+  args: {
+    value: v.literal(1.5),
+  },
+  returns: v.object({
+    value: v.literal(1.5),
+  }),
+  handler: (_, args) => {
+    return args;
+  },
+});
+
+export const literalStringArg = query({
+  args: {
+    value: v.literal("test"),
+  },
+  returns: v.object({
+    value: v.literal("test"),
+  }),
+  handler: (_, args) => {
+    return args;
+  },
+});
+
+export const literalBoolArg = query({
+  args: {
+    value: v.literal(true),
+  },
+  returns: v.object({
+    value: v.literal(true),
+  }),
+  handler: (_, args) => {
+    return args;
+  },
+});


### PR DESCRIPTION
## Problem

When using `v.literal(1)` in TypeScript, the function-spec incorrectly reported the literal value as `1.0` instead of `1`, causing runtime validation errors:

```typescript
export const query10 = query({
  args: {
    i: v.literal(1),
  },
  returns: {
    i: v.literal(1),
  },
  handler: (ctx, args) => {
    return args;
  },
});
```

This produced a function-spec with `value: 1.0`, but when calling the function with `1`, it failed with:

```
ClientError.serverError(msg: [Request ID: 67be452c7b31cf99] Server Error
  ArgumentValidationError: `1` does not match literal validator `v.literal(1.0)`.Path: .i
)
```

### Root Cause

JavaScript doesn't distinguish between integers and floats - both `1` and `1.0` are the same `number` type. When `v.literal(1)` was serialized:

1. TypeScript's `convexToJson(1)` treated it as a regular number
2. JSON serialization couldn't preserve whether the user intended Int64 or Float64
3. Backend deserialized the JSON number as Float64 by default
4. Function-spec showed `1.0` instead of `1`
5. Runtime validation failed because the stored literal type didn't match the input

## Solution

Added an optional `literalType` field to explicitly encode the intended numeric type:

- `v.literal(1)` → `{ type: "literal", value: 1, literalType: "Int64" }`
- `v.literal(1.5)` → `{ type: "literal", value: 1.5, literalType: "Float64" }`
- `v.literal("test")` → `{ type: "literal", value: "test", literalType: "String" }`
- `v.literal(true)` → `{ type: "literal", value: true, literalType: "Boolean" }`

## Changes

### TypeScript (`npm-packages/convex/`)

**`src/values/validators.ts`**
- Added `literalType?: "Float64" | "Int64" | "Boolean" | "String"` to `ValidatorJSON` type
- Updated `VLiteral.json` getter to detect and include the appropriate `literalType`
- Integer detection uses `Number.isInteger()` for JavaScript numbers

**`src/cli/lib/deployApi/validator.ts`**
- Updated zod schema to include optional `literalType` field

**`src/values/validator.test.ts`**
- Added tests verifying each literal type includes correct `literalType` field

### Rust (`crates/common/`)

**`src/schemas/json.rs`**
- Added `literal_type: Option<String>` to `ValidatorJson::Literal` variant
- Fixed critical bug: `LiteralValidator::Int64` now serializes as plain JSON number instead of `{"$integer": "..."}`
- Added deserialization logic to use `literalType` hint when converting JSON to validators
- Added 4 new tests for literal type preservation and roundtrip conversion

### Integration Tests

**`npm-packages/udf-tests/convex/args_validation.ts`**
- Added test functions for `v.literal(1)`, `v.literal(1.5)`, `v.literal("test")`, and `v.literal(true)`

## Testing

- All TypeScript tests pass (28/28)
- TypeScript build successful
- Manual verification confirms correct JSON output

**Before:**
```json
{
  "type": "literal",
  "value": 1.0
}
```

**After:**
```json
{
  "type": "literal",
  "value": 1,
  "literalType": "Int64"
}
```

## Backward Compatibility

- `literalType` field is optional and uses `#[serde(skip_serializing_if = "Option::is_none")]`
- Old validators without `literalType` still work (default to inferring type from value)
- No migration needed for existing deployments

## Fixes

Closes #213


----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
