### PR TITLE
fix: Replace portpicker crate to support servers without IPv6 (#72)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -379,7 +379,6 @@ dependencies = [
  "openidconnect",
  "parking_lot",
  "pb",
- "portpicker",
  "pretty_assertions",
  "proptest",
  "proptest-derive",
@@ -5534,7 +5533,6 @@ dependencies = [
  "mysql",
  "node_executor",
  "parking_lot",
- "portpicker",
  "postgres",
  "proptest",
  "rand 0.9.0",
@@ -6294,7 +6292,6 @@ dependencies = [
  "maplit",
  "metrics",
  "model",
- "portpicker",
  "reqwest",
  "runtime",
  "serde",
@@ -7089,15 +7086,6 @@ name = "portable-atomic"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "350e9b48cbc6b0e028b0473b114454c6316e57336ee184ceab6e53f72c178b3e"
-
-[[package]]
-name = "portpicker"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be97d76faf1bfab666e1375477b23fde79eccf0276e9b63b92a39d676a889ba9"
-dependencies = [
- "rand 0.8.5",
-]
 
 [[package]]
 name = "postgres"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -172,7 +172,6 @@ paste = { version = "1.0.12" }
 phf = { version = "0.11.2", features = [ "macros" ] }
 pin-project = "1"
 pkcs8 = "0.10.2"
-portpicker = "0.1"
 postgres-protocol = { version = "0.6" }
 pretty_assertions = "1"
 proc-macro2 = { version = "1.0" }

--- a/crates/application/Cargo.toml
+++ b/crates/application/Cargo.toml
@@ -133,7 +133,6 @@ model = { workspace = true, features = ["testing"] }
 must-let = { workspace = true }
 node_executor = { workspace = true, features = ["testing"] }
 openidconnect = { workspace = true }
-portpicker = { workspace = true }
 pretty_assertions = { workspace = true }
 proptest = { workspace = true }
 proptest-derive = { workspace = true }

--- a/crates/common/src/http/mod.rs
+++ b/crates/common/src/http/mod.rs
@@ -1285,6 +1285,17 @@ pub fn platform_api_cors() -> CorsLayer {
         .max_age(Duration::from_secs(86400))
 }
 
+/// Pick an unused ephemeral port by binding to port 0.
+/// Replaces the `portpicker` crate which fails on systems without IPv6.
+/// Binds IPv4 first (always required), then verifies on IPv6 if available.
+pub fn pick_unused_port() -> std::io::Result<u16> {
+    let ipv4 = std::net::TcpListener::bind("127.0.0.1:0")?;
+    let port = ipv4.local_addr()?.port();
+    // Also verify on IPv6 if available; ignore errors (IPv6 may not exist)
+    let _ = std::net::TcpListener::bind(format!("[::1]:{port}"));
+    Ok(port)
+}
+
 /// Collects metrics and returns them in the Prometheus exposition format.
 /// Returns an empty response if no metrics have been recorded yet.
 /// Note that registered metrics will not show here until recorded at least

--- a/crates/local_backend/Cargo.toml
+++ b/crates/local_backend/Cargo.toml
@@ -130,7 +130,6 @@ metrics = { workspace = true, features = ["testing"] }
 model = { workspace = true, features = ["testing"] }
 mysql = { workspace = true, features = ["testing"] }
 node_executor = { workspace = true, features = ["testing"] }
-portpicker = { workspace = true }
 postgres = { workspace = true, features = ["testing"] }
 proptest = { workspace = true }
 runtime = { workspace = true, features = ["testing"] }

--- a/crates/local_backend/src/subs/mod.rs
+++ b/crates/local_backend/src/subs/mod.rs
@@ -522,7 +522,7 @@ mod tests {
                 .route("/test", get(ws_handler))
                 .with_state(ws_shutdown_tx),
         );
-        let port = portpicker::pick_unused_port().expect("No ports free");
+        let port = common::http::pick_unused_port().expect("No ports free");
         let addr = format!("127.0.0.1:{port}").parse()?;
         let (shutdown_tx, shutdown_rx) = oneshot::channel();
         let proxy_server = tokio::spawn(app.serve(addr, async move {

--- a/crates/node_executor/Cargo.toml
+++ b/crates/node_executor/Cargo.toml
@@ -35,7 +35,6 @@ keybroker = { workspace = true }
 maplit = { workspace = true }
 metrics = { workspace = true }
 model = { workspace = true }
-portpicker = { workspace = true }
 reqwest = { workspace = true, features = ["json"] }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/node_executor/src/local.rs
+++ b/crates/node_executor/src/local.rs
@@ -81,7 +81,7 @@ impl InnerLocalNodeExecutor {
         );
 
         let client = Client::new();
-        let port = portpicker::pick_unused_port().context("No ports free")?;
+        let port = common::http::pick_unused_port().context("No ports free")?;
         let server_handle =
             Self::try_start_node_executor_server(&client, port, &source_path, &source_dir).await?;
         Ok(Self {


### PR DESCRIPTION
  The `portpicker` crate (unmaintained, last updated 4 years ago) crashes
  with an unhelpful "No ports free" error on servers that don't have IPv6
  enabled, preventing the backend from starting entirely.

  Replace it with an inline `pick_unused_port()` in `common::http` that
  binds to IPv4 first and optionally verifies on IPv6 when available,
  so the backend works in both IPv4-only and dual-stack environments.

<!-- Describe your PR here. -->



<!--
  The following applies to third-party contributors.
  Convex employees and contractors can delete or ignore.
-->

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
