### PR TITLE
fix: pass database spec before storage flags in run_backend.sh

### DIFF
--- a/self-hosted/docker-build/run_backend.sh
+++ b/self-hosted/docker-build/run_backend.sh
@@ -68,6 +68,5 @@ exec ./convex-local-backend "$@" \
     ${DISABLE_BEACON:+--disable-beacon} \
     ${REDACT_LOGS_TO_CLIENT:+--redact-logs-to-client} \
     ${DO_NOT_REQUIRE_SSL:+--do-not-require-ssl} \
-    "${DB_FLAGS[@]}" \
-    "${STORAGE_FLAGS[@]}" \
-    "$DB_SPEC"
+    "${DB_FLAGS[@]}" "$DB_SPEC" \
+    "${STORAGE_FLAGS[@]}"


### PR DESCRIPTION
When both POSTGRES_URL (or MYSQL_URL) and S3 storage environment variables are set, `$DB_SPEC` is appended as a trailing positional argument after --s3-storage, causing the CLI to interpret the database connection string as the S3 storage argument: `--db postgres-v5 --s3-storage postgresql://user:pass@host:5432`

This causes the backend to attempt S3 operations against the Postgres URL, leading to high CPU usage, memory growth, and degraded performance over time.

The fix moves `$DB_SPEC` to immediately follow `${DB_FLAGS[@]}` so the database connection string is correctly associated with --db: `--db postgres-v5 postgresql://user:pass@host:5432 --s3-storage`

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
