### PR TITLE
docs: add nuxt-convex module to Nuxt documentation

### DIFF
--- a/npm-packages/docs/docs/client/vue.md
+++ b/npm-packages/docs/docs/client/vue.md
@@ -9,7 +9,8 @@ framework for building web user interfaces."
 
 The community-maintained
 [`convex-vue`](https://www.npmjs.com/package/convex-vue) npm package is a Vue.js
-integration library for Convex. It also powers [convex-nuxt](./vue/nuxt.md).
+integration library for Convex. There are also [Nuxt modules](./vue/nuxt.md)
+available for deeper framework integration.
 
 See the [Vue Quickstart](/quickstart/vue.mdx) to get started or the
 [convex-vue GitHub page](https://github.com/chris-visser/convex-vue) for more

--- a/npm-packages/docs/docs/client/vue/nuxt.md
+++ b/npm-packages/docs/docs/client/vue/nuxt.md
@@ -5,9 +5,20 @@ sidebar_position: 100
 
 [Nuxt](https://nuxt.com/) is a powerful web framework powered by Vue.
 
-The community-maintained
-[`convex-nuxt` npm package](https://www.npmjs.com/package/convex-nuxt) provides
-deep integration of Convex with the Nuxt 3 ecosystem.
+There are two community-maintained Nuxt modules for Convex:
+
+## nuxt-convex
+
+The [`nuxt-convex` npm package](https://www.npmjs.com/package/nuxt-convex)
+provides a Nuxt module with file storage composables and Nuxt 4 support.
+
+See the [nuxt-convex documentation](https://nuxt-convex.onmax.me/) or the
+[GitHub repository](https://github.com/onmax/nuxt-convex) for more information.
+
+## convex-nuxt
+
+The [`convex-nuxt` npm package](https://www.npmjs.com/package/convex-nuxt)
+provides integration of Convex with the Nuxt 3 ecosystem via suspense for SSR/SSG support.
 
 It uses [convex-vue](../vue.md) under the hood.
 
@@ -17,14 +28,14 @@ documentation.
 
 <Admonition type="info">
 
-The
-[`convex-nuxt` library](https://github.com/chris-visser/convex-nuxt/tree/main)
-is community-maintained. Thank you to the maintainer
+The [`convex-nuxt` library](https://github.com/chris-visser/convex-nuxt) is
+community-maintained. Thank you to the maintainer
 [Chris Visser](https://github.com/chris-visser) for his work on this project!
 
-You're welcome to ask questions about the library on the
-[Convex Discord](https://convex.dev/community) but opening a
-[convex-nuxt GitHub](https://github.com/chris-visser/convex-nuxt) issue is a
-better way to request a new feature or report a bug.
-
 </Admonition>
+
+---
+
+You're welcome to ask questions about these libraries on the
+[Convex Discord](https://convex.dev/community) but opening a GitHub issue on the
+respective repository is a better way to request a new feature or report a bug.


### PR DESCRIPTION
Adds [nuxt-convex](https://nuxt-convex.onmax.me/) as an alternative community-maintained Nuxt module alongside the existing convex-nuxt.

| Feature | nuxt-convex | convex-nuxt |
|---------|-------------|-------------|
| File storage composables | ✅ | ❌ |
| DevTools integration | ✅ | ❌ |
| Nuxt 4 support | ✅ | ❌ |
| SSR/SSG via suspense | ❌ (WIP) | ✅ |