### PR TITLE
Fix Next.js SDK URL defaulting to throw on explicit undefined

### DIFF
--- a/npm-packages/convex/src/nextjs/index.ts
+++ b/npm-packages/convex/src/nextjs/index.ts
@@ -183,15 +183,13 @@ export async function fetchAction<Action extends FunctionReference<"action">>(
 }
 
 function setupClient(options: NextjsOptions) {
-  if ("url" in options && options.url === undefined) {
-    // This will be an error in the future.
-    // eslint-disable-next-line no-console
-    console.error(
-      "deploymentUrl is undefined, are your environment variables set? In the future explicitly passing undefined will cause an error. To explicitly use the default, pass `process.env.NEXT_PUBLIC_CONVEX_URL`.",
-    );
-  }
+  const isExplicit = "url" in options;
   const client = new ConvexHttpClient(
-    getConvexUrl(options.url, options.skipConvexDeploymentUrlCheck ?? false),
+    getConvexUrl(
+      options.url,
+      options.skipConvexDeploymentUrlCheck ?? false,
+      isExplicit,
+    ),
   );
   if (options.token !== undefined) {
     client.setAuth(options.token);
@@ -204,24 +202,20 @@ function setupClient(options: NextjsOptions) {
 }
 
 function getConvexUrl(
-  /**
-   * The URL of the Convex deployment to use for the function call.
-   *
-   * Defaults to `process.env.NEXT_PUBLIC_CONVEX_URL` if not provided.
-   *
-   * Explicitly passing undefined here (such as in broken ENV variables) will throw an error in the future
-   */
   deploymentUrl: string | undefined,
   skipConvexDeploymentUrlCheck: boolean,
+  isExplicit: boolean,
 ) {
-  const url = deploymentUrl ?? process.env.NEXT_PUBLIC_CONVEX_URL;
-  const isFromEnv = deploymentUrl === undefined;
-  if (typeof url !== "string") {
+  if (isExplicit && deploymentUrl === undefined) {
     throw new Error(
-      isFromEnv
-        ? `Environment variable NEXT_PUBLIC_CONVEX_URL is not set.`
-        : `Convex function called with invalid deployment address.`,
+      "Convex function called with `url` explicitly set to `undefined`. " +
+        "This usually means an environment variable is not set. " +
+        "To use the default, omit the `url` option or pass `process.env.NEXT_PUBLIC_CONVEX_URL`.",
     );
+  }
+  const url = deploymentUrl ?? process.env.NEXT_PUBLIC_CONVEX_URL;
+  if (typeof url !== "string") {
+    throw new Error(`Environment variable NEXT_PUBLIC_CONVEX_URL is not set.`);
   }
   if (!skipConvexDeploymentUrlCheck) {
     validateDeploymentUrl(url);

--- a/npm-packages/convex/src/nextjs/nextjs.test.tsx
+++ b/npm-packages/convex/src/nextjs/nextjs.test.tsx
@@ -19,6 +19,14 @@ describe("env setup", () => {
       "Environment variable NEXT_PUBLIC_CONVEX_URL is not set.",
     );
   });
+
+  test("throws on explicit undefined url instead of falling back to env", async () => {
+    global.process.env.NEXT_PUBLIC_CONVEX_URL = "https://127.0.0.1:3001";
+    await expect(
+      preloadQuery(anyApi.myQuery.default, {}, { url: undefined }),
+    ).rejects.toThrow("explicitly set to `undefined`");
+    delete global.process.env.NEXT_PUBLIC_CONVEX_URL;
+  });
 });
 
 describe("preloadQuery and usePreloadedQuery", () => {


### PR DESCRIPTION
## Summary

Fixes #24

When calling `preloadQuery(api.foo.bla, {}, {url: process.env.MY_VAR})` where `MY_VAR` is unset, the SDK previously fell back silently to `NEXT_PUBLIC_CONVEX_URL`. This masked broken environment variables and made debugging difficult.

This PR changes the behavior so that explicitly passing `undefined` as `url` throws an error immediately, rather than silently falling back. Not passing `url` at all still defaults to `NEXT_PUBLIC_CONVEX_URL` as before.

### Changes

- `setupClient` now detects whether `url` was explicitly provided via `"url" in options`
- `getConvexUrl` receives an `isExplicit` flag and throws a clear error when `url` is explicitly `undefined`
- Removed the deprecation warning in favor of an actual error
- Added a test for the explicit-undefined case

### Breaking change note

As discussed in #24 by @thomasballinger and @nipunn1313, this is technically a breaking change for code that relied on the silent fallback when passing `undefined`. The fix is to either omit the `url` option entirely or pass `process.env.NEXT_PUBLIC_CONVEX_URL` directly.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

This contribution was developed with AI assistance (Claude Code).