### PR TITLE
fix: accept camelCase `tableName` in streaming export endpoints

### DIFF
--- a/crates/fivetran_source/src/api_types/mod.rs
+++ b/crates/fivetran_source/src/api_types/mod.rs
@@ -139,6 +139,7 @@ pub enum SelectionArg {
 
     /// If only the table name is provided, assumes it’s in the root component.
     SingleTable {
+        #[serde(alias = "tableName")]
         table_name: String,
 
         /// The component path of the table. If not provided, the table is
@@ -226,6 +227,28 @@ mod tests {
             r#"{"selection": { "_other": "incl" }}"#,
             SelectionArg::Exact {
                 selection: Selection::default(),
+            },
+        );
+    }
+
+    #[test]
+    fn test_table_name_camel_case() {
+        assert_selection_arg_deserialization(
+            r#"{"tableName": "users"}"#,
+            SelectionArg::SingleTable {
+                table_name: "users".to_string(),
+                component: None,
+            },
+        );
+    }
+
+    #[test]
+    fn test_table_name_camel_case_and_component() {
+        assert_selection_arg_deserialization(
+            r#"{"tableName": "jobs", "component": "cron"}"#,
+            SelectionArg::SingleTable {
+                table_name: "jobs".to_string(),
+                component: Some("cron".to_string()),
             },
         );
     }


### PR DESCRIPTION
## Summary

- Adds `#[serde(alias = "tableName")]` to `SelectionArg::SingleTable` so the streaming export endpoints (`/api/document_deltas` and `/api/list_snapshot`) accept the camelCase `tableName` parameter documented in the API docs and used by the Airbyte connector
- Adds tests for camelCase deserialization (`tableName` alone and with `component`)

Fixes #408

## Details

The `SelectionArg` enum uses `#[serde(untagged)]`, so when `tableName` (camelCase) doesn't match the expected `table_name` (snake_case), serde silently falls through to `Everything {}`, returning all tables unfiltered. The parent structs have `#[serde(rename_all = "camelCase")]` but this doesn't propagate into flattened untagged enums.

## Test plan

- [ ] Existing `test_table_name_only` still passes (snake_case still works)
- [ ] New `test_table_name_camel_case` passes
- [ ] New `test_table_name_camel_case_and_component` passes
- [ ] `cargo test -p fivetran_source`

🤖 Generated with [Claude Code](https://claude.com/claude-code)