### PR TITLE
Remove portpicker dependency, use direct port binding

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -155,7 +155,6 @@ performance_stats = { path = "crates/performance_stats" }
 phf = { version = "0.11.2", features = [ "macros" ] }
 pin-project = "1"
 pkcs8 = "0.10.2"
-portpicker = "0.1"
 postgres = { path = "crates/postgres" }
 postgres-protocol = { version = "0.6" }
 pretty_assertions = "1"

--- a/crates/application/Cargo.toml
+++ b/crates/application/Cargo.toml
@@ -133,7 +133,6 @@ model = { workspace = true, features = ["testing"] }
 must-let = { workspace = true }
 node_executor = { workspace = true, features = ["testing"] }
 openidconnect = { workspace = true }
-portpicker = { workspace = true }
 pretty_assertions = { workspace = true }
 proptest = { workspace = true }
 proptest-derive = { workspace = true }

--- a/crates/local_backend/Cargo.toml
+++ b/crates/local_backend/Cargo.toml
@@ -130,7 +130,6 @@ metrics = { workspace = true, features = ["testing"] }
 model = { workspace = true, features = ["testing"] }
 mysql = { workspace = true, features = ["testing"] }
 node_executor = { workspace = true, features = ["testing"] }
-portpicker = { workspace = true }
 postgres = { workspace = true, features = ["testing"] }
 proptest = { workspace = true }
 runtime = { workspace = true, features = ["testing"] }

--- a/crates/local_backend/src/subs/mod.rs
+++ b/crates/local_backend/src/subs/mod.rs
@@ -500,8 +500,9 @@ mod tests {
                 .route("/test", get(ws_handler))
                 .with_state(ws_shutdown_tx),
         );
-        let port = portpicker::pick_unused_port().expect("No ports free");
-        let addr = format!("127.0.0.1:{port}").parse()?;
+        let listener = std::net::TcpListener::bind("127.0.0.1:0")?;
+        let addr = listener.local_addr()?;
+        drop(listener);
         let (shutdown_tx, shutdown_rx) = oneshot::channel();
         let proxy_server = tokio::spawn(app.serve(addr, async move {
             shutdown_rx.await.unwrap();


### PR DESCRIPTION
## Summary

Relates to #72

Removes the `portpicker` crate dependency entirely by replacing its last usage with `TcpListener::bind("127.0.0.1:0")` - the same pattern already used in `crates/node_executor/src/local.rs`.

### Changes

- **`crates/local_backend/src/subs/mod.rs`**: Replace `portpicker::pick_unused_port()` with `TcpListener::bind("127.0.0.1:0")` to get an OS-assigned port
- **`Cargo.toml`**: Remove `portpicker = "0.1"` from workspace dependencies
- **`crates/local_backend/Cargo.toml`**: Remove `portpicker` dependency
- **`crates/application/Cargo.toml`**: Remove unused `portpicker` dependency

### Why

The `portpicker` crate is unmaintained (last updated 4+ years ago) and fails on servers without IPv6 support, causing the "No ports free" crash reported in #72. The production crash path in `local.rs` was already fixed to use direct port binding - this PR completes the cleanup by removing the last usage and the dependency itself.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

This contribution was developed with AI assistance (Claude Code).