### PR TITLE
added --from-file flag for multi-line env vars

### DIFF
--- a/npm-packages/convex/src/cli/env.ts
+++ b/npm-packages/convex/src/cli/env.ts
@@ -24,16 +24,26 @@ const envSet = new Command("set")
   .description(
     "Set a variable: `npx convex env set NAME value`\n" +
       "Read from stdin: `echo 'value' | npx convex env set NAME`\n" +
+      "Read from a file: `npx convex env set NAME --from-file path/to/file`\n" +
       "If the variable already exists, its value is updated.\n\n" +
       "A single `NAME=value` argument is also supported.",
   )
+  .option("--from-file <path>", "Read value from file")
   .configureHelp({ showGlobalOptions: true })
   .allowExcessArguments(false)
   .action(async (originalName, originalValue, _options, cmd) => {
     const options = cmd.optsWithGlobals();
     const { ctx, deployment } = await selectEnvDeployment(options);
     await ensureHasConvexDependency(ctx, "env set");
-    await envSetInDeployment(ctx, deployment, originalName, originalValue);
+    const fromFile = typeof options.fromFile === "string" ? options.fromFile : undefined;
+    const envOptions = fromFile ? { fromFile } : undefined;
+    await envSetInDeployment(
+      ctx,
+      deployment,
+      originalName,
+      originalValue,
+      envOptions,
+    );
   });
 
 async function selectEnvDeployment(

--- a/npm-packages/docs/docs/cli.md
+++ b/npm-packages/docs/docs/cli.md
@@ -178,6 +178,7 @@ addition to your own tables.
 npx convex env list
 npx convex env get <name>
 npx convex env set <name> <value>
+npx convex env set <name> --from-file <path>
 npx convex env remove <name>
 ```
 


### PR DESCRIPTION
<!-- Describe your PR here. -->

Added a `--from-file` flag to `convex env set` to support setting multi-line environment variable values (e.g. PEM-formatted keys).

This avoids issues with passing multi-line secrets via shell arguments and preserves newlines correctly. Documentation is updated to include the new flag.

Fixes #128.


<!--
  The following applies to third-party contributors.
  Convex employees and contractors can delete or ignore.
-->

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
