### PR TITLE
docs: update convex-test docs for Vitest v4

### DIFF
--- a/npm-packages/common/config/rush/pnpm-lock.yaml
+++ b/npm-packages/common/config/rush/pnpm-lock.yaml
@@ -1818,8 +1818,8 @@ importers:
         specifier: ^6.4.1
         version: 6.4.1(@types/node@22.19.1)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1)
       vitest:
-        specifier: ^3.2.4
-        version: 3.2.4(@edge-runtime/vm@5.0.0)(@types/debug@4.1.12)(@types/node@22.19.1)(happy-dom@20.0.10)(jiti@2.6.1)(jsdom@27.4.0(bufferutil@4.0.9)(postcss@8.5.6))(lightningcss@1.30.2)(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1)
+        specifier: 4.0.18
+        version: 4.0.18(@edge-runtime/vm@5.0.0)(@opentelemetry/api@1.9.0)(@types/node@22.19.1)(@vitest/browser-playwright@4.0.18)(happy-dom@20.0.10)(jiti@2.6.1)(jsdom@27.4.0(bufferutil@4.0.9)(postcss@8.5.6))(lightningcss@1.30.2)(sass@1.94.0)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1)
 
   ../../demos/cron-jobs:
     dependencies:

--- a/npm-packages/demos/convex-test/package.json
+++ b/npm-packages/demos/convex-test/package.json
@@ -19,7 +19,7 @@
     "convex-test": "^0.0.41",
     "globals": "~17.0.0",
     "typescript": "^5.9.2",
-    "vitest": "^3.2.4",
+    "vitest": "4.0.18",
     "vite": "^6.4.1"
   }
 }

--- a/npm-packages/demos/convex-test/vitest.config.ts
+++ b/npm-packages/demos/convex-test/vitest.config.ts
@@ -3,6 +3,5 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
   test: {
     environment: "edge-runtime",
-    server: { deps: { inline: ["convex-test"] } },
   },
 });

--- a/npm-packages/docs/docs/testing/convex-test.mdx
+++ b/npm-packages/docs/docs/testing/convex-test.mdx
@@ -62,8 +62,7 @@ convex-test library.
   <Step title="Configure Vitest">
 
     Add <JSDialectFileName name="vitest.config.ts" /> file to configure the test
-    environment to better match the Convex runtime, and to inline the test library
-    for better dependency tracking.
+    environment to better match the Convex runtime.
 
     <Details summary={<>If your Convex functions are in a directory other than <code>convex</code></>}>
       If your project has a
@@ -104,22 +103,34 @@ convex-test library.
 
     <Details summary="Set up multiple test environments (e.g. Convex + frontend)">
       If you want to use Vitest to test both your Convex functions and your React
-      frontend, you might want to use multiple Vitest environments depending on the
-      test file location via
-      [environmentMatchGlobs](https://vitest.dev/config/#environmentmatchglobs):
+      frontend, you can use the
+      [projects](https://vitest.dev/guide/projects) array to define separate
+      configurations per environment:
 
       ```ts title="vitest.config.ts"
       import { defineConfig } from "vitest/config";
 
       export default defineConfig({
         test: {
-          environmentMatchGlobs: [
-            // all tests in convex/ will run in edge-runtime
-            ["convex/**", "edge-runtime"],
-            // all other tests use jsdom
-            ["**", "jsdom"],
+          projects: [
+            {
+              extends: true,
+              test: {
+                name: "convex",
+                include: ["convex/**/*.test.{ts,js}"],
+                environment: "edge-runtime",
+              },
+            },
+            {
+              extends: true,
+              test: {
+                name: "frontend",
+                include: ["**/*.test.{ts,tsx,js,jsx}"],
+                exclude: ["convex/**"],
+                environment: "jsdom",
+              },
+            },
           ],
-          server: { deps: { inline: ["convex-test"] } },
         },
       });
       ```
@@ -131,7 +142,6 @@ convex-test library.
     export default defineConfig({
       test: {
         environment: "edge-runtime",
-        server: { deps: { inline: ["convex-test"] } },
       },
     });
     ```


### PR DESCRIPTION
Updates the convex-test documentation:
- Replace environmentMatchGlobs with projects array (Vitest v4 approach)
- Remove server.deps.inline from config examples (Vitest handles deps automatically)