### PR TITLE
Fix infinite recursion when file and folders have same name

### DIFF
--- a/npm-packages/convex/src/server/api.ts
+++ b/npm-packages/convex/src/server/api.ts
@@ -270,6 +270,14 @@ type ApiFromModulesAllowEmptyNodes<AllModules extends Record<string, object>> =
     >
   >;
 
+type FilterKeysInApi<key, API, Predicate> = API extends Predicate
+  ? key
+  : API extends FunctionReference<any, any, any, any>
+    ? never
+    : FilterApi<API, Predicate> extends Record<string, never>
+      ? never
+      : key;
+
 /**
  * @public
  *
@@ -277,15 +285,11 @@ type ApiFromModulesAllowEmptyNodes<AllModules extends Record<string, object>> =
  * for example all public queries.
  */
 export type FilterApi<API, Predicate> = Expand<{
-  [mod in keyof API as API[mod] extends Predicate
-    ? mod
-    : API[mod] extends FunctionReference<any, any, any, any>
-      ? never
-      : FilterApi<API[mod], Predicate> extends Record<string, never>
-        ? never
-        : mod]: API[mod] extends Predicate
-    ? API[mod]
-    : FilterApi<API[mod], Predicate>;
+  [mod in keyof API as FilterKeysInApi<
+    mod,
+    API[mod],
+    Predicate
+  >]: API[mod] extends Predicate ? API[mod] : FilterApi<API[mod], Predicate>;
 }>;
 
 /**


### PR DESCRIPTION
When a file and a folder has the same name, api.d.ts in the generated code ends up looking something like this:

```ts
declare const fullApi: ApiFromModules<{
  feed: typeof feed;
  "feed/items": typeof feed_items;
}>;
```

`ApiFromModulesAllowEmptyNodes` then generates this

```ts
{
  feed: {
    getFeedItem: FunctionReference<..>;
    items: {
      getFeedItemDisplayTitle: FunctionReference<..>,
    };
  };
}
```

When this is sent to `FilterApi` it creates a infinite recursion. I think the reason is that this part of FilterApi

```
API[mod] extends Predicate
    ? mod
    : API[mod] extends FunctionReference<any, any, any, any>
      ? never
      : FilterApi<API[mod], Predicate> extends Record<string, never>
        ? never
        : mod
```

ends up with a werirdness in the typescript-compiler where `mod` in `API[mod]` on line 5 ends up beeing not `"getFeedItem"` as we want, but `"getFeedItem" | "items"`. Full disclosure, I don't understand exactly how this works, and for getting to the issue I've had help by Codex, however 100% of the PR has been handcoded, the AI has only been used for researching.

Either way, the fix is pretty simple. We extract the part that returns never to a new util function. here the types end up behaving how we want them too

Fixes: #345

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
