### PR TITLE
Block dynamic imports in v8 isolate Convex files at deploy time

### DIFF
--- a/npm-packages/convex/src/bundler/index.ts
+++ b/npm-packages/convex/src/bundler/index.ts
@@ -520,6 +520,41 @@ function hasUseNodeDirective(ctx: Context, fpath: string): boolean {
   }
 }
 
+function containsDynamicImport(node: any): boolean {
+  if (!node || typeof node !== "object") return false;
+  if (
+    node.type === "CallExpression" &&
+    node.callee?.type === "Import"
+  ) {
+    return true;
+  }
+  for (const key of Object.keys(node)) {
+    if (key === "leadingComments" || key === "trailingComments") continue;
+    const child = node[key];
+    if (Array.isArray(child)) {
+      if (child.some((c) => containsDynamicImport(c))) return true;
+    } else if (child && typeof child.type === "string") {
+      if (containsDynamicImport(child)) return true;
+    }
+  }
+  return false;
+}
+
+export function hasDynamicImport(source: string): boolean {
+  if (!source.includes("import(")) {
+    return false;
+  }
+  try {
+    const ast = parseAST(source, {
+      sourceType: "module",
+      plugins: ["jsx", "typescript"],
+    });
+    return containsDynamicImport(ast.program);
+  } catch {
+    return false;
+  }
+}
+
 export function mustBeIsolate(relPath: string): boolean {
   // Check if the path without extension matches any of the static paths.
   return ["http", "crons", "schema", "auth.config"].includes(
@@ -567,6 +602,23 @@ export async function entryPointsByEnvironment(ctx: Context, dir: string) {
       node.push(entryPoint);
     } else {
       isolate.push(entryPoint);
+    }
+  }
+
+  for (const entryPoint of isolate) {
+    const source = ctx.fs.readUtf8File(entryPoint);
+    if (hasDynamicImport(source)) {
+      const relPath = path.relative(dir, entryPoint);
+      return await ctx.crash({
+        exitCode: 1,
+        errorType: "invalid filesystem data",
+        printedMessage:
+          `Dynamic import (\`import()\`) is not allowed in "${relPath}" ` +
+          `because it does not have a "use node" directive. ` +
+          `Dynamic imports are only supported in Node.js actions. ` +
+          `Add "use node" at the top of the file if this is a Node.js action, ` +
+          `or replace the dynamic import with a static import.`,
+      });
     }
   }
 

--- a/npm-packages/convex/src/bundler/test_fixtures/js/project_with_dynamic_import/actions.js
+++ b/npm-packages/convex/src/bundler/test_fixtures/js/project_with_dynamic_import/actions.js
@@ -1,0 +1,4 @@
+export async function loadModule() {
+  const mod = await import("./helper.js");
+  return mod.default();
+}

--- a/npm-packages/convex/src/bundler/test_fixtures/js/project_with_dynamic_import_use_node/actions.js
+++ b/npm-packages/convex/src/bundler/test_fixtures/js/project_with_dynamic_import_use_node/actions.js
@@ -1,0 +1,6 @@
+"use node";
+
+export async function loadModule() {
+  const mod = await import("./helper.js");
+  return mod.default();
+}


### PR DESCRIPTION
## Summary

- Add deploy-time validation that rejects import() expressions in Convex files that don't have a "use node" directive. Previously this was only caught at runtime in the V8 isolate, leading to a bad DX.
- The check runs during bundling in entryPointsByEnvironment(), before esbuild, using @babel/parser AST analysis with a fast string pre-check.
- Test files (.test.ts, .spec.ts) are already excluded from entry points by existing bundler logic and are unaffected.

Test plan

- Added unit tests for hasDynamicImport() covering: top-level imports, nested in functions, template literals, TypeScript, static-only imports, comments, and string literals.
- Added integration tests verifying entryPointsByEnvironment() rejects isolate files with dynamic imports and allows them in "use node" files.


----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
