### PR TITLE
fix: prefer native WebSocket over ws package for Bun compatibility

### DIFF
--- a/npm-packages/convex/src/browser/simple_client-node.ts
+++ b/npm-packages/convex/src/browser/simple_client-node.ts
@@ -3,10 +3,15 @@ import {
   setDefaultWebSocketConstructor,
 } from "./simple_client.js";
 
+// Prefer the native global WebSocket when available (Bun, Deno, Node >= 21)
+// and fall back to the `ws` npm package for older Node.js versions.
 // This file is compiled with `bundle: true` with an exception for
-// `./simple_client.js` so this "ws" import will be inlined.
+// `./simple_client.js` so a dynamic import approach won't work here.
 import ws from "ws";
-const nodeWebSocket = ws as unknown as typeof WebSocket;
+const nodeWebSocket: typeof WebSocket =
+  typeof WebSocket !== "undefined"
+    ? WebSocket
+    : (ws as unknown as typeof WebSocket);
 
 setDefaultWebSocketConstructor(nodeWebSocket);
 

--- a/npm-packages/convex/src/cli/lib/networkTest.ts
+++ b/npm-packages/convex/src/cli/lib/networkTest.ts
@@ -16,7 +16,7 @@ import {
   formatSize,
   ThrowingFetchError,
 } from "./utils/utils.js";
-import ws from "ws";
+import { nodeWebSocket } from "./nodeWebSocket.js";
 import { BaseConvexClient } from "../../browser/index.js";
 import { DefaultLogger } from "../../browser/logging.js";
 const ipFamilyNumbers = { ipv4: 4, ipv6: 6, auto: 0 } as const;
@@ -244,7 +244,7 @@ async function checkWs(
       }
     },
     {
-      webSocketConstructor: ws as unknown as typeof WebSocket,
+      webSocketConstructor: nodeWebSocket,
       unsavedChangesWarning: false,
       logger,
     },

--- a/npm-packages/convex/src/cli/lib/nodeWebSocket.ts
+++ b/npm-packages/convex/src/cli/lib/nodeWebSocket.ts
@@ -1,0 +1,11 @@
+import ws from "ws";
+
+// Prefer the native global WebSocket when available (Bun, Deno, Node >= 21)
+// and fall back to the `ws` npm package for older Node.js versions.
+// This fixes compatibility issues where Bun's `ws` shim mishandles the HTTP
+// 101 upgrade handshake, especially behind reverse proxies.
+// See: https://github.com/get-convex/convex-backend/issues/390
+export const nodeWebSocket: typeof WebSocket =
+  typeof WebSocket !== "undefined"
+    ? WebSocket
+    : (ws as unknown as typeof WebSocket);

--- a/npm-packages/convex/src/cli/lib/run.ts
+++ b/npm-packages/convex/src/cli/lib/run.ts
@@ -1,6 +1,6 @@
 import { chalkStderr } from "chalk";
 import util from "util";
-import ws from "ws";
+import { nodeWebSocket } from "./nodeWebSocket.js";
 import { ConvexHttpClient } from "../../browser/http_client.js";
 import { BaseConvexClient } from "../../browser/index.js";
 import {
@@ -403,8 +403,8 @@ export async function subscribe(
       }
     },
     {
-      // pretend that a Node.js 'ws' library WebSocket is a browser WebSocket
-      webSocketConstructor: ws as unknown as typeof WebSocket,
+      // Uses native WebSocket on Bun/Node 21+, falls back to `ws` on older Node
+      webSocketConstructor: nodeWebSocket,
       unsavedChangesWarning: false,
     },
   );


### PR DESCRIPTION
Fixes #390

The CLI and the Node.js `ConvexClient` always import the `ws` package and use it as the WebSocket constructor. This is unnecessary on runtimes that already have a native `WebSocket` (Bun, Deno, Node 22+), and it actively breaks things under Bun because Bun's `ws` shim mishandles HTTP 101 upgrades through reverse proxies.

This is technically a Bun bug, but preferring the native `WebSocket` when it exists is a good change on its own. The build script already externalizes `ws` for Bun compat (build.cjs L155), and `BaseConvexClient` already falls back to the global `WebSocket` when no constructor is passed (client.ts L293). This just extends that same pattern to the CLI entry points.

Can't drop `ws` entirely because we still support Node 18, which doesn't have a global `WebSocket`.

**What changed:**

New file `src/cli/lib/nodeWebSocket.ts` exports a `nodeWebSocket` that checks for a global `WebSocket` first, falls back to `ws`. Then `run.ts` and `networkTest.ts` import that instead of `ws` directly. `simple_client-node.ts` inlines the same check since it's bundled separately by esbuild.

**Repro:**

Set up a WebSocket server behind a Node HTTP proxy (simulating nginx) and connected from Bun 1.3.5. `ws` through the proxy times out, while direct connections work fine. Node handles both cases. Full verification with real nginx + TLS would need the reporter's setup.