### PR TITLE
Add custom attributes to logging in function execution context

### DIFF
--- a/crates/application/src/application_function_runner/http_routing.rs
+++ b/crates/application/src/application_function_runner/http_routing.rs
@@ -204,6 +204,7 @@ impl<RT: Runtime> ApplicationFunctionRunner<RT> {
                             None,
                             None,
                             Duration::ZERO,
+                            None,
                         );
                         let new_log_line = LogLine::new_system_log_line(
                             if is_client_disconnect {
@@ -251,6 +252,7 @@ impl<RT: Runtime> ApplicationFunctionRunner<RT> {
                             None,
                             None,
                             Duration::ZERO,
+                            None,
                         );
                         self.function_log
                             .log_http_action(

--- a/crates/application/src/application_function_runner/mod.rs
+++ b/crates/application/src/application_function_runner/mod.rs
@@ -1475,6 +1475,7 @@ impl<RT: Runtime> ApplicationFunctionRunner<RT> {
                         syscall_trace: node_outcome.syscall_trace,
                         udf_server_version,
                         user_execution_time: None,
+                        custom_log_attributes: None,
                     };
                     let outcome =
                         ValidatedActionOutcome::new(outcome, returns_validator, &table_mapping);

--- a/crates/isolate/src/environment/log_attributes.rs
+++ b/crates/isolate/src/environment/log_attributes.rs
@@ -1,0 +1,300 @@
+//! Shared utilities for custom log attributes in UDFs and actions.
+//!
+//! This module provides validation and merging logic for custom log attributes
+//! that can be set via `ctx.setLogAttributes()` in user functions.
+
+use serde_json::Value as JsonValue;
+
+/// Maximum number of custom log attributes allowed
+pub const MAX_ATTRIBUTES: usize = 10;
+
+/// Maximum serialized size of custom log attributes in bytes
+pub const MAX_SIZE_BYTES: usize = 1024;
+
+/// Maximum length for attribute keys
+pub const MAX_KEY_LENGTH: usize = 64;
+
+/// Check if a single attribute is valid, returning an error message if not.
+///
+/// Validation rules:
+/// - Key must be <= 64 characters
+/// - Key must contain only alphanumeric characters, underscores, and dots
+/// - Value must be string, number, or boolean
+pub fn validate_log_attribute(key: &str, value: &JsonValue) -> Result<(), String> {
+    // Key validation: alphanumeric + underscores + dots, max 64 chars
+    if key.len() > MAX_KEY_LENGTH {
+        return Err(format!(
+            "setLogAttributes: key '{}' exceeds max length of {MAX_KEY_LENGTH} chars",
+            &key[..32]
+        ));
+    }
+    if !key
+        .chars()
+        .all(|c| c.is_alphanumeric() || c == '_' || c == '.')
+    {
+        return Err(format!(
+            "setLogAttributes: key '{key}' must contain only alphanumeric characters, \
+             underscores, and dots"
+        ));
+    }
+
+    // Values must be string, number, or boolean
+    match value {
+        JsonValue::String(_) | JsonValue::Number(_) | JsonValue::Bool(_) => Ok(()),
+        _ => Err(format!(
+            "setLogAttributes: value for key '{}' must be string, number, or boolean (got {})",
+            key,
+            match value {
+                JsonValue::Null => "null",
+                JsonValue::Array(_) => "array",
+                JsonValue::Object(_) => "object",
+                _ => "unknown",
+            }
+        )),
+    }
+}
+
+/// Merge new attributes into existing ones leniently.
+///
+/// This function:
+/// - Skips invalid attributes (with warnings)
+/// - Stops adding if max attribute count is reached
+/// - Reverts additions that would exceed max size
+///
+/// Returns a list of warning messages for any skipped attributes.
+pub fn merge_custom_log_attributes_lenient(
+    existing: &mut serde_json::Map<String, JsonValue>,
+    attrs: serde_json::Map<String, JsonValue>,
+) -> Vec<String> {
+    let mut warnings = Vec::new();
+
+    // Add new attributes, filtering out invalid ones
+    for (key, value) in attrs {
+        // Validate the attribute
+        if let Err(msg) = validate_log_attribute(&key, &value) {
+            warnings.push(msg);
+            continue;
+        }
+
+        // Check if adding this attribute would exceed the key limit
+        // (only count if it's a new key, not an update)
+        if !existing.contains_key(&key) && existing.len() >= MAX_ATTRIBUTES {
+            warnings.push(format!(
+                "setLogAttributes: skipping key '{key}' - maximum of {MAX_ATTRIBUTES} attributes \
+                 reached"
+            ));
+            continue;
+        }
+
+        // Tentatively add/update the attribute
+        let old_value = existing.insert(key.clone(), value.clone());
+
+        // Check if we've exceeded the size limit
+        if let Ok(serialized) = serde_json::to_string(&existing)
+            && serialized.len() > MAX_SIZE_BYTES
+        {
+            // Revert this addition - it made us too large
+            if let Some(old) = old_value {
+                existing.insert(key.clone(), old);
+            } else {
+                existing.remove(&key);
+            }
+            warnings.push(format!(
+                "setLogAttributes: skipping key '{key}' - would exceed max size of \
+                 {MAX_SIZE_BYTES} bytes"
+            ));
+            // Stop adding more attributes
+            break;
+        }
+    }
+
+    warnings
+}
+
+/// Validate custom log attributes strictly (used for testing).
+///
+/// Unlike `merge_custom_log_attributes_lenient`, this returns an error
+/// if any validation fails rather than skipping invalid attributes.
+#[cfg(test)]
+pub fn validate_log_attributes(attrs: &serde_json::Map<String, JsonValue>) -> anyhow::Result<()> {
+    use errors::ErrorMetadata;
+
+    // Max 10 attribute keys
+    if attrs.len() > MAX_ATTRIBUTES {
+        anyhow::bail!(ErrorMetadata::bad_request(
+            "TooManyLogAttributes",
+            format!(
+                "Too many log attributes: {} (max {MAX_ATTRIBUTES})",
+                attrs.len()
+            )
+        ));
+    }
+
+    // Max 1KB total serialized size
+    let size = serde_json::to_string(attrs)
+        .map_err(|e| anyhow::anyhow!("Failed to serialize log attributes: {e}"))?
+        .len();
+    if size > MAX_SIZE_BYTES {
+        anyhow::bail!(ErrorMetadata::bad_request(
+            "LogAttributesTooLarge",
+            format!("Log attributes too large: {size} bytes (max {MAX_SIZE_BYTES})")
+        ));
+    }
+
+    for (key, value) in attrs {
+        // Key validation: alphanumeric + underscores + dots, max 64 chars
+        if key.len() > MAX_KEY_LENGTH {
+            anyhow::bail!(ErrorMetadata::bad_request(
+                "InvalidLogAttributeKey",
+                format!(
+                    "Log attribute key too long: {} (max {MAX_KEY_LENGTH} chars)",
+                    key.len()
+                )
+            ));
+        }
+        if !key
+            .chars()
+            .all(|c| c.is_alphanumeric() || c == '_' || c == '.')
+        {
+            anyhow::bail!(ErrorMetadata::bad_request(
+                "InvalidLogAttributeKey",
+                format!(
+                    "Log attribute key must be alphanumeric with underscores or dots: {}",
+                    key
+                )
+            ));
+        }
+
+        // Values must be string, number, or boolean
+        match value {
+            JsonValue::String(_) | JsonValue::Number(_) | JsonValue::Bool(_) => {},
+            _ => {
+                anyhow::bail!(ErrorMetadata::bad_request(
+                    "InvalidLogAttributeValue",
+                    format!(
+                        "Log attribute value must be string, number, or boolean for key: {}",
+                        key
+                    )
+                ));
+            },
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::*;
+
+    #[test]
+    fn test_validate_log_attribute_valid() {
+        assert!(validate_log_attribute("valid_key", &json!("string")).is_ok());
+        assert!(validate_log_attribute("key123", &json!(42)).is_ok());
+        assert!(validate_log_attribute("key", &json!(true)).is_ok());
+    }
+
+    #[test]
+    fn test_validate_log_attribute_dot_separated_keys() {
+        // OTel-style dot-separated keys should be valid
+        assert!(validate_log_attribute("http.method", &json!("POST")).is_ok());
+        assert!(validate_log_attribute("user.id", &json!("123")).is_ok());
+        assert!(validate_log_attribute("service.name", &json!("my_service")).is_ok());
+    }
+
+    #[test]
+    fn test_validate_log_attribute_invalid_key_chars() {
+        let result = validate_log_attribute("invalid-key", &json!("value"));
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .contains("alphanumeric characters, underscores, and dots"));
+    }
+
+    #[test]
+    fn test_validate_log_attribute_key_too_long() {
+        let long_key = "a".repeat(65);
+        let result = validate_log_attribute(&long_key, &json!("value"));
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("exceeds max length"));
+    }
+
+    #[test]
+    fn test_validate_log_attribute_invalid_value_type() {
+        assert!(validate_log_attribute("key", &json!(null)).is_err());
+        assert!(validate_log_attribute("key", &json!([1, 2, 3])).is_err());
+        assert!(validate_log_attribute("key", &json!({"nested": "object"})).is_err());
+    }
+
+    #[test]
+    fn test_merge_skips_invalid_attributes() {
+        let mut existing = serde_json::Map::new();
+        let mut attrs = serde_json::Map::new();
+        attrs.insert("valid_key".to_string(), json!("value"));
+        attrs.insert("invalid-key".to_string(), json!("value"));
+
+        let warnings = merge_custom_log_attributes_lenient(&mut existing, attrs);
+
+        assert_eq!(existing.len(), 1);
+        assert!(existing.contains_key("valid_key"));
+        assert_eq!(warnings.len(), 1);
+    }
+
+    #[test]
+    fn test_merge_respects_max_attributes() {
+        let mut existing = serde_json::Map::new();
+        for i in 0..MAX_ATTRIBUTES {
+            existing.insert(format!("key{i}"), json!("value"));
+        }
+
+        let mut attrs = serde_json::Map::new();
+        attrs.insert("new_key".to_string(), json!("value"));
+
+        let warnings = merge_custom_log_attributes_lenient(&mut existing, attrs);
+
+        assert_eq!(existing.len(), MAX_ATTRIBUTES);
+        assert!(!existing.contains_key("new_key"));
+        assert_eq!(warnings.len(), 1);
+        assert!(warnings[0].contains("maximum of"));
+    }
+
+    #[test]
+    fn test_merge_allows_update_at_max() {
+        let mut existing = serde_json::Map::new();
+        for i in 0..MAX_ATTRIBUTES {
+            existing.insert(format!("key{i}"), json!("original"));
+        }
+
+        let mut attrs = serde_json::Map::new();
+        attrs.insert("key0".to_string(), json!("updated"));
+
+        let warnings = merge_custom_log_attributes_lenient(&mut existing, attrs);
+
+        assert_eq!(existing.len(), MAX_ATTRIBUTES);
+        assert_eq!(existing.get("key0"), Some(&json!("updated")));
+        assert!(warnings.is_empty());
+    }
+
+    #[test]
+    fn test_validate_log_attributes_too_many() {
+        let mut attrs = serde_json::Map::new();
+        for i in 0..=MAX_ATTRIBUTES {
+            attrs.insert(format!("key{i}"), json!("value"));
+        }
+
+        let result = validate_log_attributes(&attrs);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_validate_log_attributes_valid() {
+        let mut attrs = serde_json::Map::new();
+        attrs.insert("key1".to_string(), json!("value1"));
+        attrs.insert("key2".to_string(), json!(42));
+        attrs.insert("http.method".to_string(), json!("GET"));
+
+        assert!(validate_log_attributes(&attrs).is_ok());
+    }
+}

--- a/crates/isolate/src/environment/mod.rs
+++ b/crates/isolate/src/environment/mod.rs
@@ -19,6 +19,7 @@ pub mod auth_config;
 pub mod component_definitions;
 pub mod crypto_rng;
 pub mod helpers;
+pub mod log_attributes;
 pub mod schema;
 pub mod udf;
 pub mod warnings;

--- a/crates/isolate/src/environment/udf/async_syscall.rs
+++ b/crates/isolate/src/environment/udf/async_syscall.rs
@@ -590,6 +590,7 @@ impl<RT: Runtime> AsyncSyscallProvider<RT> for DatabaseUdfEnvironment<RT> {
             rng_seed: _,
             memory_in_mb: _,
             user_execution_time: _,
+            custom_log_attributes: _,
         } = outcome;
 
         log_run_udf(

--- a/crates/isolate/src/environment/udf/mod.rs
+++ b/crates/isolate/src/environment/udf/mod.rs
@@ -63,6 +63,7 @@ use common::{
         LogLevel,
         LogLine,
         LogLines,
+        SystemLogMetadata,
     },
     query_journal::QueryJournal,
     runtime::{
@@ -203,6 +204,9 @@ pub struct DatabaseUdfEnvironment<RT: Runtime> {
 
     reactor_depth: usize,
     udf_callback: Box<dyn UdfCallback<RT>>,
+
+    /// Custom log attributes set by the function via ctx.setLogAttributes()
+    custom_log_attributes: Option<serde_json::Map<String, JsonValue>>,
 }
 
 fn not_allowed_in_udf(name: &str, description: &str) -> ErrorMetadata {
@@ -263,6 +267,10 @@ impl<RT: Runtime> IsolateEnvironment<RT> for DatabaseUdfEnvironment<RT> {
     }
 
     fn syscall(&mut self, name: &str, args: JsonValue) -> anyhow::Result<JsonValue> {
+        // Handle setLogAttributes directly since it needs to modify self
+        if name == "1.0/setLogAttributes" {
+            return self.syscall_set_log_attributes(args);
+        }
         syscall_impl(self, name, args)
     }
 
@@ -368,7 +376,66 @@ impl<RT: Runtime> DatabaseUdfEnvironment<RT> {
             reactor_depth,
             udf_callback,
             client_id,
+
+            custom_log_attributes: None,
         }
+    }
+
+    /// Merge custom log attributes set by ctx.setLogAttributes()
+    /// Get the custom log attributes
+    pub fn custom_log_attributes(&self) -> Option<&serde_json::Map<String, JsonValue>> {
+        self.custom_log_attributes.as_ref()
+    }
+
+    /// Handle the setLogAttributes syscall
+    /// This is lenient - invalid attributes are skipped with a warning, and if
+    /// limits are exceeded, attributes are truncated rather than throwing
+    /// an error.
+    fn syscall_set_log_attributes(&mut self, args: JsonValue) -> anyhow::Result<JsonValue> {
+        use serde::Deserialize;
+
+        #[derive(Deserialize)]
+        struct SetLogAttributesArgs {
+            attrs: serde_json::Map<String, JsonValue>,
+        }
+
+        let SetLogAttributesArgs { attrs } = serde_json::from_value(args).map_err(|e| {
+            anyhow::anyhow!(ErrorMetadata::bad_request(
+                "InvalidArguments",
+                format!("Invalid arguments to setLogAttributes: {e}")
+            ))
+        })?;
+
+        // Filter and merge attributes leniently, collecting warnings
+        let warnings = self.merge_custom_log_attributes_lenient(attrs);
+
+        // Emit any warnings as log lines
+        for warning in warnings {
+            self.emit_log_line(LogLine::new_system_log_line(
+                LogLevel::Warn,
+                vec![warning],
+                self.rt.unix_timestamp(),
+                SystemLogMetadata {
+                    code: "setLogAttributes".to_string(),
+                },
+            ));
+        }
+
+        Ok(JsonValue::Null)
+    }
+
+    /// Merge attributes leniently using the shared utility.
+    /// Returns a list of warning messages for skipped attributes.
+    fn merge_custom_log_attributes_lenient(
+        &mut self,
+        attrs: serde_json::Map<String, JsonValue>,
+    ) -> Vec<String> {
+        use crate::environment::log_attributes::merge_custom_log_attributes_lenient;
+
+        let existing = self
+            .custom_log_attributes
+            .get_or_insert_with(serde_json::Map::new);
+        merge_custom_log_attributes_lenient(existing, attrs)
     }
 
     #[fastrace::trace]
@@ -480,6 +547,7 @@ impl<RT: Runtime> DatabaseUdfEnvironment<RT> {
                 udf_server_version: self.udf_server_version,
                 memory_in_mb,
                 user_execution_time: Some(user_execution_time),
+                custom_log_attributes: self.custom_log_attributes.clone(),
             }),
             // TODO: Add num_writes and write_bandwidth to UdfOutcome,
             // and use them in log_mutation.
@@ -502,6 +570,7 @@ impl<RT: Runtime> DatabaseUdfEnvironment<RT> {
                 udf_server_version: self.udf_server_version,
                 memory_in_mb,
                 user_execution_time: Some(user_execution_time),
+                custom_log_attributes: self.custom_log_attributes.clone(),
             }),
             _ => anyhow::bail!("UdfEnvironment should only run queries and mutations"),
         };
@@ -1006,3 +1075,6 @@ impl<RT: Runtime> DatabaseUdfEnvironment<RT> {
         Ok(())
     }
 }
+
+// Note: Unit tests for log attribute validation are in
+// crate::environment::log_attributes::tests

--- a/crates/isolate/src/isolate2/runner.rs
+++ b/crates/isolate/src/isolate2/runner.rs
@@ -559,6 +559,7 @@ async fn run_request<RT: Runtime>(
             memory_in_mb: 0,
             // Bogus value because we are removing isolate2
             user_execution_time: Some(Duration::ZERO),
+            custom_log_attributes: None,
         };
         return Ok(outcome);
     }
@@ -708,6 +709,7 @@ async fn run_request<RT: Runtime>(
             .unwrap(),
         // Bogus value because we are removing isolate2
         user_execution_time: Some(Duration::ZERO),
+        custom_log_attributes: None,
     };
     Ok(outcome)
 }

--- a/crates/isolate/src/tests/custom_log_attributes.rs
+++ b/crates/isolate/src/tests/custom_log_attributes.rs
@@ -1,0 +1,202 @@
+use common::{
+    assert_obj,
+    value::ConvexValue,
+};
+use keybroker::Identity;
+use runtime::testing::TestRuntime;
+use serde_json::json;
+
+use crate::test_helpers::UdfTest;
+
+// Note: These tests use UdfTest::default() instead of run_test_with_isolate2
+// because isolate2 is being deprecated and doesn't support
+// custom_log_attributes.
+
+#[convex_macro::test_runtime]
+async fn test_query_with_attributes(rt: TestRuntime) -> anyhow::Result<()> {
+    let t = UdfTest::default(rt).await?;
+    let (outcome, _token) = t
+        .raw_query(
+            "custom_log_attributes:queryWithAttributes",
+            vec![ConvexValue::Object(assert_obj!())],
+            Identity::system(),
+            None,
+        )
+        .await?;
+
+    // Verify the function succeeded
+    assert!(
+        outcome.result.is_ok(),
+        "Function failed with error: {:?}",
+        outcome.result.as_ref().err()
+    );
+
+    // Verify custom log attributes were set
+    let attrs = outcome
+        .custom_log_attributes
+        .expect("custom_log_attributes should be set");
+    assert_eq!(attrs.get("user_id"), Some(&json!("user_123")));
+    assert_eq!(attrs.get("operation"), Some(&json!("test_query")));
+    assert_eq!(attrs.get("count"), Some(&json!(42)));
+
+    Ok(())
+}
+
+#[convex_macro::test_runtime]
+async fn test_mutation_with_attributes(rt: TestRuntime) -> anyhow::Result<()> {
+    let t = UdfTest::default(rt).await?;
+    let outcome = t
+        .raw_mutation(
+            "custom_log_attributes:mutationWithAttributes",
+            vec![ConvexValue::Object(assert_obj!())],
+            Identity::system(),
+        )
+        .await?;
+
+    // Verify the function succeeded
+    assert!(outcome.result.is_ok());
+
+    // Verify custom log attributes were set
+    let attrs = outcome
+        .custom_log_attributes
+        .expect("custom_log_attributes should be set");
+    assert_eq!(attrs.get("user_id"), Some(&json!("user_456")));
+    assert_eq!(attrs.get("action_type"), Some(&json!("create")));
+    assert_eq!(attrs.get("success"), Some(&json!(true)));
+
+    Ok(())
+}
+
+#[convex_macro::test_runtime]
+async fn test_action_with_attributes(rt: TestRuntime) -> anyhow::Result<()> {
+    let t = UdfTest::default(rt).await?;
+    let (outcome, _log_lines) = t
+        .raw_action(
+            "custom_log_attributes:actionWithAttributes",
+            vec![ConvexValue::Object(assert_obj!())],
+            Identity::system(),
+        )
+        .await?;
+
+    // Verify the function succeeded
+    assert!(outcome.result.is_ok());
+
+    // Verify custom log attributes were set
+    let attrs = outcome
+        .custom_log_attributes
+        .expect("custom_log_attributes should be set");
+    assert_eq!(attrs.get("external_api"), Some(&json!("test_service")));
+    assert_eq!(attrs.get("request_id"), Some(&json!("req_789")));
+    assert_eq!(attrs.get("latency_ms"), Some(&json!(150)));
+
+    Ok(())
+}
+
+#[convex_macro::test_runtime]
+async fn test_multiple_set_calls_merge(rt: TestRuntime) -> anyhow::Result<()> {
+    let t = UdfTest::default(rt).await?;
+    let outcome = t
+        .raw_mutation(
+            "custom_log_attributes:multipleSetCalls",
+            vec![ConvexValue::Object(assert_obj!())],
+            Identity::system(),
+        )
+        .await?;
+
+    // Verify the function succeeded
+    assert!(outcome.result.is_ok());
+
+    // Verify attributes were merged correctly
+    let attrs = outcome
+        .custom_log_attributes
+        .expect("custom_log_attributes should be set");
+    assert_eq!(attrs.get("first_key"), Some(&json!("first_value")));
+    assert_eq!(attrs.get("second_key"), Some(&json!("second_value")));
+    // shared_key should have the value from the second call
+    assert_eq!(attrs.get("shared_key"), Some(&json!("overwritten")));
+
+    Ok(())
+}
+
+#[convex_macro::test_runtime]
+async fn test_various_value_types(rt: TestRuntime) -> anyhow::Result<()> {
+    let t = UdfTest::default(rt).await?;
+    let (outcome, _token) = t
+        .raw_query(
+            "custom_log_attributes:variousTypes",
+            vec![ConvexValue::Object(assert_obj!())],
+            Identity::system(),
+            None,
+        )
+        .await?;
+
+    // Verify the function succeeded
+    assert!(outcome.result.is_ok());
+
+    // Verify various types are handled correctly
+    let attrs = outcome
+        .custom_log_attributes
+        .expect("custom_log_attributes should be set");
+    assert_eq!(attrs.get("string_val"), Some(&json!("hello")));
+    assert_eq!(attrs.get("number_val"), Some(&json!(123.456)));
+    assert_eq!(attrs.get("bool_true"), Some(&json!(true)));
+    assert_eq!(attrs.get("bool_false"), Some(&json!(false)));
+    assert_eq!(attrs.get("int_val"), Some(&json!(42)));
+
+    Ok(())
+}
+
+#[convex_macro::test_runtime]
+async fn test_empty_attributes(rt: TestRuntime) -> anyhow::Result<()> {
+    let t = UdfTest::default(rt).await?;
+    let (outcome, _token) = t
+        .raw_query(
+            "custom_log_attributes:emptyAttributes",
+            vec![ConvexValue::Object(assert_obj!())],
+            Identity::system(),
+            None,
+        )
+        .await?;
+
+    // Verify the function succeeded
+    assert!(outcome.result.is_ok());
+
+    // Empty attributes should result in an empty map (not None)
+    let attrs = outcome
+        .custom_log_attributes
+        .expect("custom_log_attributes should be set");
+    assert!(attrs.is_empty());
+
+    Ok(())
+}
+
+#[convex_macro::test_runtime]
+async fn test_dot_separated_keys(rt: TestRuntime) -> anyhow::Result<()> {
+    let t = UdfTest::default(rt).await?;
+    let (outcome, _token) = t
+        .raw_query(
+            "custom_log_attributes:dotSeparatedKeys",
+            vec![ConvexValue::Object(assert_obj!())],
+            Identity::system(),
+            None,
+        )
+        .await?;
+
+    // Verify the function succeeded
+    assert!(
+        outcome.result.is_ok(),
+        "Function failed with error: {:?}",
+        outcome.result.as_ref().err()
+    );
+
+    // Verify OTel-style dot-separated keys were set correctly
+    let attrs = outcome
+        .custom_log_attributes
+        .expect("custom_log_attributes should be set");
+    assert_eq!(attrs.get("http.method"), Some(&json!("POST")));
+    assert_eq!(attrs.get("http.status_code"), Some(&json!(200)));
+    assert_eq!(attrs.get("user.id"), Some(&json!("user_123")));
+    assert_eq!(attrs.get("service.name"), Some(&json!("my_service")));
+
+    Ok(())
+}

--- a/crates/isolate/src/tests/mod.rs
+++ b/crates/isolate/src/tests/mod.rs
@@ -9,6 +9,7 @@ mod backend_state;
 mod basic;
 mod creation_time;
 mod custom_errors;
+mod custom_log_attributes;
 mod environment_variables;
 mod fetch;
 mod globals;

--- a/crates/pb/protos/outcome.proto
+++ b/crates/pb/protos/outcome.proto
@@ -33,6 +33,9 @@ message UdfOutcome {
   optional bool observed_identity = 10;
   uint64 memory_in_mb = 11;
   optional google.protobuf.Duration user_execution_time = 12;
+
+  // Custom log attributes set by ctx.setLogAttributes(), JSON-encoded
+  optional string custom_log_attributes_json = 13;
 }
 
 message ActionOutcome {
@@ -44,6 +47,9 @@ message ActionOutcome {
   common.FunctionResult result = 7;
   SyscallTrace syscall_trace = 8;
   optional google.protobuf.Duration user_execution_time = 10;
+
+  // Custom log attributes set by ctx.setLogAttributes(), JSON-encoded
+  optional string custom_log_attributes_json = 11;
 }
 
 message HttpActionOutcome {
@@ -57,6 +63,9 @@ message HttpActionOutcome {
   optional string path = 5;
   optional string method = 6;
   optional google.protobuf.Duration user_execution_time = 7;
+
+  // Custom log attributes set by ctx.setLogAttributes(), JSON-encoded
+  optional string custom_log_attributes_json = 8;
 }
 
 message SyscallTrace {

--- a/crates/udf/src/validation.rs
+++ b/crates/udf/src/validation.rs
@@ -849,6 +849,7 @@ pub struct ValidatedUdfOutcome {
     pub memory_in_mb: u64,
     // TODO(ENG-10204) Make required
     pub user_execution_time: Option<Duration>,
+    pub custom_log_attributes: Option<serde_json::Map<String, serde_json::Value>>,
 }
 
 impl HeapSize for ValidatedUdfOutcome {
@@ -860,6 +861,11 @@ impl HeapSize for ValidatedUdfOutcome {
             + self.journal.heap_size()
             + self.result.heap_size()
             + self.syscall_trace.heap_size()
+            + self
+                .custom_log_attributes
+                .as_ref()
+                .map(|m| serde_json::to_string(m).map(|s| s.len()).unwrap_or(0))
+                .unwrap_or(0)
     }
 }
 
@@ -890,6 +896,7 @@ impl ValidatedUdfOutcome {
             mutation_queue_length: None,
             memory_in_mb: 0,
             user_execution_time: Some(Duration::ZERO),
+            custom_log_attributes: None,
         })
     }
 
@@ -915,6 +922,7 @@ impl ValidatedUdfOutcome {
             mutation_queue_length,
             memory_in_mb: outcome.memory_in_mb,
             user_execution_time: outcome.user_execution_time,
+            custom_log_attributes: outcome.custom_log_attributes,
         };
 
         // TODO(CX-6318) Don't pack json value until it's been validated.
@@ -956,6 +964,7 @@ pub struct ValidatedActionOutcome {
     pub mutation_queue_length: Option<usize>,
     // TODO(ENG-10204) Make required
     pub user_execution_time: Option<Duration>,
+    pub custom_log_attributes: Option<serde_json::Map<String, serde_json::Value>>,
 }
 
 impl ValidatedActionOutcome {
@@ -974,6 +983,7 @@ impl ValidatedActionOutcome {
             udf_server_version: outcome.udf_server_version,
             mutation_queue_length: None,
             user_execution_time: outcome.user_execution_time,
+            custom_log_attributes: outcome.custom_log_attributes,
         };
 
         if returns_validator.needs_validation()
@@ -1015,6 +1025,7 @@ impl ValidatedActionOutcome {
             mutation_queue_length: None,
             // FIXME: We should count user execution time even for failed functions
             user_execution_time: None,
+            custom_log_attributes: None,
         }
     }
 
@@ -1035,6 +1046,7 @@ impl ValidatedActionOutcome {
             udf_server_version: None,
             mutation_queue_length: None,
             user_execution_time: None,
+            custom_log_attributes: None,
         }
     }
 }

--- a/npm-packages/convex/src/server/registration.ts
+++ b/npm-packages/convex/src/server/registration.ts
@@ -93,6 +93,16 @@ export interface GenericMutationCtx<DataModel extends GenericDataModel> {
     mutation: Mutation,
     ...args: OptionalRestArgs<Mutation>
   ) => Promise<FunctionReturnType<Mutation>>;
+
+  /**
+   * Set custom log attributes that will be included in the function execution log.
+   *
+   * Can be called multiple times - attributes are merged with last-write-wins semantics.
+   *
+   * @param attrs - Key-value pairs where values must be string, number, or boolean.
+   *                Maximum 10 keys, 1KB total size, keys must be alphanumeric with underscores or dots.
+   */
+  setLogAttributes: (attrs: Record<string, string | number | boolean>) => void;
 }
 
 /**
@@ -150,6 +160,16 @@ export interface GenericQueryCtx<DataModel extends GenericDataModel> {
     query: Query,
     ...args: OptionalRestArgs<Query>
   ) => Promise<FunctionReturnType<Query>>;
+
+  /**
+   * Set custom log attributes that will be included in the function execution log.
+   *
+   * Can be called multiple times - attributes are merged with last-write-wins semantics.
+   *
+   * @param attrs - Key-value pairs where values must be string, number, or boolean.
+   *                Maximum 10 keys, 1KB total size, keys must be alphanumeric with underscores or dots.
+   */
+  setLogAttributes: (attrs: Record<string, string | number | boolean>) => void;
 }
 
 /**
@@ -265,6 +285,16 @@ export interface GenericActionCtx<DataModel extends GenericDataModel> {
       VectorSearchQuery<NamedTableInfo<DataModel, TableName>, IndexName>
     >,
   ): Promise<Array<{ _id: Id<TableName>; _score: number }>>;
+
+  /**
+   * Set custom log attributes that will be included in the function execution log.
+   *
+   * Can be called multiple times - attributes are merged with last-write-wins semantics.
+   *
+   * @param attrs - Key-value pairs where values must be string, number, or boolean.
+   *                Maximum 10 keys, 1KB total size, keys must be alphanumeric with underscores or dots.
+   */
+  setLogAttributes: (attrs: Record<string, string | number | boolean>) => void;
 }
 
 /**
@@ -615,8 +645,8 @@ export type MutationBuilder<
       | Validator<any, "required", any>
       | void,
     ReturnValue extends ReturnValueForOptionalValidator<ReturnsValidator> = any,
-    OneOrZeroArgs extends
-      ArgsArrayForOptionalValidator<ArgsValidator> = DefaultArgsForOptionalValidator<ArgsValidator>,
+    OneOrZeroArgs extends ArgsArrayForOptionalValidator<ArgsValidator> =
+      DefaultArgsForOptionalValidator<ArgsValidator>,
   >(
     mutation:
       | {
@@ -708,8 +738,8 @@ export type MutationBuilderWithTable<
       | Validator<any, "required", any>
       | void,
     ReturnValue extends ReturnValueForOptionalValidator<ReturnsValidator> = any,
-    OneOrZeroArgs extends
-      ArgsArrayForOptionalValidator<ArgsValidator> = DefaultArgsForOptionalValidator<ArgsValidator>,
+    OneOrZeroArgs extends ArgsArrayForOptionalValidator<ArgsValidator> =
+      DefaultArgsForOptionalValidator<ArgsValidator>,
   >(
     mutation:
       | {
@@ -801,8 +831,8 @@ export type QueryBuilder<
       | Validator<any, "required", any>
       | void,
     ReturnValue extends ReturnValueForOptionalValidator<ReturnsValidator> = any,
-    OneOrZeroArgs extends
-      ArgsArrayForOptionalValidator<ArgsValidator> = DefaultArgsForOptionalValidator<ArgsValidator>,
+    OneOrZeroArgs extends ArgsArrayForOptionalValidator<ArgsValidator> =
+      DefaultArgsForOptionalValidator<ArgsValidator>,
   >(
     query:
       | {
@@ -890,8 +920,8 @@ export type QueryBuilderWithTable<
       | Validator<any, "required", any>
       | void,
     ReturnValue extends ReturnValueForOptionalValidator<ReturnsValidator> = any,
-    OneOrZeroArgs extends
-      ArgsArrayForOptionalValidator<ArgsValidator> = DefaultArgsForOptionalValidator<ArgsValidator>,
+    OneOrZeroArgs extends ArgsArrayForOptionalValidator<ArgsValidator> =
+      DefaultArgsForOptionalValidator<ArgsValidator>,
   >(
     query:
       | {
@@ -979,8 +1009,8 @@ export type ActionBuilder<
       | Validator<any, "required", any>
       | void,
     ReturnValue extends ReturnValueForOptionalValidator<ReturnsValidator> = any,
-    OneOrZeroArgs extends
-      ArgsArrayForOptionalValidator<ArgsValidator> = DefaultArgsForOptionalValidator<ArgsValidator>,
+    OneOrZeroArgs extends ArgsArrayForOptionalValidator<ArgsValidator> =
+      DefaultArgsForOptionalValidator<ArgsValidator>,
   >(
     func:
       | {

--- a/npm-packages/docs/docs/production/integrations/log-streams/log-streams.mdx
+++ b/npm-packages/docs/docs/production/integrations/log-streams/log-streams.mdx
@@ -262,6 +262,11 @@ Schema:
     make up the vector bandwidth used by the function
   - `memory_used_mb`: number, for queries, mutations, and actions, the memory
     used in MiB. This combined with `execution_time_ms` makes up the compute.
+- `custom_attributes`: optional object, user-defined attributes set via
+  [`ctx.setLogAttributes()`](/generated-api/server#setlogattributes). Only
+  present if attributes were set and non-empty. Keys must be alphanumeric with
+  underscores or dots (e.g., `user_id`, `http.method`). Useful for adding
+  context like user IDs, operation types, or request metadata for log analysis.
 
 Example event for a query:
 
@@ -286,6 +291,10 @@ Example event for a query:
       "file_storage_write_bytes": 0,
       "vector_storage_read_bytes": 0,
       "vector_storage_write_bytes": 0
+    },
+    "custom_attributes": {
+      "user_id": "user_123",
+      "operation": "list_messages"
     }
   }
 }

--- a/npm-packages/udf-tests/convex/custom_log_attributes.ts
+++ b/npm-packages/udf-tests/convex/custom_log_attributes.ts
@@ -1,0 +1,94 @@
+import { query, mutation, action } from "./_generated/server";
+
+// Test setting log attributes in a query
+export const queryWithAttributes = query({
+  args: {},
+  handler: async (ctx) => {
+    ctx.setLogAttributes({
+      user_id: "user_123",
+      operation: "test_query",
+      count: 42,
+    });
+    return "query completed";
+  },
+});
+
+// Test setting log attributes in a mutation
+export const mutationWithAttributes = mutation({
+  args: {},
+  handler: async (ctx) => {
+    ctx.setLogAttributes({
+      user_id: "user_456",
+      action_type: "create",
+      success: true,
+    });
+    return "mutation completed";
+  },
+});
+
+// Test setting log attributes in an action
+export const actionWithAttributes = action({
+  args: {},
+  handler: async (ctx) => {
+    ctx.setLogAttributes({
+      external_api: "test_service",
+      request_id: "req_789",
+      latency_ms: 150,
+    });
+    return "action completed";
+  },
+});
+
+// Test multiple setLogAttributes calls (should merge)
+export const multipleSetCalls = mutation({
+  args: {},
+  handler: async (ctx) => {
+    ctx.setLogAttributes({
+      first_key: "first_value",
+      shared_key: "original",
+    });
+    ctx.setLogAttributes({
+      second_key: "second_value",
+      shared_key: "overwritten",
+    });
+    return "merged attributes";
+  },
+});
+
+// Test with various value types
+export const variousTypes = query({
+  args: {},
+  handler: async (ctx) => {
+    ctx.setLogAttributes({
+      string_val: "hello",
+      number_val: 123.456,
+      bool_true: true,
+      bool_false: false,
+      int_val: 42,
+    });
+    return "various types set";
+  },
+});
+
+// Test empty attributes (should be valid)
+export const emptyAttributes = query({
+  args: {},
+  handler: async (ctx) => {
+    ctx.setLogAttributes({});
+    return "empty attributes";
+  },
+});
+
+// Test OTel-style dot-separated keys
+export const dotSeparatedKeys = query({
+  args: {},
+  handler: async (ctx) => {
+    ctx.setLogAttributes({
+      "http.method": "POST",
+      "http.status_code": 200,
+      "user.id": "user_123",
+      "service.name": "my_service",
+    });
+    return "dot-separated keys set";
+  },
+});

--- a/npm-packages/udf-tests/convex/http_action.ts
+++ b/npm-packages/udf-tests/convex/http_action.ts
@@ -108,6 +108,18 @@ const slowResponse = httpAction(async (_ctx, _request) => {
   return new Response("slow");
 });
 
+// Test custom log attributes in HTTP action
+const withLogAttributes = httpAction(async (ctx, request) => {
+  ctx.setLogAttributes({
+    http_method: request.method,
+    endpoint: "/with_log_attributes",
+    status_code: 200,
+  });
+  return new Response("HTTP action with log attributes completed", {
+    status: 200,
+  });
+});
+
 const http = httpRouter();
 http.route({
   method: "POST",
@@ -163,6 +175,11 @@ http.route({
   method: "GET",
   path: "/slow",
   handler: slowResponse,
+});
+http.route({
+  method: "GET",
+  path: "/with_log_attributes",
+  handler: withLogAttributes,
 });
 http.route({
   method: "GET",


### PR DESCRIPTION
### Summary

> AI Assisted (Opus 4.5)

Adds a new API `ctx.setLogAttributes({ key: value })` that allows developers to attach custom metadata to function execution logs. This enables better observability by letting users tag logs with contextual information like user IDs, operation types, or request metadata.

Crucially this allows users to fully attribute cost down to whatever facet they want - eg by their own user, org, team etc This is huge as it is almost impossible to do this using traditional infra.

### Changes

- **TypeScript API**: Added `setLogAttributes()` to `QueryCtx`, `MutationCtx`, and `ActionCtx`
- **Rust backend**: New `1.0/setLogAttributes` syscall with lenient validation
- **Log streaming**: Custom attributes appear in `function_execution` events as `custom_attributes`
- **Limits**: Max 10 keys, 1KB total size, alphanumeric+underscore keys, string/number/boolean values
- **Behavior**: Multiple calls merge (last-write-wins), empty objects omitted from logs, graceful degradation on limit violations
- **Docs**: Updated log streams schema and server API documentation

### Example

```typescript
export const sendMessage = mutation({
  handler: async (ctx, args) => {
    ctx.setLogAttributes({
      user_id: await ctx.auth.getUserIdentity()?.subject,
      channel_id: args.channelId,
    });
    // ...
  },
});
```

Backward Compatibility

- Older backends without this syscall will log a warning but won't crash user functions
- No changes to existing log event schemas (new field is optional)

Test plan

[x] cargo test -p isolate custom_log_attributes - syscall integration tests
[x] cargo test -p common custom_log_attributes - log streaming tests
[x] cargo test -p isolate test_http_action_with_log_attributes - HTTP action test

Open Questions

- Limits: Are 10 keys / 1KB reasonable defaults?


This is a proposal based on a [Discord feature request](https://discord.com/channels/1019350475847499849/1466524833121828886). Feedback welcome on API naming and limits. @ianmacartney FYI

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
