### PR TITLE
fixed vue quickstart

### DIFF
--- a/npm-packages/docs/docs/quickstart/vue.mdx
+++ b/npm-packages/docs/docs/quickstart/vue.mdx
@@ -36,7 +36,7 @@ for Convex.
     To get started, install the `convex` package.
 
     ```sh
-    cd my-vue-app && npm install convex-vue
+    cd my-vue-app && npm install convex convex-vue
     ```
 
   </Step>


### PR DESCRIPTION
updated vue's quick start documentation to be similar to nuxt documentation, by adding convex package during setup
----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
