### PR TITLE
fixed the type of onPaginatedUpdate_experimental in simple_client

### DIFF
--- a/npm-packages/convex/src/browser/simple_client.ts
+++ b/npm-packages/convex/src/browser/simple_client.ts
@@ -11,7 +11,6 @@ import {
   FunctionArgs,
   FunctionReference,
   FunctionReturnType,
-  PaginationResult,
 } from "../server/index.js";
 import { getFunctionName } from "../server/api.js";
 import { AuthTokenFetcher } from "./sync/authentication_manager.js";
@@ -264,7 +263,9 @@ export class ConvexClient {
     query: Query,
     args: FunctionArgs<Query>,
     options: { initialNumItems: number },
-    callback: (result: PaginationResult<FunctionReturnType<Query>>) => unknown,
+    callback: (
+      result: PaginatedQueryResult<FunctionReturnType<Query>>,
+    ) => unknown,
     onError?: (e: Error) => unknown,
   ): Unsubscribe<PaginatedQueryResult<FunctionReturnType<Query>[]>> {
     if (this.disabled) {


### PR DESCRIPTION
<!-- Describe your PR here. -->

```ts
        let newValue;
        try {
          if (isPaginatedQuery) {
            newValue = this.paginatedClient.localQueryResultByToken(queryToken);
          } else {
            newValue = this.client.localQueryResultByToken(queryToken);
          }
        } catch (error) {
          if (!(error instanceof Error)) throw error;
          if (onError) {
            onError(
              error,
              "Second argument to onUpdate onError is reserved for later use",
            );
          } else {
            // Make some noise without unsubscribing or failing to call other callbacks.
            void Promise.reject(error);
          }
          continue;
        }
        callback(
          newValue,
          "Second argument to onUpdate callback is reserved for later use",
        );
```
https://github.com/get-convex/convex-backend/blob/main/npm-packages/convex/src/browser/simple_client.ts#L451-L474

return of `localQueryResultByToken` is `PaginatedQueryResult` not `PaginationResult`, this was a typo i think.



<!--
  The following applies to third-party contributors.
  Convex employees and contractors can delete or ignore.
-->

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
