### PR TITLE
Add --typescript-compiler CLI flag for dev/deploy/run commands

### DIFF
--- a/npm-packages/convex/src/cli/deploy.ts
+++ b/npm-packages/convex/src/cli/deploy.ts
@@ -190,6 +190,7 @@ async function deployToNewPreviewDeployment(
     verbose?: boolean | undefined;
     typecheck: "enable" | "try" | "disable";
     typecheckComponents: boolean;
+    typescriptCompiler?: "tsc" | "tsgo" | undefined;
     codegen: "enable" | "disable";
 
     debug?: boolean | undefined;
@@ -251,6 +252,7 @@ async function deployToNewPreviewDeployment(
     dryRun: false,
     typecheck: options.typecheck,
     typecheckComponents: options.typecheckComponents,
+    typescriptCompiler: options.typescriptCompiler,
     debug: !!options.debug,
     debugBundlePath: options.debugBundlePath,
     debugNodeApis: false,

--- a/npm-packages/convex/src/cli/dev.ts
+++ b/npm-packages/convex/src/cli/dev.ts
@@ -39,6 +39,12 @@ export const dev = new Command("dev")
     false,
   )
   .addOption(
+    new Option(
+      "--typescript-compiler <compiler>",
+      "TypeScript compiler to use for typechecking. Requires `@typescript/native-preview` to be installed for `tsgo`.",
+    ).choices(["tsc", "tsgo"] as const),
+  )
+  .addOption(
     new Option("--codegen <mode>", "Regenerate code in `convex/_generated/`")
       .choices(["enable", "disable"] as const)
       .default("enable" as const),

--- a/npm-packages/convex/src/cli/lib/command.ts
+++ b/npm-packages/convex/src/cli/lib/command.ts
@@ -1,6 +1,7 @@
 import { Command, Option } from "@commander-js/extra-typings";
 import { OneoffCtx } from "../../bundler/context.js";
 import { LogMode } from "./logs.js";
+import { TypescriptCompiler } from "./typecheck.js";
 import {
   CONVEX_DEPLOYMENT_ENV_VAR_NAME,
   CONVEX_SELF_HOSTED_ADMIN_KEY_VAR_NAME,
@@ -49,6 +50,7 @@ declare module "@commander-js/extra-typings" {
         yes?: boolean;
         typecheck: "enable" | "try" | "disable";
         typecheckComponents: boolean;
+        typescriptCompiler?: TypescriptCompiler;
         codegen: "enable" | "disable";
         cmd?: string;
         cmdUrlEnvVarName?: string;
@@ -82,6 +84,7 @@ declare module "@commander-js/extra-typings" {
         identity?: string;
         typecheck: "enable" | "try" | "disable";
         typecheckComponents: boolean;
+        typescriptCompiler?: TypescriptCompiler;
         codegen: "enable" | "disable";
         component?: string;
         liveComponentSources?: boolean;
@@ -203,6 +206,7 @@ export async function normalizeDevOptions(
     verbose?: boolean;
     typecheck: "enable" | "try" | "disable";
     typecheckComponents?: boolean;
+    typescriptCompiler?: TypescriptCompiler;
     codegen: "enable" | "disable";
     once?: boolean;
     untilSuccess: boolean;
@@ -220,6 +224,7 @@ export async function normalizeDevOptions(
   verbose: boolean;
   typecheck: "enable" | "try" | "disable";
   typecheckComponents: boolean;
+  typescriptCompiler?: TypescriptCompiler | undefined;
   codegen: boolean;
   once: boolean;
   untilSuccess: boolean;
@@ -260,6 +265,7 @@ export async function normalizeDevOptions(
     verbose: !!cmdOptions.verbose,
     typecheck: cmdOptions.typecheck,
     typecheckComponents: !!cmdOptions.typecheckComponents,
+    typescriptCompiler: cmdOptions.typescriptCompiler,
     codegen: cmdOptions.codegen === "enable",
     once: !!cmdOptions.once,
     untilSuccess: cmdOptions.untilSuccess,
@@ -306,6 +312,12 @@ Command.prototype.addDeployOptions = function () {
       "--typecheck-components",
       "Check TypeScript files within component implementations with `tsc --noEmit`.",
       false,
+    )
+    .addOption(
+      new Option(
+        "--typescript-compiler <compiler>",
+        "TypeScript compiler to use for typechecking. Requires `@typescript/native-preview` to be installed for `tsgo`.",
+      ).choices(["tsc", "tsgo"] as const),
     )
     .addOption(
       new Option(
@@ -384,6 +396,12 @@ Command.prototype.addRunOptions = function () {
         "--typecheck-components",
         "Check TypeScript files within component implementations with `tsc --noEmit`.",
         false,
+      )
+      .addOption(
+        new Option(
+          "--typescript-compiler <compiler>",
+          "TypeScript compiler to use for typechecking. Requires `@typescript/native-preview` to be installed for `tsgo`.",
+        ).choices(["tsc", "tsgo"] as const),
       )
       .addOption(
         new Option(

--- a/npm-packages/convex/src/cli/lib/components.ts
+++ b/npm-packages/convex/src/cli/lib/components.ts
@@ -39,7 +39,11 @@ import {
   AppDefinitionConfig,
   ComponentDefinitionConfig,
 } from "./deployApi/definitionConfig.js";
-import { typeCheckFunctionsInMode, TypeCheckMode } from "./typecheck.js";
+import {
+  typeCheckFunctionsInMode,
+  TypeCheckMode,
+  TypescriptCompiler,
+} from "./typecheck.js";
 import { withTmpDir } from "../../bundler/fs.js";
 import { handleDebugBundlePath } from "./debugBundlePath.js";
 import { chalkStderr } from "chalk";
@@ -63,6 +67,7 @@ export type PushOptions = {
   dryRun: boolean;
   typecheck: "enable" | "try" | "disable";
   typecheckComponents: boolean;
+  typescriptCompiler?: TypescriptCompiler | undefined;
   debug: boolean;
   debugBundlePath?: string | undefined;
   debugNodeApis: boolean;
@@ -439,6 +444,7 @@ async function startComponentsPushAndCodegen(
         ctx,
         options.typecheck,
         rootComponent.path,
+        options.typescriptCompiler,
       );
     }
     if (options.typecheckComponents) {
@@ -448,6 +454,7 @@ async function startComponentsPushAndCodegen(
             ctx,
             options.typecheck,
             directory.path,
+            options.typescriptCompiler,
           );
         }
       }
@@ -460,7 +467,12 @@ async function startComponentsPushAndCodegen(
         ) {
           continue;
         }
-        await typeCheckFunctionsInMode(ctx, options.typecheck, directory.path);
+        await typeCheckFunctionsInMode(
+          ctx,
+          options.typecheck,
+          directory.path,
+          options.typescriptCompiler,
+        );
       }
     }
   });

--- a/npm-packages/convex/src/cli/lib/deploy2.ts
+++ b/npm-packages/convex/src/cli/lib/deploy2.ts
@@ -365,6 +365,7 @@ export async function deployToDeployment(
     yes?: boolean | undefined;
     typecheck: "enable" | "try" | "disable";
     typecheckComponents: boolean;
+    typescriptCompiler?: "tsc" | "tsgo" | undefined;
     codegen: "enable" | "disable";
     cmd?: string | undefined;
     cmdUrlEnvVarName?: string | undefined;
@@ -386,6 +387,7 @@ export async function deployToDeployment(
     dryRun: !!options.dryRun,
     typecheck: options.typecheck,
     typecheckComponents: options.typecheckComponents,
+    typescriptCompiler: options.typescriptCompiler,
     debug: !!options.debug,
     debugBundlePath: options.debugBundlePath,
     debugNodeApis: false,

--- a/npm-packages/convex/src/cli/lib/dev.ts
+++ b/npm-packages/convex/src/cli/lib/dev.ts
@@ -14,6 +14,7 @@ import { performance } from "perf_hooks";
 import path from "path";
 import { LogManager, LogMode, watchLogs } from "./logs.js";
 import { PushOptions } from "./components.js";
+import { TypescriptCompiler } from "./typecheck.js";
 import {
   formatDuration,
   getCurrentTimeString,
@@ -36,6 +37,7 @@ export async function devAgainstDeployment(
     verbose: boolean;
     typecheck: "enable" | "try" | "disable";
     typecheckComponents: boolean;
+    typescriptCompiler?: TypescriptCompiler | undefined;
     codegen: boolean;
     once: boolean;
     untilSuccess: boolean;
@@ -71,13 +73,14 @@ export async function devAgainstDeployment(
         dryRun: false,
         typecheck: devOptions.typecheck,
         typecheckComponents: devOptions.typecheckComponents,
+        typescriptCompiler: devOptions.typescriptCompiler,
         debug: false,
         debugBundlePath: devOptions.debugBundlePath,
         debugNodeApis: devOptions.debugNodeApis,
         codegen: devOptions.codegen,
         liveComponentSources: devOptions.liveComponentSources,
         logManager, // Pass logManager to control logs during deploy
-        largeIndexDeletionCheck: "no verification", // `convex dev` can’t push to prod
+        largeIndexDeletionCheck: "no verification", // `convex dev` can't push to prod
       },
       devOptions,
     ),

--- a/npm-packages/convex/src/cli/lib/typecheck.ts
+++ b/npm-packages/convex/src/cli/lib/typecheck.ts
@@ -47,11 +47,15 @@ export async function typeCheckFunctionsInMode(
   ctx: Context,
   typeCheckMode: TypeCheckMode,
   functionsDir: string,
+  typescriptCompilerOverride?: TypescriptCompiler,
 ): Promise<void> {
   if (typeCheckMode === "disable") {
     return;
   }
-  const typescriptCompiler = await resolveTypescriptCompiler(ctx);
+  const typescriptCompiler = await resolveTypescriptCompiler(
+    ctx,
+    typescriptCompilerOverride,
+  );
   await typeCheckFunctions(
     ctx,
     typescriptCompiler,


### PR DESCRIPTION
## Summary

Exposes the existing tsgo support via a CLI flag. This allows trying the experimental compiler without modifying convex.json.

### Why a CLI flag?

The main use case is CI/CD pipelines where you want to test tsgo compatibility without changing the committed config:

```yaml
# Test with tsgo in a separate CI job
- run: npx convex deploy --typescript-compiler=tsgo
```

This lets teams validate tsgo works for their project before committing to it in convex.json. Useful while tsgo is stabilizing, since you can run comparison builds or catch regressions without affecting the rest of the team.

### Changes

Added `--typescript-compiler` flag to:
- `convex dev`
- `convex deploy`
- `convex run --push`

### Usage

```bash
convex dev --typescript-compiler=tsgo
convex deploy --typescript-compiler=tsgo
```

Requires `@typescript/native-preview` to be installed when using tsgo.

### Resolution order

CLI flag takes precedence over convex.json, which takes precedence over the default (tsc). This follows the existing pattern for other options.

## Test plan

- [ ] Verify `convex dev --typescript-compiler=tsgo` uses tsgo when @typescript/native-preview is installed
- [ ] Verify `convex dev --typescript-compiler=tsc` uses tsc
- [ ] Verify default behavior (no flag) still works
- [ ] Verify `convex deploy --typescript-compiler=tsgo` works