### PR TITLE
fix(mcp): improve error message formatting in runOneoffQuery

### DIFF
--- a/npm-packages/convex/src/cli/lib/mcp/tools/runOneoffQuery.ts
+++ b/npm-packages/convex/src/cli/lib/mcp/tools/runOneoffQuery.ts
@@ -104,10 +104,18 @@ export const RunOneoffQueryTool: ConvexTool<
         logLines: result.logLines,
       };
     } catch (err) {
+      let errorMessage: string;
+      if (err instanceof Error) {
+        errorMessage = err.message;
+      } else if (typeof err === "string") {
+        errorMessage = err;
+      } else {
+        errorMessage = JSON.stringify(err, null, 2);
+      }
       return await ctx.crash({
         exitCode: 1,
         errorType: "fatal",
-        printedMessage: `Failed to run query: ${(err as Error).toString().trim()}`,
+        printedMessage: `Failed to run query: ${errorMessage}`,
       });
     }
   },


### PR DESCRIPTION
## Summary
- Fix error handling in `runOneoffQuery` to properly format non-Error objects
- When `err` is a plain object, `JSON.stringify` is used instead of `.toString()` which returns `[object Object]`

## Test plan
- [x] Trigger an error in `runOneoffQuery` (e.g., invalid query syntax)
- [x] Verify error message shows actual error details instead of `[object Object]`

Fixes #313

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)