### PR TITLE
Add MCP tool annotations (readOnlyHint, destructiveHint)

### DIFF
--- a/npm-packages/convex/src/cli/lib/mcp/tools/data.ts
+++ b/npm-packages/convex/src/cli/lib/mcp/tools/data.ts
@@ -39,6 +39,7 @@ export const DataTool: ConvexTool<typeof inputSchema, typeof outputSchema> = {
   description,
   inputSchema,
   outputSchema,
+  annotations: { readOnlyHint: true },
   handler: async (ctx, args) => {
     const { projectDir, deployment } =
       await ctx.decodeDeploymentSelectorReadOnly(args.deploymentSelector);

--- a/npm-packages/convex/src/cli/lib/mcp/tools/env.ts
+++ b/npm-packages/convex/src/cli/lib/mcp/tools/env.ts
@@ -35,6 +35,7 @@ export const EnvListTool: ConvexTool<
   description: "List all environment variables in your Convex deployment.",
   inputSchema: envListInputSchema,
   outputSchema: envListOutputSchema,
+  annotations: { readOnlyHint: true },
   handler: async (ctx, args) => {
     const { projectDir, deployment } = await ctx.decodeDeploymentSelector(
       args.deploymentSelector,
@@ -84,6 +85,7 @@ export const EnvGetTool: ConvexTool<
     "Get a specific environment variable from your Convex deployment.",
   inputSchema: envGetInputSchema,
   outputSchema: envGetOutputSchema,
+  annotations: { readOnlyHint: true },
   handler: async (ctx, args) => {
     const { projectDir, deployment } = await ctx.decodeDeploymentSelector(
       args.deploymentSelector,
@@ -131,6 +133,7 @@ export const EnvSetTool: ConvexTool<
   description: "Set an environment variable in your Convex deployment.",
   inputSchema: envSetInputSchema,
   outputSchema: envSetOutputSchema,
+  annotations: { destructiveHint: true },
   handler: async (ctx, args) => {
     const { projectDir, deployment } = await ctx.decodeDeploymentSelector(
       args.deploymentSelector,
@@ -176,6 +179,7 @@ export const EnvRemoveTool: ConvexTool<
   description: "Remove an environment variable from your Convex deployment.",
   inputSchema: envRemoveInputSchema,
   outputSchema: envRemoveOutputSchema,
+  annotations: { destructiveHint: true },
   handler: async (ctx, args) => {
     const { projectDir, deployment } = await ctx.decodeDeploymentSelector(
       args.deploymentSelector,

--- a/npm-packages/convex/src/cli/lib/mcp/tools/functionSpec.ts
+++ b/npm-packages/convex/src/cli/lib/mcp/tools/functionSpec.ts
@@ -34,6 +34,7 @@ export const FunctionSpecTool: ConvexTool<
   description,
   inputSchema,
   outputSchema,
+  annotations: { readOnlyHint: true },
   handler: async (ctx, args) => {
     const { projectDir, deployment } = ctx.decodeDeploymentSelectorUnchecked(
       args.deploymentSelector,

--- a/npm-packages/convex/src/cli/lib/mcp/tools/index.ts
+++ b/npm-packages/convex/src/cli/lib/mcp/tools/index.ts
@@ -10,13 +10,14 @@ import { EnvListTool, EnvGetTool, EnvSetTool, EnvRemoveTool } from "./env.js";
 import { RunOneoffQueryTool } from "./runOneoffQuery.js";
 import { LogsTool } from "./logs.js";
 import { InsightsTool } from "./insights.js";
-import { Tool } from "@modelcontextprotocol/sdk/types.js";
+import { Tool, ToolAnnotations } from "@modelcontextprotocol/sdk/types.js";
 
 export type ConvexTool<Input extends ZodTypeAny, Output extends ZodTypeAny> = {
   name: string;
   description: string;
   inputSchema: Input;
   outputSchema: Output;
+  annotations?: ToolAnnotations;
   handler: (
     ctx: RequestContext,
     input: z.infer<Input>,
@@ -30,6 +31,7 @@ export function mcpTool(tool: ConvexTool<ZodTypeAny, ZodTypeAny>): Tool {
     name: tool.name,
     description: tool.description,
     inputSchema: zodToJsonSchema(tool.inputSchema) as ToolInput,
+    ...(tool.annotations && { annotations: tool.annotations }),
   };
 }
 

--- a/npm-packages/convex/src/cli/lib/mcp/tools/insights.ts
+++ b/npm-packages/convex/src/cli/lib/mcp/tools/insights.ts
@@ -124,6 +124,7 @@ export const InsightsTool: ConvexTool<typeof inputSchema, typeof outputSchema> =
     description,
     inputSchema,
     outputSchema,
+    annotations: { readOnlyHint: true },
     handler: async (ctx, args) => {
       const { projectDir, deployment } = ctx.decodeDeploymentSelectorUnchecked(
         args.deploymentSelector,

--- a/npm-packages/convex/src/cli/lib/mcp/tools/logs.ts
+++ b/npm-packages/convex/src/cli/lib/mcp/tools/logs.ts
@@ -76,6 +76,7 @@ export const LogsTool: ConvexTool<typeof inputSchema, typeof outputSchema> = {
   description,
   inputSchema,
   outputSchema,
+  annotations: { readOnlyHint: true },
   handler: async (ctx, args) => {
     const { projectDir, deployment } =
       await ctx.decodeDeploymentSelectorReadOnly(args.deploymentSelector);

--- a/npm-packages/convex/src/cli/lib/mcp/tools/run.ts
+++ b/npm-packages/convex/src/cli/lib/mcp/tools/run.ts
@@ -43,6 +43,7 @@ export const RunTool: ConvexTool<typeof inputSchema, typeof outputSchema> = {
   description,
   inputSchema,
   outputSchema,
+  annotations: { destructiveHint: true, openWorldHint: true },
   handler: async (ctx, args) => {
     const { projectDir, deployment } = await ctx.decodeDeploymentSelector(
       args.deploymentSelector,

--- a/npm-packages/convex/src/cli/lib/mcp/tools/runOneoffQuery.ts
+++ b/npm-packages/convex/src/cli/lib/mcp/tools/runOneoffQuery.ts
@@ -57,6 +57,7 @@ export const RunOneoffQueryTool: ConvexTool<
   description,
   inputSchema,
   outputSchema,
+  annotations: { readOnlyHint: true },
   handler: async (ctx, args) => {
     const { projectDir, deployment } =
       await ctx.decodeDeploymentSelectorReadOnly(args.deploymentSelector);

--- a/npm-packages/convex/src/cli/lib/mcp/tools/status.ts
+++ b/npm-packages/convex/src/cli/lib/mcp/tools/status.ts
@@ -60,6 +60,7 @@ export const StatusTool: ConvexTool<typeof inputSchema, typeof outputSchema> = {
   description,
   inputSchema,
   outputSchema,
+  annotations: { readOnlyHint: true },
   handler: async (ctx: RequestContext, input) => {
     const projectDir = input.projectDir ?? ctx.options.projectDir;
     if (projectDir === undefined) {

--- a/npm-packages/convex/src/cli/lib/mcp/tools/tables.ts
+++ b/npm-packages/convex/src/cli/lib/mcp/tools/tables.ts
@@ -29,6 +29,7 @@ export const TablesTool: ConvexTool<typeof inputSchema, typeof outputSchema> = {
     "List all tables in a particular Convex deployment and their inferred and declared schema.",
   inputSchema,
   outputSchema,
+  annotations: { readOnlyHint: true },
   handler: async (ctx, args) => {
     const { projectDir, deployment } = ctx.decodeDeploymentSelectorUnchecked(
       args.deploymentSelector,


### PR DESCRIPTION
Adds MCP annotations to all 12 tools so AI clients can distinguish read-only operations from mutating ones.

**Read-only** (`readOnlyHint: true`):
`status`, `data`, `tables`, `functionSpec`, `envList`, `envGet`, `runOneoffQuery`, `logs`, `insights`

**Destructive** (`destructiveHint: true`):
`envSet`, `envRemove`

**Destructive + open-world** (`destructiveHint: true, openWorldHint: true`):
`run` (can invoke actions with outbound network access)

Changes:
- Import `ToolAnnotations` from the MCP SDK
- Add optional `annotations` field to `ConvexTool` type
- Pass annotations through in `mcpTool()`
- Add one line per tool file

No behavioral changes. Clients that ignore annotations are unaffected.

Ref: #424 (annotations suggestion from @mikecann's triage)