### PR TITLE
Simplify useQuery object form to minimal QueryOptions base

### DIFF
--- a/npm-packages/convex/src/browser/index.ts
+++ b/npm-packages/convex/src/browser/index.ts
@@ -40,3 +40,5 @@ export type { QueryJournal } from "./sync/protocol.js";
 /** @internal */
 export type { UserIdentityAttributes } from "./sync/protocol.js";
 export type { FunctionResult } from "./sync/function_result.js";
+export { convexQueryOptions } from "./query_options.js";
+export type { QueryOptions } from "./query_options.js";

--- a/npm-packages/convex/src/browser/query_options.test.ts
+++ b/npm-packages/convex/src/browser/query_options.test.ts
@@ -1,7 +1,6 @@
 import { test } from "vitest";
 import { makeFunctionReference } from "../server/index.js";
 import { EmptyObject } from "../server/registration.js";
-import { ConvexReactClient } from "../react/client.js";
 import { convexQueryOptions } from "./query_options.js";
 
 const apiQueryFuncWithArgs = makeFunctionReference<
@@ -43,10 +42,4 @@ test("convexQueryOptions", async () => {
   });
 });
 
-test("prewarmQuery types", async () => {
-  const client = {
-    prewarmQuery: () => {},
-  } as unknown as ConvexReactClient;
 
-  client.prewarmQuery({ query: apiQueryFuncWithArgs, args: { name: "hi" } });
-});

--- a/npm-packages/convex/src/browser/query_options.ts
+++ b/npm-packages/convex/src/browser/query_options.ts
@@ -1,26 +1,49 @@
-/**
- * Query options are a potential new API for a variety of functions, but in particular a new overload of the React hook for queries.
- *
- * Inspired by https://tanstack.com/query/v5/docs/framework/react/guides/query-options
- */
+// Inspired by https://tanstack.com/query/v5/docs/framework/react/guides/query-options
 import type { FunctionArgs, FunctionReference } from "../server/api.js";
 
-// TODO if this type can encompass all use cases we can add not requiring args for queries
-// that don't take arguments. Goal would be that queryOptions allows leaving out args,
-// but queryOptions returns an object that always contains args. Helpers, "middleware,"
-// anything that intercepts these arguments
 /**
- * Query options.
+ * Options for a Convex query: the query function reference and its arguments.
+ *
+ * Used with {@link convexQueryOptions} to create type-safe query option objects
+ * for use with the object-form overloads of {@link useQuery} and
+ * {@link useSuspenseQuery}.
+ *
+ * @public
  */
-export type ConvexQueryOptions<Query extends FunctionReference<"query">> = {
+export type QueryOptions<Query extends FunctionReference<"query">> = {
+  /**
+   * The query function to run.
+   */
   query: Query;
+  /**
+   * The arguments to the query function.
+   */
   args: FunctionArgs<Query>;
-  extendSubscriptionFor?: number;
 };
 
-// This helper helps more once we have more inference happening.
+/**
+ * Creates a type-safe {@link QueryOptions} object for a Convex query.
+ *
+ * This is an identity function that exists to provide type inference — passing
+ * your query and args through this helper ensures TypeScript infers the correct
+ * `Query` type parameter, which enables precise return types on hooks like
+ * {@link useQuery} and {@link useSuspenseQuery}.
+ *
+ * ```typescript
+ * const opts = convexQueryOptions({
+ *   query: api.users.getById,
+ *   args: { id: userId },
+ * });
+ * // opts is typed as QueryOptions<typeof api.users.getById>
+ * client.prewarmQuery(opts);
+ * ```
+ *
+ * @param options - The query and its arguments.
+ * @returns The same object, typed as `QueryOptions<Query>`.
+ * @public
+ */
 export function convexQueryOptions<Query extends FunctionReference<"query">>(
-  options: ConvexQueryOptions<Query>,
-): ConvexQueryOptions<Query> {
+  options: QueryOptions<Query>,
+): QueryOptions<Query> {
   return options;
 }

--- a/npm-packages/convex/src/react/client.test.tsx
+++ b/npm-packages/convex/src/react/client.test.tsx
@@ -5,6 +5,7 @@ import { test, expect, describe, vi } from "vitest";
 import ws from "ws";
 
 import { ConvexReactClient, createMutation, useQuery } from "./client.js";
+import { convexQueryOptions } from "../browser/query_options.js";
 import { ConvexProvider } from "./index.js";
 import React from "react";
 import { renderHook } from "@testing-library/react";
@@ -190,5 +191,19 @@ describe("async query fetch", () => {
     optimisticUpdate();
     const queryResult = client.query(anyApi.myQuery.default, {});
     expect(await queryResult).toStrictEqual("queryResult");
+  });
+});
+
+describe("prewarmQuery types", () => {
+  test("accepts QueryOptions shape", () => {
+    const client = testConvexReactClient();
+    const opts = convexQueryOptions({
+      query: makeFunctionReference<"query", { name: string }, string>(
+        "myQuery",
+      ),
+      args: { name: "hi" },
+    });
+    // Type-level check: prewarmQuery accepts QueryOptions without extendSubscriptionFor
+    client.prewarmQuery(opts);
   });
 });

--- a/npm-packages/convex/src/react/hydration.tsx
+++ b/npm-packages/convex/src/react/hydration.tsx
@@ -1,7 +1,7 @@
 import { useMemo } from "react";
 import { useQuery } from "../react/client.js";
-import { FunctionReference, makeFunctionReference } from "../server/api.js";
-import { jsonToConvex } from "../values/index.js";
+import { FunctionReference } from "../server/api.js";
+import { parsePreloaded } from "./preloaded.js";
 
 /**
  * The preloaded query payload, which should be passed to a client component
@@ -34,17 +34,14 @@ export type Preloaded<Query extends FunctionReference<"query">> = {
 export function usePreloadedQuery<Query extends FunctionReference<"query">>(
   preloadedQuery: Preloaded<Query>,
 ): Query["_returnType"] {
-  const args = useMemo(
-    () => jsonToConvex(preloadedQuery._argsJSON),
-    [preloadedQuery._argsJSON],
-  ) as Query["_args"];
-  const preloadedResult = useMemo(
-    () => jsonToConvex(preloadedQuery._valueJSON),
-    [preloadedQuery._valueJSON],
+  const parsed = useMemo(
+    () => parsePreloaded(preloadedQuery),
+    // Depend on the stable JSON strings rather than object identity so that
+    // callers creating a new Preloaded object on each render don't cause
+    // unnecessary re-parses.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [preloadedQuery._argsJSON, preloadedQuery._valueJSON, preloadedQuery._name],
   );
-  const result = useQuery(
-    makeFunctionReference(preloadedQuery._name) as Query,
-    args,
-  );
-  return result === undefined ? preloadedResult : result;
+  const result = useQuery(parsed.queryReference, parsed.argsObject);
+  return result === undefined ? parsed.preloadedResult : result;
 }

--- a/npm-packages/convex/src/react/index.ts
+++ b/npm-packages/convex/src/react/index.ts
@@ -86,3 +86,5 @@ export {
   useAction,
   useConvexConnectionState,
 } from "./client.js";
+export { convexQueryOptions } from "../browser/query_options.js";
+export type { QueryOptions } from "../browser/query_options.js";

--- a/npm-packages/convex/src/react/preloaded.ts
+++ b/npm-packages/convex/src/react/preloaded.ts
@@ -1,0 +1,29 @@
+import {
+  FunctionArgs,
+  FunctionReference,
+  makeFunctionReference,
+} from "../server/api.js";
+import { jsonToConvex } from "../values/index.js";
+import type { Preloaded } from "./hydration.js";
+
+/**
+ * Parse a preloaded query payload into its constituent parts.
+ *
+ * This is a hook-free helper that can be used by both `useQuery` and
+ * `usePreloadedQuery` to avoid duplicating the parsing logic.
+ *
+ * @internal
+ */
+export function parsePreloaded<Query extends FunctionReference<"query">>(
+  preloaded: Preloaded<Query>,
+): {
+  queryReference: Query;
+  argsObject: FunctionArgs<Query>;
+  preloadedResult: Query["_returnType"];
+} {
+  return {
+    queryReference: makeFunctionReference(preloaded._name) as Query,
+    argsObject: jsonToConvex(preloaded._argsJSON) as FunctionArgs<Query>,
+    preloadedResult: jsonToConvex(preloaded._valueJSON) as Query["_returnType"],
+  };
+}

--- a/npm-packages/convex/src/react/use_query_object_options.test.ts
+++ b/npm-packages/convex/src/react/use_query_object_options.test.ts
@@ -1,0 +1,73 @@
+/**
+ * @vitest-environment custom-vitest-environment.ts
+ */
+
+/* eslint-disable @typescript-eslint/no-unused-vars */
+import { test, describe, expectTypeOf } from "vitest";
+import { anyApi, makeFunctionReference } from "../server/api.js";
+
+import type { ApiFromModules, QueryBuilder } from "../server/index.js";
+import { useQuery as useQueryReal } from "./client.js";
+
+const useQuery = (() => {}) as unknown as typeof useQueryReal;
+const query: QueryBuilder<any, "public"> = (() => {}) as any;
+
+const module = {
+  noArgs: query(() => "result"),
+  args: query((_ctx, { _arg }: { _arg: string }) => "result"),
+};
+type API = ApiFromModules<{ module: typeof module }>;
+const api = anyApi as unknown as API;
+
+describe("useQuery object options types", () => {
+  test("supports object options and skip sentinel", () => {
+    useQuery({
+      query: api.module.noArgs,
+      args: {},
+    });
+
+    useQuery({
+      query: api.module.args,
+      args: { _arg: "asdf" },
+    });
+
+    const _arg: string | undefined = undefined;
+    useQuery(
+      !_arg
+        ? "skip"
+        : {
+            query: api.module.args,
+            args: { _arg },
+          },
+    );
+
+    const result = useQuery({
+      query: api.module.args,
+      args: { _arg: "asdf" },
+    });
+    expectTypeOf(result).toEqualTypeOf<string | undefined>();
+
+    useQuery("skip");
+  });
+
+  test("rejects wrong arg types", () => {
+    // @ts-expect-error wrong arg shape
+    useQuery({
+      query: api.module.args,
+      args: { wrongField: "asdf" },
+    });
+
+    // @ts-expect-error missing required args field
+    useQuery({
+      query: api.module.args,
+    });
+
+    // @ts-expect-error mutation reference is not a query
+    useQuery({
+      query: makeFunctionReference<"mutation", Record<string, never>, void>(
+        "myMutation",
+      ),
+      args: {},
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add a minimal object-form `useQuery` overload that accepts `QueryOptions<Query> | "skip"`
- keep return type aligned with legacy `useQuery`: `T | undefined`, and keep throwing query errors
- remove object-form extras from this first step (`initialValue`, `throwOnError`, and preloaded object support)
- rename `ConvexQueryOptions` to `QueryOptions` and keep `convexQueryOptions()` helper typed to that base shape
- keep `usePreloadedQuery` as a thin wrapper by factoring preloaded parsing into `parsePreloaded`

## Why
This keeps phase 1 intentionally small and avoids locking in richer result/error semantics before we settle the final shape.

## Testing
- `npm run format-check` (in `npm-packages/convex`)
- `npm run test-not-silent -- src/react/use_query.test.ts src/react/use_query_object_options.test.ts` (in `npm-packages/convex`)

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.