### PR TITLE
improved node path error handling

### DIFF
--- a/crates/node_executor/src/local.rs
+++ b/crates/node_executor/src/local.rs
@@ -96,7 +96,8 @@ impl InnerLocalNodeExecutor {
         let cmd = TokioCommand::new(node_path)
             .arg("--version")
             .output()
-            .await?;
+            .await
+            .context("`node` is not on PATH")?;
         let version = String::from_utf8_lossy(&cmd.stdout);
 
         if !version.starts_with("v18.")


### PR DESCRIPTION
<!-- Describe your PR here. -->

Improves the error message shown when `node` is missing from PATH during deployment per #192 

<!--
  The following applies to third-party contributors.
  Convex employees and contractors can delete or ignore.
-->

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
