### PR TITLE
[codex] docs: mention legacy aiFiles field

### DIFF
--- a/npm-packages/docs/docs/production/project-configuration.mdx
+++ b/npm-packages/docs/docs/production/project-configuration.mdx
@@ -72,7 +72,8 @@ show install or update suggestions during `npx convex dev`.
 :::caution This setting is supported in Convex CLI `1.34.1` and later. :::
 
 To suppress those suggestions, set `aiFiles.enabled` to `false` in
-`convex.json`:
+`convex.json` (this field was previously called
+`aiFiles.disableStalenessMessage`):
 
 ```json title="convex.json"
 {


### PR DESCRIPTION
## What changed
Updates the `convex.json` AI files configuration docs so the main instruction explicitly says the current field is `aiFiles.enabled` and that it was previously called `aiFiles.disableStalenessMessage`.

## Why
This makes the page clearer for readers who have seen the legacy field name in older examples or changelog context.

## Validation
I did not run a full docs build for this small wording change.
