### PR TITLE
fix: reduce memory growth during file storage exports

### DIFF
--- a/crates/exports/src/export_storage.rs
+++ b/crates/exports/src/export_storage.rs
@@ -123,6 +123,7 @@ pub(crate) async fn write_storage_table<'a, 'b: 'a, RT: Runtime>(
 
     let max_prefetch_bytes = *EXPORT_MAX_INFLIGHT_PREFETCH_BYTES;
     let inflight_bytes_semaphore = tokio::sync::Semaphore::new(max_prefetch_bytes);
+    let num_files = {
     let files_stream = table_iterator
         .stream_documents_in_table(*tablet_id, *by_id, None)
         .map_ok(|LatestDocument { value: doc, .. }| async {
@@ -217,7 +218,16 @@ pub(crate) async fn write_storage_table<'a, 'b: 'a, RT: Runtime>(
             last_log_time = Instant::now();
         }
     }
+    num_files
+    };
     tracing::info!("Export _storage files complete: {num_files} files");
+
+    // Free buffered document metadata for the storage table.
+    // Without this, the MultiTableIterator retains all document IDs
+    // from _file_storage in its buffered_documents map, leaking memory
+    // across repeated exports.
+    table_iterator.unregister_table(*tablet_id)?;
+
     Ok(())
 }
 

--- a/crates/storage/src/lib.rs
+++ b/crates/storage/src/lib.rs
@@ -1161,15 +1161,12 @@ impl<RT: Runtime> Storage for LocalDirStorage<RT> {
         key: &FullyQualifiedObjectKey,
     ) -> anyhow::Result<Option<ObjectAttributes>> {
         let path = Path::new(key.as_str());
-        let mut buf = vec![];
-        let result = File::open(path);
-        if result.is_err() {
-            return Ok(None);
-        }
-        let mut file = result.unwrap();
-        file.read_to_end(&mut buf)?;
+        let metadata = match std::fs::metadata(path) {
+            Ok(m) => m,
+            Err(_) => return Ok(None),
+        };
         Ok(Some(ObjectAttributes {
-            size: buf.len() as u64,
+            size: metadata.len(),
         }))
     }
 


### PR DESCRIPTION
## Summary

Fixes #435 — RAM grows with each `convex export --include-file-storage` and is never reclaimed.

Two fixes targeting the export code path:

- **Unregister `_file_storage` from `MultiTableIterator` after export** (`export_storage.rs`). User tables correctly call `unregister_table` after writing, but the storage table path skipped this, leaving `buffered_documents` entries permanently allocated.

- **Use `std::fs::metadata()` instead of `File::read_to_end()` in `LocalDirStorage::get_fq_object_attributes`** (`lib.rs`). The previous implementation read the entire file contents into a `Vec<u8>` just to return `buf.len() as u64` — every blob was fully loaded into memory solely to measure its size. This caused massive allocation churn and jemalloc arena fragmentation that prevented memory from being returned to the OS.

## Test plan

- [x] `cargo check -p storage -p exports` passes
- [x] Run existing export tests
- [x] Self-hosted: run `convex export --include-file-storage` multiple times and verify RSS does not grow between exports

🤖 Generated with [Claude Code](https://claude.com/claude-code)