### PR TITLE
fix: use self-hosted dashboard URL in auth config error message

### DIFF
--- a/npm-packages/convex/src/cli/lib/config.ts
+++ b/npm-packages/convex/src/cli/lib/config.ts
@@ -30,6 +30,7 @@ import {
   logAndHandleFetchError,
   ThrowingFetchError,
   currentPackageHomepage,
+  CONVEX_SELF_HOSTED_URL_VAR_NAME,
 } from "./utils/utils.js";
 import { recursivelyDelete } from "./fsUtils.js";
 import { NodeDependency } from "./deployApi/modules.js";
@@ -967,6 +968,20 @@ export async function handlePushConfigError(
       setEnvVarInstructions = `Go to:\n\n    ${chalkStderr.bold(
         dashboardUrl,
       )}\n\n  to set it up. `;
+    } else if (process.env[CONVEX_SELF_HOSTED_URL_VAR_NAME]) {
+      const variableQuery =
+        variableName !== undefined ? `?var=${variableName}` : "";
+      try {
+        const backendUrl = new URL(
+          process.env[CONVEX_SELF_HOSTED_URL_VAR_NAME],
+        );
+        const dashboardUrl = `${backendUrl.protocol}//${backendUrl.hostname}:6791/settings/environment-variables${variableQuery}`;
+        setEnvVarInstructions = `Go to:\n\n    ${chalkStderr.bold(
+          dashboardUrl,
+        )}\n\n  to set it up. `;
+      } catch {
+        // If the URL is malformed, fall through to the generic message
+      }
     }
     await ctx.crash({
       exitCode: 1,


### PR DESCRIPTION
Fixes #56

## Summary

When `handlePushConfigError()` encounters an `AuthConfigMissingEnvironmentVariable` error for self-hosted deployments, it falls through to a generic message without a dashboard link. This is because `deploymentName` is `null` for self-hosted setups (no `deploymentFields`).

This adds an `else if` branch that detects self-hosted mode via the `CONVEX_SELF_HOSTED_URL` env var and constructs the dashboard URL using `hostname:6791` (the default self-hosted dashboard port from `docker-compose.yml`) with the path `/settings/environment-variables?var=VAR_NAME`.

## Test plan

- All existing `config.test.ts` tests pass (14/14)
- Manual verification: set `CONVEX_SELF_HOSTED_URL=http://localhost:3210` and trigger the `AuthConfigMissingEnvironmentVariable` error path — output shows `http://localhost:6791/settings/environment-variables?var=VAR_NAME` instead of `dashboard.convex.dev`