### PR TITLE
cli: add --init-skip-if-exists for anonymous dev init

### DIFF
--- a/npm-packages/convex/src/cli/configure.ts
+++ b/npm-packages/convex/src/cli/configure.ts
@@ -72,6 +72,7 @@ type ChosenConfiguration =
 type ConfigureCmdOptions = {
   selectionWithinProject: DeploymentSelectionWithinProject;
   prod: boolean;
+  initSkipIfExists?: boolean | undefined;
   localOptions: {
     ports?: {
       cloud: number;
@@ -292,6 +293,9 @@ export async function _deploymentCredentialsOrConfigure(
           chosenConfiguration,
           deploymentName: deploymentSelection.deploymentName,
           ...cmdOptions.localOptions,
+          ...(cmdOptions.initSkipIfExists
+            ? { initSkipIfExists: true }
+            : {}),
         });
         return {
           adminKey: result.adminKey,

--- a/npm-packages/convex/src/cli/dev.ts
+++ b/npm-packages/convex/src/cli/dev.ts
@@ -61,6 +61,11 @@ export const dev = new Command("dev")
     "Execute only the first 3 steps, on failure watch for local and remote changes and retry steps 2 and 3",
     false,
   )
+  .option(
+    "--init-skip-if-exists",
+    "When initializing convex/, don't overwrite existing convex/README.md or convex/tsconfig.json.",
+    false,
+  )
   .addOption(
     new Option(
       "--run <functionName>",

--- a/npm-packages/convex/src/cli/lib/codegen.test.ts
+++ b/npm-packages/convex/src/cli/lib/codegen.test.ts
@@ -1,0 +1,67 @@
+import fs from "fs";
+import os from "os";
+import path from "path";
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import { Context, oneoffContext } from "../../bundler/context.js";
+import { doInitConvexFolder } from "./codegen.js";
+
+describe("doInitConvexFolder", () => {
+  let tmpDir: string;
+  let functionsDir: string;
+  let ctx: Context;
+
+  beforeEach(async () => {
+    ctx = await oneoffContext({
+      url: undefined,
+      adminKey: undefined,
+      envFile: undefined,
+    });
+    tmpDir = fs.mkdtempSync(`${os.tmpdir()}${path.sep}`);
+    functionsDir = path.join(tmpDir, "convex");
+    ctx.fs.mkdir(functionsDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  test("skipIfExists preserves existing files", async () => {
+    const readmePath = path.join(functionsDir, "README.md");
+    const tsconfigPath = path.join(functionsDir, "tsconfig.json");
+    const readme = "CUSTOM-README-SENTINEL";
+    const tsconfig = '{"compilerOptions":{"customSentinel":true}}';
+
+    ctx.fs.writeUtf8File(readmePath, readme);
+    ctx.fs.writeUtf8File(tsconfigPath, tsconfig);
+
+    await doInitConvexFolder(ctx, functionsDir, { skipIfExists: true });
+
+    expect(ctx.fs.readUtf8File(readmePath)).toBe(readme);
+    expect(ctx.fs.readUtf8File(tsconfigPath)).toBe(tsconfig);
+  });
+
+  test("skipIfExists still creates missing files", async () => {
+    const readmePath = path.join(functionsDir, "README.md");
+    const tsconfigPath = path.join(functionsDir, "tsconfig.json");
+
+    await doInitConvexFolder(ctx, functionsDir, { skipIfExists: true });
+
+    expect(ctx.fs.exists(readmePath)).toBe(true);
+    expect(ctx.fs.exists(tsconfigPath)).toBe(true);
+  });
+
+  test("default behavior overwrites existing files", async () => {
+    const readmePath = path.join(functionsDir, "README.md");
+    const tsconfigPath = path.join(functionsDir, "tsconfig.json");
+    const readme = "CUSTOM-README-SENTINEL";
+    const tsconfig = '{"compilerOptions":{"customSentinel":true}}';
+
+    ctx.fs.writeUtf8File(readmePath, readme);
+    ctx.fs.writeUtf8File(tsconfigPath, tsconfig);
+
+    await doInitConvexFolder(ctx, functionsDir);
+
+    expect(ctx.fs.readUtf8File(readmePath)).not.toBe(readme);
+    expect(ctx.fs.readUtf8File(tsconfigPath)).not.toBe(tsconfig);
+  });
+});

--- a/npm-packages/convex/src/cli/lib/codegen.ts
+++ b/npm-packages/convex/src/cli/lib/codegen.ts
@@ -65,9 +65,10 @@ export async function doInitConvexFolder(
   opts?: {
     dryRun?: boolean;
     debug?: boolean;
+    skipIfExists?: boolean;
   },
 ) {
-  const skipIfExists = false; // Not currently configured
+  const skipIfExists = opts?.skipIfExists ?? false;
   let folder: string;
   if (functionsFolder) {
     folder = functionsFolder;

--- a/npm-packages/convex/src/cli/lib/localDeployment/anonymous.ts
+++ b/npm-packages/convex/src/cli/lib/localDeployment/anonymous.ts
@@ -61,6 +61,7 @@ export async function handleAnonymousDeployment(
     forceUpgrade: boolean;
     deploymentName: string | null;
     chosenConfiguration: "new" | "existing" | "ask" | null;
+    initSkipIfExists?: boolean;
   },
 ): Promise<DeploymentDetails> {
   if (await isOffline()) {
@@ -180,7 +181,11 @@ export async function handleAnonymousDeployment(
   });
 
   if (deployment.kind === "new") {
-    await doInitConvexFolder(ctx);
+    const initOpts =
+      options.initSkipIfExists === undefined
+        ? undefined
+        : { skipIfExists: options.initSkipIfExists };
+    await doInitConvexFolder(ctx, undefined, initOpts);
   }
   return {
     adminKey,


### PR DESCRIPTION
## Summary

- Adds a new `convex dev` flag: `--init-skip-if-exists`
- Threads this option through:
  - `dev` CLI options
  - configure flow
  - anonymous local deployment initialization
  - `doInitConvexFolder(...)`
- Adds `skipIfExists?: boolean` support to `doInitConvexFolder(...)`
- Adds tests for init behavior in `src/cli/lib/codegen.test.ts`:
  - preserves existing `convex/README.md` and `convex/tsconfig.json` when `skipIfExists` is enabled
  - still creates missing files
  - preserves existing default overwrite behavior when option is not set

## Motivation

In anonymous local dev flows (e.g. `CONVEX_AGENT_MODE=anonymous npx convex dev --once`), users may want to avoid overwriting existing `convex/README.md` and `convex/tsconfig.json` in worktrees.  
This change provides an opt-in guard without changing existing defaults.

## Usage

```bash
CONVEX_AGENT_MODE=anonymous npx convex dev --once --init-skip-if-exists
