### PR TITLE
Constrain document retention boundary by document deletion worker cursor

### DIFF
--- a/crates/database/src/retention.rs
+++ b/crates/database/src/retention.rs
@@ -224,7 +224,6 @@ pub struct LeaderRetentionManager<RT: Runtime> {
     rt: RT,
     bounds_reader: Reader<SnapshotBounds>,
     checkpoint_reader: Reader<Checkpoint>,
-    #[allow(unused)]
     document_checkpoint_reader: Reader<Checkpoint>,
 }
 
@@ -378,6 +377,7 @@ impl<RT: Runtime> LeaderRetentionWorkerSeed<RT> {
             LeaderRetentionWorkers::go_advance_min_snapshot(
                 self.bounds_writer,
                 self.retention_manager.checkpoint_reader.clone(),
+                self.retention_manager.document_checkpoint_reader.clone(),
                 rt.clone(),
                 self.persistence.clone(),
                 send_min_index_snapshot,
@@ -497,6 +497,7 @@ impl LeaderRetentionWorkers {
     async fn candidate_min_snapshot_ts(
         snapshot_reader: &Reader<SnapshotManager>,
         checkpoint_reader: &Reader<Checkpoint>,
+        document_checkpoint_reader: &Reader<Checkpoint>,
         retention_type: RetentionType,
     ) -> anyhow::Result<RepeatableTimestamp> {
         let delay = match retention_type {
@@ -520,6 +521,19 @@ impl LeaderRetentionWorkers {
                 None => RepeatableTimestamp::MIN,
             };
             candidate = cmp::min(candidate, index_confirmed_deleted);
+
+            // Also ensure the document boundary doesn't advance past the
+            // document retention worker's confirmed deleted cursor. Without
+            // this, lowering DOCUMENT_RETENTION_DELAY temporarily can jump the
+            // boundary far ahead, and raising it back won't undo that -- leaving
+            // other system components unable to read at timestamps the worker
+            // hasn't cleaned up yet.
+            let document_confirmed_deleted =
+                match document_checkpoint_reader.lock().checkpoint {
+                    Some(val) => val,
+                    None => RepeatableTimestamp::MIN,
+                };
+            candidate = cmp::min(candidate, document_confirmed_deleted);
         }
 
         Ok(candidate)
@@ -530,12 +544,18 @@ impl LeaderRetentionWorkers {
         persistence: &dyn Persistence,
         snapshot_reader: &Reader<SnapshotManager>,
         checkpoint_reader: &Reader<Checkpoint>,
+        document_checkpoint_reader: &Reader<Checkpoint>,
         retention_type: RetentionType,
         lease_lost_shutdown: ShutdownSignal,
     ) -> anyhow::Result<Option<RepeatableTimestamp>> {
         let candidate =
-            Self::candidate_min_snapshot_ts(snapshot_reader, checkpoint_reader, retention_type)
-                .await?;
+            Self::candidate_min_snapshot_ts(
+                snapshot_reader,
+                checkpoint_reader,
+                document_checkpoint_reader,
+                retention_type,
+            )
+            .await?;
         let min_snapshot_ts = match retention_type {
             RetentionType::Document => bounds_writer.read().min_document_snapshot_ts,
             RetentionType::Index => bounds_writer.read().min_index_snapshot_ts,
@@ -612,6 +632,7 @@ impl LeaderRetentionWorkers {
     async fn go_advance_min_snapshot<RT: Runtime>(
         mut bounds_writer: Writer<SnapshotBounds>,
         checkpoint_reader: Reader<Checkpoint>,
+        document_checkpoint_reader: Reader<Checkpoint>,
         rt: RT,
         persistence: Arc<dyn Persistence>,
         min_snapshot_sender: Sender<RepeatableTimestamp>,
@@ -628,6 +649,7 @@ impl LeaderRetentionWorkers {
                     persistence.as_ref(),
                     &snapshot_reader,
                     &checkpoint_reader,
+                    &document_checkpoint_reader,
                     RetentionType::Index,
                     shutdown.clone(),
                 )
@@ -639,6 +661,7 @@ impl LeaderRetentionWorkers {
                     persistence.as_ref(),
                     &snapshot_reader,
                     &checkpoint_reader,
+                    &document_checkpoint_reader,
                     RetentionType::Document,
                     shutdown.clone(),
                 )


### PR DESCRIPTION
Fixes #358

### Problem

When `DOCUMENT_RETENTION_DELAY` is temporarily lowered (e.g. 172800s -> 3600s), `candidate_min_snapshot_ts` computes a boundary ~47 hours ahead (via `persisted_max_repeatable_ts - delay`). This gets applied through `cmp::max` in `advance_timestamp`, making the jump permanent. Raising the delay back doesn't undo it because the boundary only ever moves forward.

This leaves `document_min_snapshot_ts` far ahead of what the document deletion worker has actually cleaned up, causing `out_of_retention` errors from any system component that validates document snapshots against the boundary.

[`12370cddc`](https://github.com/get-convex/convex-backend/commit/12370cddc) partially addressed this by capping the worker's scan range to `min(min_document_snapshot_ts, now() - DOCUMENT_RETENTION_DELAY)`, but the boundary itself can still jump ahead.

### Fix

`candidate_min_snapshot_ts` already constrains the document boundary by `index_confirmed_deleted` to ensure indexes are deleted before their documents. This PR adds the same pattern for `document_confirmed_deleted_ts`, preventing the boundary from advancing past where the document deletion worker has actually finished cleaning up.

The `document_checkpoint_reader` field on `LeaderRetentionManager` already existed (marked `#[allow(unused)]`) -- this PR threads it through to `candidate_min_snapshot_ts` and uses it.