### PR TITLE
dashboard: add copy buttons to deployment URLs in summary

### DIFF
--- a/npm-packages/dashboard-common/src/features/health/components/DeploymentSummary.tsx
+++ b/npm-packages/dashboard-common/src/features/health/components/DeploymentSummary.tsx
@@ -18,6 +18,7 @@ import {
   CodeIcon,
   ExternalLinkIcon,
 } from "@radix-ui/react-icons";
+import { CopyButton } from "@common/elements/CopyButton";
 import Link from "next/link";
 import { useContext, useEffect, useState } from "react";
 import semver from "semver";
@@ -375,27 +376,41 @@ export function DeploymentSummary({
               <span className="text-xs font-medium text-content-secondary">
                 Cloud URL
               </span>
-              <Link
-                href={convexCloudUrl!}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="font-mono text-xs break-all text-content-link hover:underline"
-              >
-                {convexCloudUrl}
-              </Link>
+              <div className="flex items-center gap-1">
+                <Link
+                  href={convexCloudUrl!}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="font-mono text-xs break-all text-content-link hover:underline"
+                >
+                  {convexCloudUrl}
+                </Link>
+                <CopyButton
+                  text={convexCloudUrl!}
+                  inline
+                  tip="Copy Cloud URL"
+                />
+              </div>
             </div>
             <div className="flex flex-col gap-1">
               <span className="text-xs font-medium text-content-secondary">
                 HTTP Actions URL
               </span>
-              <Link
-                href={convexSiteUrl!}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="font-mono text-xs break-all text-content-link hover:underline"
-              >
-                {convexSiteUrl}
-              </Link>
+              <div className="flex items-center gap-1">
+                <Link
+                  href={convexSiteUrl!}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="font-mono text-xs break-all text-content-link hover:underline"
+                >
+                  {convexSiteUrl}
+                </Link>
+                <CopyButton
+                  text={convexSiteUrl!}
+                  inline
+                  tip="Copy HTTP Actions URL"
+                />
+              </div>
             </div>
           </div>
         )}


### PR DESCRIPTION
## Summary
- Adds inline copy buttons next to the **Cloud URL** and **HTTP Actions URL** in the deployment summary/overview panel
- Uses the existing `CopyButton` component (with `inline` mode and tooltips) for a consistent UX
- The URLs remain clickable links — the copy button appears alongside them

## Motivation
The deployment overview page displays the Cloud URL and HTTP Actions URL as clickable links, but there's no easy way to copy them to the clipboard without manually selecting the text. The settings page already has copy buttons for these URLs via `CopyTextButton`, but the overview/summary panel (which is the first thing users see) does not. This is a small quality-of-life improvement.

## Test plan
- [ ] Verify the copy button appears next to both Cloud URL and HTTP Actions URL in the deployment summary
- [ ] Verify clicking the copy button copies the URL to clipboard and shows "Copied!" feedback
- [ ] Verify the URL link remains clickable and opens in a new tab
- [ ] Verify layout doesn't break on smaller viewports (the flex container handles wrapping)