### PR TITLE
fix: npx convex dev refuses to target production deployments via CONVEX_DEPLOY_KEY

### DIFF
--- a/npm-packages/convex/src/cli/configure.test.ts
+++ b/npm-packages/convex/src/cli/configure.test.ts
@@ -1,0 +1,133 @@
+import { test, expect, beforeAll, vi, MockInstance } from "vitest";
+import { _deploymentCredentialsOrConfigure } from "./configure.js";
+import { oneoffContext } from "../bundler/context.js";
+import { Context } from "../bundler/context.js";
+import { DeploymentSelection } from "./lib/deploymentSelection.js";
+
+let stderrSpy: MockInstance;
+
+beforeAll(async () => {
+  stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+});
+
+function makeProdDeployKeySelection(): DeploymentSelection {
+  return {
+    kind: "existingDeployment",
+    deploymentToActOn: {
+      url: "https://prod-deployment.convex.cloud",
+      adminKey: "prod:tall-forest-1234|fakekey",
+      deploymentFields: {
+        deploymentName: "tall-forest-1234",
+        deploymentType: "prod",
+        projectSlug: "my-project",
+        teamSlug: "my-team",
+      },
+      source: "deployKey",
+    },
+  };
+}
+
+function makeDevDeployKeySelection(): DeploymentSelection {
+  return {
+    kind: "existingDeployment",
+    deploymentToActOn: {
+      url: "https://dev-deployment.convex.cloud",
+      adminKey: "dev:happy-animal-5678|fakekey",
+      deploymentFields: {
+        deploymentName: "happy-animal-5678",
+        deploymentType: "dev",
+        projectSlug: "my-project",
+        teamSlug: "my-team",
+      },
+      source: "deployKey",
+    },
+  };
+}
+
+const baseCmdOptions = {
+  selectionWithinProject: { kind: "ownDev" as const },
+  prod: false,
+  localOptions: {
+    forceUpgrade: false,
+  },
+};
+
+test("_deploymentCredentialsOrConfigure rejects prod deploy key without --prod flag", async () => {
+  const originalContext = await oneoffContext({
+    url: undefined,
+    adminKey: undefined,
+    envFile: undefined,
+  });
+
+  let crashMessage: string | null = null;
+  const ctx: Context = {
+    ...originalContext,
+    crash: (args: { printedMessage: string | null }) => {
+      crashMessage = args.printedMessage;
+      throw new Error("crash");
+    },
+  } as unknown as Context;
+
+  const selection = makeProdDeployKeySelection();
+
+  await expect(
+    _deploymentCredentialsOrConfigure(ctx, selection, null, baseCmdOptions),
+  ).rejects.toThrow("crash");
+
+  expect(crashMessage).toContain(
+    "`npx convex dev` cannot be used with a production deployment",
+  );
+  expect(crashMessage).toContain("CONVEX_DEPLOY_KEY");
+});
+
+test("_deploymentCredentialsOrConfigure allows prod deploy key with --prod flag", async () => {
+  const originalContext = await oneoffContext({
+    url: undefined,
+    adminKey: undefined,
+    envFile: undefined,
+  });
+
+  const ctx: Context = {
+    ...originalContext,
+    crash: (args: { printedMessage: string | null }) => {
+      throw new Error(`Unexpected crash: ${args.printedMessage}`);
+    },
+  } as unknown as Context;
+
+  const selection = makeProdDeployKeySelection();
+
+  const result = await _deploymentCredentialsOrConfigure(ctx, selection, null, {
+    ...baseCmdOptions,
+    prod: true,
+  });
+
+  expect(result.url).toBe("https://prod-deployment.convex.cloud");
+  expect(result.deploymentFields?.deploymentType).toBe("prod");
+});
+
+test("_deploymentCredentialsOrConfigure allows dev deploy key without --prod flag", async () => {
+  const originalContext = await oneoffContext({
+    url: undefined,
+    adminKey: undefined,
+    envFile: undefined,
+  });
+
+  const ctx: Context = {
+    ...originalContext,
+    crash: (args: { printedMessage: string | null }) => {
+      throw new Error(`Unexpected crash: ${args.printedMessage}`);
+    },
+  } as unknown as Context;
+
+  const selection = makeDevDeployKeySelection();
+
+  const result = await _deploymentCredentialsOrConfigure(
+    ctx,
+    selection,
+    null,
+    baseCmdOptions,
+  );
+
+  expect(result.url).toBe("https://dev-deployment.convex.cloud");
+  expect(result.deploymentFields?.deploymentType).toBe("dev");
+});

--- a/npm-packages/convex/src/cli/configure.ts
+++ b/npm-packages/convex/src/cli/configure.ts
@@ -195,6 +195,23 @@ export async function _deploymentCredentialsOrConfigure(
         cmdOptions.selectionWithinProject,
         deploymentSelection.deploymentToActOn.source,
       );
+      // Guard: `npx convex dev` must not target a production deployment
+      // unless the hidden `--prod` flag is explicitly passed.
+      if (
+        deploymentSelection.deploymentToActOn.deploymentFields
+          ?.deploymentType === "prod" &&
+        deploymentSelection.deploymentToActOn.source === "deployKey" &&
+        !cmdOptions.prod
+      ) {
+        return await ctx.crash({
+          exitCode: 1,
+          errorType: "fatal",
+          printedMessage:
+            "`npx convex dev` cannot be used with a production deployment. " +
+            "The CONVEX_DEPLOY_KEY environment variable points to a production deployment. " +
+            "Use `npx convex deploy` to push to production, or set CONVEX_DEPLOY_KEY to a dev or project deploy key.",
+        });
+      }
       return {
         url: deploymentSelection.deploymentToActOn.url,
         adminKey: deploymentSelection.deploymentToActOn.adminKey,


### PR DESCRIPTION
## Problem

When `CONVEX_DEPLOY_KEY` is set to a production deployment's deploy key (e.g. `prod:xxx|...`) in the terminal environment, running `npx convex dev` in a new directory would silently connect to the production deployment and push code to it. This could overwrite all existing production functions with an empty function set, causing downtime for live applications.

## Root Cause

In `deploymentSelection.ts`, when `CONVEX_DEPLOY_KEY` contains a deployment key like `prod:xxx|key`, the deployment selection returns `kind: "existingDeployment"` with `deploymentType: "prod"`. The `_deploymentCredentialsOrConfigure` function in `configure.ts` (used by `npx convex dev`) accepted this without verifying the deployment type was appropriate for the `dev` command.

## Fix

Added a guard in `_deploymentCredentialsOrConfigure` that checks when:
- The deployment type is `prod`
- The source is a deploy key (`CONVEX_DEPLOY_KEY`)
- The `--prod` flag was NOT explicitly passed

In this case, the CLI now exits with a clear error message:

```
`npx convex dev` cannot be used with a production deployment. The CONVEX_DEPLOY_KEY environment variable points to a production deployment. Use `npx convex deploy` to push to production, or set CONVEX_DEPLOY_KEY to a dev or project deploy key.
```

The hidden `--prod` flag (which exists for intentional use cases) still allows targeting production.

## Tests

Added 3 tests in `configure.test.ts`:
1. Prod deploy key without `--prod` flag → rejected with clear error
2. Prod deploy key with `--prod` flag → allowed through
3. Dev deploy key without `--prod` flag → works normally

All 227 existing CLI tests continue to pass.

## Issues
Fixes #387 