### PR TITLE
Add custom CA certificate support for MySQL connections

### DIFF
--- a/crates/mysql/src/connection.rs
+++ b/crates/mysql/src/connection.rs
@@ -1,5 +1,7 @@
 use std::{
+    env,
     mem,
+    path::PathBuf,
     str::FromStr,
     time::Duration,
 };
@@ -61,6 +63,7 @@ use mysql_async::{
     PoolConstraints,
     PoolOpts,
     Row,
+    SslOpts,
     TxOpts,
     Value as MySqlValue,
 };
@@ -556,7 +559,19 @@ impl<RT: Runtime> ConvexMySqlPool<RT> {
             .with_abs_conn_ttl(Some(*MYSQL_MAX_CONNECTION_LIFETIME))
             .with_abs_conn_ttl_jitter(Some(*MYSQL_MAX_CONNECTION_LIFETIME / 10))
             .with_reset_connection(false); // persist prepared statements
-        let opts = OptsBuilder::from_opts(Opts::from_str(url.as_ref())?).pool_opts(pool_opts);
+        let mut opts = OptsBuilder::from_opts(Opts::from_str(url.as_ref())?).pool_opts(pool_opts);
+        if let Some(ca_file_path) = env::var_os("MYSQL_CA_FILE") {
+            if !ca_file_path.is_empty() {
+                let ca_file_path = PathBuf::from(ca_file_path);
+                anyhow::ensure!(
+                    ca_file_path.exists(),
+                    "MYSQL_CA_FILE does not exist: {}",
+                    ca_file_path.display()
+                );
+                let ssl_opts = SslOpts::default().with_root_certs(vec![ca_file_path.into()]);
+                opts = opts.ssl_opts(ssl_opts);
+            }
+        }
         Ok(Self {
             pool: Pool::new(opts),
             use_prepared_statements,


### PR DESCRIPTION
## Summary

Fixes #31

Adds `MYSQL_CA_FILE` environment variable support for MySQL connections, following the same pattern as `PG_CA_FILE` for PostgreSQL (merged in PR #66). This allows self-hosted users with custom certificate authorities (e.g., Kubernetes CloudNativePG) to connect to MySQL without TLS handshake failures.

### Changes

- Read `MYSQL_CA_FILE` env var in `ConvexMySqlPool::new()`
- If set and non-empty, configure `SslOpts` with the custom root certificate
- Validate the file exists before passing it to `mysql_async`
- Added `SslOpts` import from `mysql_async`

### Usage

Set the environment variable to the path of your PEM-format CA certificate:

```
MYSQL_CA_FILE=/path/to/ca.pem
```

The certificate is added alongside the system's built-in root certificates, matching the PostgreSQL behavior.

### Notes

- As @nipunn1313 noted in #31, this completes the certificate support story - postgres was covered by PR #66, this covers mysql.
- The implementation mirrors the postgres pattern in `crates/postgres/src/lib.rs` as closely as possible given the different TLS libraries.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

This contribution was developed with AI assistance (Claude Code).