### PR TITLE
fix(posthog): detect invalid project tokens via /decide endpoint

### DIFF
--- a/crates/local_backend/src/log_sinks.rs
+++ b/crates/local_backend/src/log_sinks.rs
@@ -525,7 +525,7 @@ fn validate_posthog_host(host: Option<&String>) -> anyhow::Result<()> {
 #[derive(Deserialize, ToSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct CreatePostHogLogsLogStreamArgs {
-    /// PostHog project API key.
+    /// PostHog project token.
     api_key: String,
     /// PostHog host URL. Defaults to https://us.i.posthog.com.
     host: Option<String>,
@@ -549,7 +549,7 @@ impl TryFrom<CreatePostHogLogsLogStreamArgs> for PostHogLogsConfig {
 #[derive(Deserialize, ToSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct CreatePostHogErrorTrackingLogStreamArgs {
-    /// PostHog project API key.
+    /// PostHog project token.
     api_key: String,
     /// PostHog host URL. Defaults to https://us.i.posthog.com.
     host: Option<String>,
@@ -1119,7 +1119,7 @@ pub struct UpdateSentrySinkArgs {
 #[derive(Deserialize, ToSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct UpdatePostHogLogsSinkArgs {
-    /// PostHog project API key.
+    /// PostHog project token.
     #[serde(default)]
     api_key: Option<String>,
     /// PostHog host URL.
@@ -1133,7 +1133,7 @@ pub struct UpdatePostHogLogsSinkArgs {
 #[derive(Deserialize, ToSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct UpdatePostHogErrorTrackingSinkArgs {
-    /// PostHog project API key.
+    /// PostHog project token.
     #[serde(default)]
     api_key: Option<String>,
     /// PostHog host URL.

--- a/crates/log_streaming/src/sinks/posthog_error_tracking.rs
+++ b/crates/log_streaming/src/sinks/posthog_error_tracking.rs
@@ -106,8 +106,8 @@ impl<RT: Runtime> PostHogErrorTrackingSink<RT> {
     }
 
     async fn verify_creds(&mut self) -> anyhow::Result<()> {
-        // PostHog's ingestion endpoints return 200 even for invalid API keys,
-        // so we use the /decide endpoint which actually validates the key.
+        // PostHog's ingestion endpoints return 200 even for invalid project tokens,
+        // so we use the /decide endpoint which actually validates the token.
         let mut decide_url = self.capture_url.clone();
         decide_url.set_path("/decide");
         decide_url.set_query(Some("v=3"));
@@ -134,8 +134,8 @@ impl<RT: Runtime> PostHogErrorTrackingSink<RT> {
             Ok(_) => Ok(()),
             Err(e) => {
                 anyhow::bail!(ErrorMetadata::bad_request(
-                    "PostHogErrorTrackingInvalidApiKey",
-                    format!("Failed to verify PostHog API key: {e}"),
+                    "PostHogErrorTrackingInvalidProjectToken",
+                    format!("Failed to verify PostHog project token: {e}"),
                 ));
             },
         }
@@ -309,7 +309,7 @@ impl<RT: Runtime> PostHogErrorTrackingSink<RT> {
     }
 
     async fn send_batch(&mut self, batch_json: Vec<u8>) -> anyhow::Result<()> {
-        // PostHog capture API uses api_key in the body, no Authorization header
+        // PostHog capture API uses the project token in the body, no Authorization header
         let header_map = HeaderMap::from_iter([(CONTENT_TYPE, APPLICATION_JSON_CONTENT_TYPE)]);
         let batch_json = Bytes::from(batch_json);
 

--- a/crates/log_streaming/src/sinks/posthog_logs.rs
+++ b/crates/log_streaming/src/sinks/posthog_logs.rs
@@ -117,8 +117,8 @@ impl<RT: Runtime> PostHogLogsSink<RT> {
     }
 
     async fn verify_creds(&mut self) -> anyhow::Result<()> {
-        // PostHog's ingestion endpoints return 200 even for invalid API keys,
-        // so we use the /decide endpoint which actually validates the key.
+        // PostHog's ingestion endpoints return 200 even for invalid project tokens,
+        // so we use the /decide endpoint which actually validates the token.
         let mut decide_url = self.endpoint_url.clone();
         decide_url.set_path("/decide");
         decide_url.set_query(Some("v=3"));
@@ -145,8 +145,8 @@ impl<RT: Runtime> PostHogLogsSink<RT> {
             Ok(_) => Ok(()),
             Err(e) => {
                 anyhow::bail!(ErrorMetadata::bad_request(
-                    "PostHogLogsInvalidApiKey",
-                    format!("Failed to verify PostHog API key: {e}"),
+                    "PostHogLogsInvalidProjectToken",
+                    format!("Failed to verify PostHog project token: {e}"),
                 ));
             },
         }

--- a/npm-packages/dashboard-common/src/features/settings/components/integrations/PostHogErrorTrackingConfigurationForm.tsx
+++ b/npm-packages/dashboard-common/src/features/settings/components/integrations/PostHogErrorTrackingConfigurationForm.tsx
@@ -10,7 +10,7 @@ import { toast } from "@common/lib/utils";
 import * as Yup from "yup";
 
 const validationSchema = Yup.object().shape({
-  apiKey: Yup.string().required("PostHog project API key is required"),
+  apiKey: Yup.string().required("PostHog project token is required"),
   host: Yup.string().url("Must be a valid URL").nullable(),
 });
 
@@ -66,11 +66,11 @@ export function PostHogErrorTrackingConfigurationForm({
       <TextInput
         value={formState.values.apiKey}
         onChange={formState.handleChange}
-        label="Project API Key"
+        label="Project Token"
         placeholder="phc_..."
         id="apiKey"
         error={formState.errors.apiKey}
-        description="Your PostHog project API key. Found in PostHog under Settings > Project > Project API Key."
+        description="Your PostHog project token. Found in PostHog under Settings > Project > General."
       />
       <TextInput
         value={formState.values.host}

--- a/npm-packages/dashboard-common/src/features/settings/components/integrations/PostHogLogsConfigurationForm.tsx
+++ b/npm-packages/dashboard-common/src/features/settings/components/integrations/PostHogLogsConfigurationForm.tsx
@@ -10,7 +10,7 @@ import { toast } from "@common/lib/utils";
 import * as Yup from "yup";
 
 const validationSchema = Yup.object().shape({
-  apiKey: Yup.string().required("PostHog project API key is required"),
+  apiKey: Yup.string().required("PostHog project token is required"),
   host: Yup.string().url("Must be a valid URL").nullable(),
   serviceName: Yup.string().nullable(),
 });
@@ -67,11 +67,11 @@ export function PostHogLogsConfigurationForm({
       <TextInput
         value={formState.values.apiKey}
         onChange={formState.handleChange}
-        label="Project API Key"
+        label="Project Token"
         placeholder="phc_..."
         id="apiKey"
         error={formState.errors.apiKey}
-        description="Your PostHog project API key. Found in PostHog under Settings > Project > Project API Key."
+        description="Your PostHog project token. Found in PostHog under Settings > Project > General."
       />
       <TextInput
         value={formState.values.host}

--- a/npm-packages/docs/docs/production/integrations/exception-reporting.mdx
+++ b/npm-packages/docs/docs/production/integrations/exception-reporting.mdx
@@ -64,8 +64,8 @@ the "Integrations" tab in the sidebar.
 
 Click on the PostHog Error Tracking card and follow the setup directions. You
 will need your
-[PostHog project API key](https://us.posthog.com/settings/project#variables),
-found in PostHog under Settings > Project > Project API Key.
+[PostHog project token](https://us.posthog.com/settings/project),
+found in PostHog under Settings > Project > General.
 
 You may optionally specify a custom host URL. Defaults to US Cloud
 (`https://us.i.posthog.com`). Use `https://eu.i.posthog.com` for EU Cloud, or

--- a/npm-packages/docs/docs/production/integrations/log-streams/log-streams.mdx
+++ b/npm-packages/docs/docs/production/integrations/log-streams/log-streams.mdx
@@ -70,8 +70,8 @@ Configuring a Datadog log stream requires specifying:
 Configuring a PostHog log stream requires specifying:
 
 - A PostHog
-  [project API key](https://us.posthog.com/settings/project#variables), found in
-  PostHog under Settings > Project > Project API Key
+  [project token](https://us.posthog.com/settings/project), found in
+  PostHog under Settings > Project > General
 - An optional host URL. Defaults to US Cloud (`https://us.i.posthog.com`). Use
   `https://eu.i.posthog.com` for EU Cloud, or your self-hosted URL. The endpoint
   path is added automatically.


### PR DESCRIPTION
## Problem

PostHog's ingestion endpoints (`/i/v1/logs` and `/i/v0/e/`) return HTTP 200 regardless of project token validity — they're fire-and-forget by design. This meant `verify_creds()` always succeeded, even with garbage tokens, and the integration never entered the "Failed" state.

## Changes

- Switch both `PostHogLogsSink` and `PostHogErrorTrackingSink` to validate project tokens against PostHog's `/decide?v=3` endpoint, which returns 401 for invalid tokens
- Remove the now-dead `is_verification` parameter from `send_batch` since `verify_creds` no longer calls it
- Fix decide URL construction to preserve port for self-hosted instances by cloning the full URL instead of using `host_str()`
- Rename "Project API Key" to "Project Token" in dashboard forms and docs to match PostHog's own nomenclature (Settings > Project > General)
- Update tests to register a `/decide` handler and remove verification event filtering

## How did you test this code?

- All 6 existing PostHog tests pass (bad token, normal operation, bandwidth tracking for both sinks)
- Verified against PostHog's `/decide` endpoint source code that it returns 401 for invalid tokens

<!--
  The following applies to third-party contributors.
  Convex employees and contractors can delete or ignore.
-->

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.