### PR TITLE
Bump actions/checkout to v6

### DIFF
--- a/.github/workflows/build_local_backend.yml
+++ b/.github/workflows/build_local_backend.yml
@@ -53,7 +53,7 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Rust
         uses: ./.github/actions/setup-rust

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: Validate PR has CLA confirmation
         # Exclude automated PRs from bots

--- a/.github/workflows/precompile.yml
+++ b/.github/workflows/precompile.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: [self-hosted, aws, x64, xlarge]
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Cache pnpm artifacts
         uses: runs-on/cache@v4
@@ -97,7 +97,7 @@ jobs:
     runs-on: ${{ fromJSON(matrix.os) }}
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Rust
         uses: ./.github/actions/setup-rust

--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: actions/setup-python@v5
         with:

--- a/.github/workflows/release_local_backend.yml
+++ b/.github/workflows/release_local_backend.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: [self-hosted, aws, "${{ matrix.arch }}", xlarge]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/release_local_dashboard.yml
+++ b/.github/workflows/release_local_dashboard.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: [self-hosted, aws, "${{ matrix.arch }}", xlarge]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/test_self_hosted_backend.yml
+++ b/.github/workflows/test_self_hosted_backend.yml
@@ -35,7 +35,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Cache pnpm artifacts
         uses: runs-on/cache@v4

--- a/npm-packages/convex/.github/workflows/test-and-lint.yml
+++ b/npm-packages/convex/.github/workflows/test-and-lint.yml
@@ -16,7 +16,7 @@ jobs:
     timeout-minutes: 30
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Node setup
         uses: actions/setup-node@v4

--- a/npm-packages/docs/docs/testing/ci.mdx
+++ b/npm-packages/docs/docs/testing/ci.mdx
@@ -23,7 +23,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: actions/setup-node@v4
       - run: npm ci
       - run: npm run test


### PR DESCRIPTION
<!-- Describe your PR here. -->
Bumping actions/checkout to https://github.com/actions/checkout?tab=readme-ov-file#checkout-v6 - is @convex-renovate-runner[bot] not configured for this? (https://docs.renovatebot.com/modules/manager/github-actions/)


<!--
  The following applies to third-party contributors.
  Convex employees and contractors can delete or ignore.
-->

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
