### PR TITLE
feat(mcp): add CRUD, file storage, and scheduled function tools

### DIFF
--- a/npm-packages/convex/src/cli/lib/mcp/tools/crud.ts
+++ b/npm-packages/convex/src/cli/lib/mcp/tools/crud.ts
@@ -1,0 +1,240 @@
+import { z } from "zod";
+import { ConvexTool } from "./index.js";
+import { loadSelectedDeploymentCredentials } from "../../api.js";
+import { runSystemQuery } from "../../run.js";
+import { ConvexHttpClient } from "../../../../browser/index.js";
+import { DefaultLogger } from "../../../../browser/logging.js";
+import { getMcpDeploymentSelection } from "../requestContext.js";
+
+// --- Get Document by ID ---
+
+const getInputSchema = z.object({
+  deploymentSelector: z
+    .string()
+    .describe("Deployment selector (from the status tool)."),
+  tableName: z.string().describe("The name of the table to read from."),
+  documentId: z.string().describe("The _id of the document to retrieve."),
+});
+
+const getOutputSchema = z.object({
+  document: z.any().describe("The full document, or null if not found."),
+});
+
+export const GetDocumentTool: ConvexTool<
+  typeof getInputSchema,
+  typeof getOutputSchema
+> = {
+  name: "get_document",
+  description:
+    "Get a single document by its _id from a table in the Convex deployment. Returns the full document or null if not found.",
+  inputSchema: getInputSchema,
+  outputSchema: getOutputSchema,
+  handler: async (ctx, args) => {
+    const { projectDir, deployment } =
+      await ctx.decodeDeploymentSelectorReadOnly(args.deploymentSelector);
+    process.chdir(projectDir);
+    const deploymentSelection = await getMcpDeploymentSelection(
+      ctx,
+      deployment,
+    );
+    const credentials = await loadSelectedDeploymentCredentials(
+      ctx,
+      deploymentSelection,
+    );
+    const result = await runSystemQuery(ctx, {
+      deploymentUrl: credentials.url,
+      adminKey: credentials.adminKey,
+      functionName: "_system/cli/queryTable",
+      componentPath: undefined,
+      args: {
+        table: args.tableName,
+        filters: [{ field: "_id", op: "eq", value: args.documentId }],
+        limit: 1,
+      },
+    });
+    const docs = (result as any)?.page ?? [];
+    return { document: docs.length > 0 ? docs[0] : null };
+  },
+};
+
+// --- Insert Document ---
+
+const insertInputSchema = z.object({
+  deploymentSelector: z
+    .string()
+    .describe("Deployment selector (from the status tool)."),
+  tableName: z.string().describe("The name of the table to insert into."),
+  document: z
+    .string()
+    .describe(
+      "The document to insert, JSON-encoded as a string. Must match the table schema.",
+    ),
+});
+
+const insertOutputSchema = z.object({
+  documentId: z.string().describe("The _id of the newly inserted document."),
+});
+
+export const InsertDocumentTool: ConvexTool<
+  typeof insertInputSchema,
+  typeof insertOutputSchema
+> = {
+  name: "insert_document",
+  description:
+    "Insert a new document into a table in the Convex deployment. The document must match the table's schema. Use the 'tables' tool first to see available fields and types.",
+  inputSchema: insertInputSchema,
+  outputSchema: insertOutputSchema,
+  handler: async (ctx, args) => {
+    const { projectDir, deployment } = await ctx.decodeDeploymentSelector(
+      args.deploymentSelector,
+    );
+    process.chdir(projectDir);
+    const metadata = await getMcpDeploymentSelection(ctx, deployment);
+    const credentials = await loadSelectedDeploymentCredentials(ctx, metadata);
+    const logger = new DefaultLogger({ verbose: false });
+    const client = new ConvexHttpClient(credentials.url, { logger });
+    client.setAdminAuth(credentials.adminKey);
+
+    let parsedDoc: Record<string, any>;
+    try {
+      parsedDoc = JSON.parse(args.document);
+    } catch {
+      return await ctx.crash({
+        exitCode: 1,
+        errorType: "fatal",
+        printedMessage: "Invalid JSON in document argument.",
+      });
+    }
+
+    try {
+      const result = await client.mutation(
+        "_system/cli/tableInsert" as any,
+        { table: args.tableName, document: parsedDoc } as any,
+      );
+      return { documentId: String(result) };
+    } catch (err) {
+      return await ctx.crash({
+        exitCode: 1,
+        errorType: "invalid filesystem or env vars",
+        printedMessage: `Failed to insert document into "${args.tableName}":\n${(err as Error).toString().trim()}`,
+      });
+    }
+  },
+};
+
+// --- Patch Document ---
+
+const patchInputSchema = z.object({
+  deploymentSelector: z
+    .string()
+    .describe("Deployment selector (from the status tool)."),
+  tableName: z.string().describe("The name of the table."),
+  documentId: z.string().describe("The _id of the document to patch."),
+  fields: z
+    .string()
+    .describe(
+      "The fields to update, JSON-encoded as a string. Only specified fields will be changed.",
+    ),
+});
+
+const patchOutputSchema = z.object({
+  success: z.boolean().describe("Whether the patch was successful."),
+});
+
+export const PatchDocumentTool: ConvexTool<
+  typeof patchInputSchema,
+  typeof patchOutputSchema
+> = {
+  name: "patch_document",
+  description:
+    "Update specific fields on an existing document by _id. Only the specified fields will be changed; other fields remain untouched. Use the 'tables' tool first to see available fields.",
+  inputSchema: patchInputSchema,
+  outputSchema: patchOutputSchema,
+  handler: async (ctx, args) => {
+    const { projectDir, deployment } = await ctx.decodeDeploymentSelector(
+      args.deploymentSelector,
+    );
+    process.chdir(projectDir);
+    const metadata = await getMcpDeploymentSelection(ctx, deployment);
+    const credentials = await loadSelectedDeploymentCredentials(ctx, metadata);
+    const logger = new DefaultLogger({ verbose: false });
+    const client = new ConvexHttpClient(credentials.url, { logger });
+    client.setAdminAuth(credentials.adminKey);
+
+    let parsedFields: Record<string, any>;
+    try {
+      parsedFields = JSON.parse(args.fields);
+    } catch {
+      return await ctx.crash({
+        exitCode: 1,
+        errorType: "fatal",
+        printedMessage: "Invalid JSON in fields argument.",
+      });
+    }
+
+    try {
+      await client.mutation("_system/cli/tablePatch" as any, {
+        table: args.tableName,
+        id: args.documentId,
+        fields: parsedFields,
+      } as any);
+      return { success: true };
+    } catch (err) {
+      return await ctx.crash({
+        exitCode: 1,
+        errorType: "invalid filesystem or env vars",
+        printedMessage: `Failed to patch document "${args.documentId}" in "${args.tableName}":\n${(err as Error).toString().trim()}`,
+      });
+    }
+  },
+};
+
+// --- Delete Document ---
+
+const deleteInputSchema = z.object({
+  deploymentSelector: z
+    .string()
+    .describe("Deployment selector (from the status tool)."),
+  tableName: z.string().describe("The name of the table."),
+  documentId: z.string().describe("The _id of the document to delete."),
+});
+
+const deleteOutputSchema = z.object({
+  success: z.boolean().describe("Whether the deletion was successful."),
+});
+
+export const DeleteDocumentTool: ConvexTool<
+  typeof deleteInputSchema,
+  typeof deleteOutputSchema
+> = {
+  name: "delete_document",
+  description:
+    "Delete a document by its _id from a table in the Convex deployment. This is irreversible.",
+  inputSchema: deleteInputSchema,
+  outputSchema: deleteOutputSchema,
+  handler: async (ctx, args) => {
+    const { projectDir, deployment } = await ctx.decodeDeploymentSelector(
+      args.deploymentSelector,
+    );
+    process.chdir(projectDir);
+    const metadata = await getMcpDeploymentSelection(ctx, deployment);
+    const credentials = await loadSelectedDeploymentCredentials(ctx, metadata);
+    const logger = new DefaultLogger({ verbose: false });
+    const client = new ConvexHttpClient(credentials.url, { logger });
+    client.setAdminAuth(credentials.adminKey);
+
+    try {
+      await client.mutation("_system/cli/tableDelete" as any, {
+        table: args.tableName,
+        id: args.documentId,
+      } as any);
+      return { success: true };
+    } catch (err) {
+      return await ctx.crash({
+        exitCode: 1,
+        errorType: "invalid filesystem or env vars",
+        printedMessage: `Failed to delete document "${args.documentId}" from "${args.tableName}":\n${(err as Error).toString().trim()}`,
+      });
+    }
+  },
+};

--- a/npm-packages/convex/src/cli/lib/mcp/tools/index.ts
+++ b/npm-packages/convex/src/cli/lib/mcp/tools/index.ts
@@ -10,6 +10,22 @@ import { EnvListTool, EnvGetTool, EnvSetTool, EnvRemoveTool } from "./env.js";
 import { RunOneoffQueryTool } from "./runOneoffQuery.js";
 import { LogsTool } from "./logs.js";
 import { InsightsTool } from "./insights.js";
+import {
+  GetDocumentTool,
+  InsertDocumentTool,
+  PatchDocumentTool,
+  DeleteDocumentTool,
+} from "./crud.js";
+import {
+  StorageListTool,
+  StorageGetUrlTool,
+  StorageDeleteTool,
+} from "./storage.js";
+import {
+  CronsListTool,
+  ScheduledListTool,
+  ScheduledCancelTool,
+} from "./scheduledFunctions.js";
 import { Tool } from "@modelcontextprotocol/sdk/types.js";
 
 export type ConvexTool<Input extends ZodTypeAny, Output extends ZodTypeAny> = {
@@ -34,6 +50,7 @@ export function mcpTool(tool: ConvexTool<ZodTypeAny, ZodTypeAny>): Tool {
 }
 
 export const convexTools: ConvexTool<any, any>[] = [
+  // Existing tools
   StatusTool,
   DataTool,
   TablesTool,
@@ -46,4 +63,17 @@ export const convexTools: ConvexTool<any, any>[] = [
   RunOneoffQueryTool,
   LogsTool,
   InsightsTool,
+  // CRUD tools
+  GetDocumentTool,
+  InsertDocumentTool,
+  PatchDocumentTool,
+  DeleteDocumentTool,
+  // File storage tools
+  StorageListTool,
+  StorageGetUrlTool,
+  StorageDeleteTool,
+  // Scheduled function tools
+  CronsListTool,
+  ScheduledListTool,
+  ScheduledCancelTool,
 ];

--- a/npm-packages/convex/src/cli/lib/mcp/tools/scheduledFunctions.ts
+++ b/npm-packages/convex/src/cli/lib/mcp/tools/scheduledFunctions.ts
@@ -1,0 +1,217 @@
+import { z } from "zod";
+import { ConvexTool } from "./index.js";
+import { loadSelectedDeploymentCredentials } from "../../api.js";
+import { runSystemQuery } from "../../run.js";
+import { ConvexHttpClient } from "../../../../browser/index.js";
+import { DefaultLogger } from "../../../../browser/logging.js";
+import { getMcpDeploymentSelection } from "../requestContext.js";
+
+// --- Crons List ---
+
+const cronsInputSchema = z.object({
+  deploymentSelector: z
+    .string()
+    .describe("Deployment selector (from the status tool)."),
+});
+
+const cronsOutputSchema = z.object({
+  crons: z.array(
+    z.object({
+      name: z.string(),
+      schedule: z.string(),
+      functionName: z.string(),
+    }),
+  ),
+});
+
+export const CronsListTool: ConvexTool<
+  typeof cronsInputSchema,
+  typeof cronsOutputSchema
+> = {
+  name: "crons_list",
+  description:
+    "List all registered cron jobs in the Convex deployment, including their schedules and target functions.",
+  inputSchema: cronsInputSchema,
+  outputSchema: cronsOutputSchema,
+  handler: async (ctx, args) => {
+    const { projectDir, deployment } =
+      await ctx.decodeDeploymentSelectorReadOnly(args.deploymentSelector);
+    process.chdir(projectDir);
+    const deploymentSelection = await getMcpDeploymentSelection(
+      ctx,
+      deployment,
+    );
+    const credentials = await loadSelectedDeploymentCredentials(
+      ctx,
+      deploymentSelection,
+    );
+
+    try {
+      const result = (await runSystemQuery(ctx, {
+        deploymentUrl: credentials.url,
+        adminKey: credentials.adminKey,
+        functionName: "_system/cli/tableData",
+        componentPath: undefined,
+        args: {
+          table: "_cron_jobs",
+          order: "asc",
+          paginationOpts: {
+            numItems: 100,
+            cursor: null,
+          },
+        },
+      })) as any;
+
+      const crons = (result?.page ?? []).map((doc: any) => ({
+        name: doc.name ?? doc._id,
+        schedule: JSON.stringify(doc.schedule ?? doc.cronSpec),
+        functionName: doc.functionName ?? doc.udfPath ?? "unknown",
+      }));
+
+      return { crons };
+    } catch {
+      return { crons: [] };
+    }
+  },
+};
+
+// --- Scheduled Functions List ---
+
+const scheduledInputSchema = z.object({
+  deploymentSelector: z
+    .string()
+    .describe("Deployment selector (from the status tool)."),
+  status: z
+    .enum(["pending", "inProgress", "completed", "failed", "canceled"])
+    .optional()
+    .describe("Filter by status. Defaults to showing all."),
+  limit: z
+    .number()
+    .max(100)
+    .optional()
+    .describe("Maximum number of scheduled functions to return. Defaults to 50."),
+});
+
+const scheduledOutputSchema = z.object({
+  scheduledFunctions: z.array(
+    z.object({
+      id: z.string(),
+      functionName: z.string(),
+      scheduledTime: z.string(),
+      status: z.string(),
+      args: z.any().optional(),
+    }),
+  ),
+});
+
+export const ScheduledListTool: ConvexTool<
+  typeof scheduledInputSchema,
+  typeof scheduledOutputSchema
+> = {
+  name: "scheduled_list",
+  description:
+    "List scheduled function calls in the Convex deployment. Can filter by status (pending, inProgress, completed, failed, canceled).",
+  inputSchema: scheduledInputSchema,
+  outputSchema: scheduledOutputSchema,
+  handler: async (ctx, args) => {
+    const { projectDir, deployment } =
+      await ctx.decodeDeploymentSelectorReadOnly(args.deploymentSelector);
+    process.chdir(projectDir);
+    const deploymentSelection = await getMcpDeploymentSelection(
+      ctx,
+      deployment,
+    );
+    const credentials = await loadSelectedDeploymentCredentials(
+      ctx,
+      deploymentSelection,
+    );
+
+    try {
+      const result = (await runSystemQuery(ctx, {
+        deploymentUrl: credentials.url,
+        adminKey: credentials.adminKey,
+        functionName: "_system/cli/tableData",
+        componentPath: undefined,
+        args: {
+          table: "_scheduled_functions",
+          order: "desc",
+          paginationOpts: {
+            numItems: args.limit ?? 50,
+            cursor: null,
+          },
+        },
+      })) as any;
+
+      let functions = (result?.page ?? []).map((doc: any) => ({
+        id: doc._id,
+        functionName: doc.udfPath ?? doc.name ?? "unknown",
+        scheduledTime: doc.scheduledTime
+          ? new Date(doc.scheduledTime).toISOString()
+          : "unknown",
+        status: doc.state?.kind ?? doc.status ?? "unknown",
+        args: doc.args,
+      }));
+
+      if (args.status) {
+        functions = functions.filter(
+          (f: any) => f.status === args.status,
+        );
+      }
+
+      return { scheduledFunctions: functions };
+    } catch {
+      return { scheduledFunctions: [] };
+    }
+  },
+};
+
+// --- Scheduled Function Cancel ---
+
+const cancelInputSchema = z.object({
+  deploymentSelector: z
+    .string()
+    .describe("Deployment selector (from the status tool)."),
+  scheduledFunctionId: z
+    .string()
+    .describe("The _id of the scheduled function to cancel."),
+});
+
+const cancelOutputSchema = z.object({
+  success: z.boolean().describe("Whether the cancellation was successful."),
+});
+
+export const ScheduledCancelTool: ConvexTool<
+  typeof cancelInputSchema,
+  typeof cancelOutputSchema
+> = {
+  name: "scheduled_cancel",
+  description:
+    "Cancel a pending scheduled function call by its _id. Only pending functions can be canceled.",
+  inputSchema: cancelInputSchema,
+  outputSchema: cancelOutputSchema,
+  handler: async (ctx, args) => {
+    const { projectDir, deployment } = await ctx.decodeDeploymentSelector(
+      args.deploymentSelector,
+    );
+    process.chdir(projectDir);
+    const metadata = await getMcpDeploymentSelection(ctx, deployment);
+    const credentials = await loadSelectedDeploymentCredentials(ctx, metadata);
+    const logger = new DefaultLogger({ verbose: false });
+    const client = new ConvexHttpClient(credentials.url, { logger });
+    client.setAdminAuth(credentials.adminKey);
+
+    try {
+      await client.mutation(
+        "_system/cli/cancelScheduledFunction" as any,
+        { id: args.scheduledFunctionId } as any,
+      );
+      return { success: true };
+    } catch (err) {
+      return await ctx.crash({
+        exitCode: 1,
+        errorType: "invalid filesystem or env vars",
+        printedMessage: `Failed to cancel scheduled function "${args.scheduledFunctionId}":\n${(err as Error).toString().trim()}`,
+      });
+    }
+  },
+};

--- a/npm-packages/convex/src/cli/lib/mcp/tools/storage.ts
+++ b/npm-packages/convex/src/cli/lib/mcp/tools/storage.ts
@@ -1,0 +1,169 @@
+import { z } from "zod";
+import { ConvexTool } from "./index.js";
+import { loadSelectedDeploymentCredentials } from "../../api.js";
+import { runSystemQuery } from "../../run.js";
+import { ConvexHttpClient } from "../../../../browser/index.js";
+import { DefaultLogger } from "../../../../browser/logging.js";
+import { getMcpDeploymentSelection } from "../requestContext.js";
+
+// --- Storage List ---
+
+const listInputSchema = z.object({
+  deploymentSelector: z
+    .string()
+    .describe("Deployment selector (from the status tool)."),
+  limit: z
+    .number()
+    .max(100)
+    .optional()
+    .describe("Maximum number of files to return. Defaults to 50."),
+});
+
+const listOutputSchema = z.object({
+  files: z.array(
+    z.object({
+      storageId: z.string(),
+      size: z.number().optional(),
+      contentType: z.string().optional(),
+    }),
+  ),
+});
+
+export const StorageListTool: ConvexTool<
+  typeof listInputSchema,
+  typeof listOutputSchema
+> = {
+  name: "storage_list",
+  description:
+    "List files stored in the Convex file storage for a deployment. Returns storage IDs, sizes, and content types.",
+  inputSchema: listInputSchema,
+  outputSchema: listOutputSchema,
+  handler: async (ctx, args) => {
+    const { projectDir, deployment } =
+      await ctx.decodeDeploymentSelectorReadOnly(args.deploymentSelector);
+    process.chdir(projectDir);
+    const deploymentSelection = await getMcpDeploymentSelection(
+      ctx,
+      deployment,
+    );
+    const credentials = await loadSelectedDeploymentCredentials(
+      ctx,
+      deploymentSelection,
+    );
+    const result = (await runSystemQuery(ctx, {
+      deploymentUrl: credentials.url,
+      adminKey: credentials.adminKey,
+      functionName: "_system/cli/tableData",
+      componentPath: undefined,
+      args: {
+        table: "_storage",
+        order: "desc",
+        paginationOpts: {
+          numItems: args.limit ?? 50,
+          cursor: null,
+        },
+      },
+    })) as any;
+
+    const files = (result?.page ?? []).map((doc: any) => ({
+      storageId: doc._id,
+      size: doc.size,
+      contentType: doc.contentType,
+    }));
+
+    return { files };
+  },
+};
+
+// --- Storage Get URL ---
+
+const getUrlInputSchema = z.object({
+  deploymentSelector: z
+    .string()
+    .describe("Deployment selector (from the status tool)."),
+  storageId: z.string().describe("The storage ID of the file to get a URL for."),
+});
+
+const getUrlOutputSchema = z.object({
+  url: z.string().nullable().describe("The serving URL for the file, or null if not found."),
+});
+
+export const StorageGetUrlTool: ConvexTool<
+  typeof getUrlInputSchema,
+  typeof getUrlOutputSchema
+> = {
+  name: "storage_get_url",
+  description:
+    "Get a serving URL for a file in Convex file storage by its storage ID.",
+  inputSchema: getUrlInputSchema,
+  outputSchema: getUrlOutputSchema,
+  handler: async (ctx, args) => {
+    const { projectDir, deployment } =
+      await ctx.decodeDeploymentSelectorReadOnly(args.deploymentSelector);
+    process.chdir(projectDir);
+    const metadata = await getMcpDeploymentSelection(ctx, deployment);
+    const credentials = await loadSelectedDeploymentCredentials(ctx, metadata);
+    const logger = new DefaultLogger({ verbose: false });
+    const client = new ConvexHttpClient(credentials.url, { logger });
+    client.setAdminAuth(credentials.adminKey);
+
+    try {
+      const url = await client.query(
+        "_system/cli/storageGetUrl" as any,
+        { storageId: args.storageId } as any,
+      );
+      return { url: url ? String(url) : null };
+    } catch {
+      return { url: null };
+    }
+  },
+};
+
+// --- Storage Delete ---
+
+const deleteInputSchema = z.object({
+  deploymentSelector: z
+    .string()
+    .describe("Deployment selector (from the status tool)."),
+  storageId: z.string().describe("The storage ID of the file to delete."),
+});
+
+const deleteOutputSchema = z.object({
+  success: z.boolean().describe("Whether the file was successfully deleted."),
+});
+
+export const StorageDeleteTool: ConvexTool<
+  typeof deleteInputSchema,
+  typeof deleteOutputSchema
+> = {
+  name: "storage_delete",
+  description:
+    "Delete a file from Convex file storage by its storage ID. This is irreversible.",
+  inputSchema: deleteInputSchema,
+  outputSchema: deleteOutputSchema,
+  handler: async (ctx, args) => {
+    const { projectDir, deployment } = await ctx.decodeDeploymentSelector(
+      args.deploymentSelector,
+    );
+    process.chdir(projectDir);
+    const metadata = await getMcpDeploymentSelection(ctx, deployment);
+    const credentials = await loadSelectedDeploymentCredentials(ctx, metadata);
+    const logger = new DefaultLogger({ verbose: false });
+    const client = new ConvexHttpClient(credentials.url, { logger });
+    client.setAdminAuth(credentials.adminKey);
+
+    try {
+      await client.mutation(
+        "_system/cli/storageDelete" as any,
+        { storageId: args.storageId } as any,
+      );
+      return { success: true };
+    } catch (err) {
+      return await ctx.crash({
+        exitCode: 1,
+        errorType: "invalid filesystem or env vars",
+        printedMessage: `Failed to delete file "${args.storageId}":\n${(err as Error).toString().trim()}`,
+      });
+    }
+  },
+};


### PR DESCRIPTION
## Summary

Adds 10 new MCP tools across 3 categories, expanding the Convex MCP server from 12 to 22 tools. All follow the existing `ConvexTool` pattern with Zod input/output schemas.

Per discussion with Graham in #410.

### CRUD Tools (`crud.ts`)
- **`get_document`** — Get a single document by `_id` (read-only)
- **`insert_document`** — Insert a new document with schema validation
- **`patch_document`** — Update specific fields on a document by `_id`
- **`delete_document`** — Delete a document by `_id`

### File Storage Tools (`storage.ts`)
- **`storage_list`** — List files in Convex storage with metadata (read-only)
- **`storage_get_url`** — Get a serving URL for a stored file (read-only)
- **`storage_delete`** — Delete a file from storage

### Scheduled Function Tools (`scheduledFunctions.ts`)
- **`crons_list`** — List all registered cron jobs (read-only)
- **`scheduled_list`** — List scheduled function calls with status filter (read-only)
- **`scheduled_cancel`** — Cancel a pending scheduled function

## Design Decisions

- **Read-only tools** use `decodeDeploymentSelectorReadOnly` — respects `--cautiously-allow-production-pii`
- **Mutating tools** use `decodeDeploymentSelector` — respects `--dangerously-enable-production-deployments`
- All tools can be disabled via existing `--disable-tools` flag
- Storage list queries `_storage` system table via existing `tableData` system query
- Scheduled functions query `_scheduled_functions` system table
- CRUD tools use `ConvexHttpClient` with admin auth (same pattern as `run.ts`)

## Testing

- Tools follow identical patterns to existing `data.ts`, `run.ts`, and `tables.ts`
- Input validation via Zod schemas
- Error handling follows `ctx.crash()` pattern

Closes #410