### PR TITLE
Fix docker-compose example error

### DIFF
--- a/self-hosted/docker/docker-compose.yml
+++ b/self-hosted/docker/docker-compose.yml
@@ -60,7 +60,7 @@ services:
       - NEXT_PUBLIC_DEPLOYMENT_URL=${NEXT_PUBLIC_DEPLOYMENT_URL:-http://127.0.0.1:${PORT:-3210}}
       - NEXT_PUBLIC_LOAD_MONACO_INTERNALLY
     depends_on:
-      backend:
+      convex-backend:
         condition: service_healthy
 
 volumes:


### PR DESCRIPTION
<!-- Describe your PR here. -->
With the original docker-compose file, Docker gives the error:
 `service "convex-dashboard" depends on undefined service "backend": invalid compose project`

Changing `backend` to `convex-backend` fixes this error.

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
