### PR TITLE
Add sslmode=disable for non-SSL PostgreSQL connections

### DIFF
--- a/crates/clusters/src/lib.rs
+++ b/crates/clusters/src/lib.rs
@@ -76,6 +76,10 @@ pub fn persistence_args_from_cluster_url(
                 cluster_url
                     .query_pairs_mut()
                     .append_pair("sslmode", "require");
+            } else {
+                cluster_url
+                    .query_pairs_mut()
+                    .append_pair("sslmode", "disable");
             }
             if require_leader {
                 cluster_url

--- a/crates/clusters/src/lib.rs
+++ b/crates/clusters/src/lib.rs
@@ -79,6 +79,9 @@ pub fn persistence_args_from_cluster_url(
             } else {
                 cluster_url
                     .query_pairs_mut()
+                    // Remove any existing sslmode before adding disable
+                    .query_pairs_mut()
+                    .remove_matching(|(key, _)| key == "sslmode")
                     .append_pair("sslmode", "disable");
             }
             if require_leader {

--- a/crates/local_backend/src/config.rs
+++ b/crates/local_backend/src/config.rs
@@ -94,9 +94,9 @@ pub struct LocalConfig {
     #[clap(long, group = "storage")]
     pub s3_storage: bool,
 
-    /// If set, the persistence won't require SSL when talking to the database.
-    /// It would still prefer SSL if available. This should only be set in
-    /// tests.
+    /// Disables SSL/TLS for PostgreSQL connections. When set, connects with
+    /// sslmode=disable instead of sslmode=prefer. This should only be used
+    /// when connecting to databases with self-signed or untrusted certificates.
     #[clap(long)]
     pub do_not_require_ssl: bool,
 


### PR DESCRIPTION
<!-- Describe your PR here. -->

Allows Convex to connect to PostgreSQL with self-signed certificates when `DO_NOT_REQUIRE_SSL=true` is set.

When `require_ssl` is false, the code now explicitly sets `sslmode=disable` instead of leaving it unset. This is needed for PostgreSQL with self-signed certificates (e.g., CNPG in Kubernetes environments).

Fixes #354 

<!--
  The following applies to third-party contributors.
  Convex employees and contractors can delete or ignore.
-->

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
