### PR TITLE
[codex] docs: clarify legacy aiFiles field

### DIFF
--- a/npm-packages/docs/docs/production/project-configuration.mdx
+++ b/npm-packages/docs/docs/production/project-configuration.mdx
@@ -83,6 +83,9 @@ To suppress those suggestions, set `aiFiles.enabled` to `false` in
 }
 ```
 
+Older examples may mention `aiFiles.disableStalenessMessage`. That legacy field
+has been replaced by `aiFiles.enabled`.
+
 When this is `false`, `npx convex dev` will not show the AI files install or
 staleness messages.
 


### PR DESCRIPTION
## What changed
Adds a short note to the `convex.json` AI files configuration docs clarifying that `aiFiles.disableStalenessMessage` is the legacy field name and `aiFiles.enabled` is the current field.

## Why
The live docs page currently still shows the legacy field name, which is confusing given the `1.34.1` changelog and current source docs. This clarification makes the page resilient even when readers have seen older examples.

## Impact
Readers looking up AI files configuration in `convex.json` are less likely to copy the deprecated field name.

## Validation
I did not run a full docs build for this one-line documentation clarification.
