### PR TITLE
feat(convex): allow filter() to return undefined to skip filtering

### DIFF
--- a/npm-packages/convex/src/server/impl/query_impl.ts
+++ b/npm-packages/convex/src/server/impl/query_impl.ts
@@ -114,7 +114,7 @@ export class QueryInitializerImpl
   filter(
     predicate: (
       q: FilterBuilder<GenericTableInfo>,
-    ) => ExpressionOrValue<boolean>,
+    ) => ExpressionOrValue<boolean> | undefined,
   ) {
     return this.fullTableScan().filter(predicate);
   }
@@ -227,7 +227,7 @@ export class QueryImpl implements Query<GenericTableInfo> {
   filter(
     predicate: (
       q: FilterBuilder<GenericTableInfo>,
-    ) => ExpressionOrValue<boolean>,
+    ) => ExpressionOrValue<boolean> | undefined,
   ): any {
     validateArg(predicate, 1, "filter", "predicate");
     const query = this.takeQuery();

--- a/npm-packages/convex/src/server/query.test.ts
+++ b/npm-packages/convex/src/server/query.test.ts
@@ -79,6 +79,31 @@ test("order and filter don't change the return type", () => {
   assert<Equals<Result, Expected>>();
 });
 
+test("filter can return undefined to skip filtering", () => {
+  function filterWithOptionalStatus(
+    db: DB,
+    status: "completed" | "pending" | undefined,
+  ) {
+    return db
+      .query("messages")
+      .order("desc")
+      .filter((q) => {
+        switch (status) {
+          case "completed":
+            return q.eq(q.field("body"), "done");
+          case "pending":
+            return q.eq(q.field("body"), "todo");
+          case undefined:
+            return undefined;
+        }
+      })
+      .collect();
+  }
+  type Result = ReturnType<typeof filterWithOptionalStatus>;
+  type Expected = Promise<Message[]>;
+  assert<Equals<Result, Expected>>();
+});
+
 test("can query() from system tables", () => {
   function collect(db: DB, tableName: SystemTableNames) {
     return db.system.query(tableName).collect();

--- a/npm-packages/convex/src/server/query.ts
+++ b/npm-packages/convex/src/server/query.ts
@@ -159,11 +159,14 @@ export interface OrderedQuery<TableInfo extends GenericTableInfo>
   /**
    * Filter the query output, returning only the values for which `predicate` evaluates to true.
    *
-   * @param predicate - An {@link Expression} constructed with the supplied {@link FilterBuilder} that specifies which documents to keep.
-   * @returns - A new {@link OrderedQuery} with the given filter predicate applied.
+   * Return `undefined` from the predicate to skip applying a filter (no filtering). This has
+   * minimal runtime cost as the filter is not added to the query pipeline.
+   *
+   * @param predicate - An {@link Expression} constructed with the supplied {@link FilterBuilder} that specifies which documents to keep, or `undefined` to apply no filter.
+   * @returns - A new {@link OrderedQuery} with the given filter predicate applied (or unchanged if the predicate returned `undefined`).
    */
   filter(
-    predicate: (q: FilterBuilder<TableInfo>) => ExpressionOrValue<boolean>,
+    predicate: (q: FilterBuilder<TableInfo>) => ExpressionOrValue<boolean> | undefined,
   ): this;
 
   /**


### PR DESCRIPTION
## Summary

Allows `filter()` to return `undefined` so callers can skip applying a filter with minimal runtime cost. When the predicate returns `undefined`, no filter operator is added to the query pipeline.

## Motivation

When building queries with optional filters (e.g. by status), you often want “no filter” to mean “return everything” without paying for a filter step. 

previously you had to completely avoid calling `.filter()` or use something like the hacky `.filter(q => q.and())`, which still adds a filter in the pipeline. 

Returning `undefined` *already works in runtime*, but typescript did not allow it. I simply changed the types and added tests to ensure behaviour is consistent.

## Why not use indexes? You’re holding it wrong!

Yes, ideally use indexes, but sometimes in the real world we deal with messy data like a union of strings translating into a boolean filter.

There is no downside of supporting this, as it just adds to ergonomics.

## Example

```ts
db
  .query("todos")
  .withIndex("by_creation_time")
  .order("desc")
  .filter((q) => {
    switch (args.status) {
      case "completed":
        return q.eq(q.field("completed"), true);
      case "pending":
        return q.eq(q.field("completed"), false);
      case undefined:
        return undefined; // no filter applied
    }
  })
  .collect();
```