### PR TITLE
Fix `convex dev --start` exiting before cleanup finishes on Ctrl+C

### DIFF
--- a/npm-packages/convex/src/cli/dev.ts
+++ b/npm-packages/convex/src/cli/dev.ts
@@ -179,9 +179,25 @@ Same format as .env.local or .env files, and overrides them.`,
   .showHelpAfterError()
   .action(async (cmdOptions) => {
     const ctx = await oneoffContext(cmdOptions);
+    const duplicateSigintGraceMs = 500;
+    let cleanupStartTime: number | null = null;
     process.on("SIGINT", async () => {
+      if (cleanupStartTime !== null) {
+        // `bun run <script>` can deliver an immediate duplicate SIGINT while the
+        // first handler is starting cleanup. Ignore that short-window signal, but
+        // keep a later Ctrl+C as a force-exit escape hatch.
+        if (Date.now() - cleanupStartTime < duplicateSigintGraceMs) {
+          logVerbose(
+            "Received SIGINT during cleanup, ignoring duplicate signal...",
+          );
+          return;
+        }
+        logVerbose("Received SIGINT during cleanup, exiting immediately...");
+        process.exit(130);
+      }
+      cleanupStartTime = Date.now();
       logVerbose("Received SIGINT, cleaning up...");
-      await ctx.flushAndExit(-2);
+      await ctx.flushAndExit(130);
     });
 
     if (cmdOptions.deployment !== undefined) {

--- a/npm-packages/convex/src/cli/init.ts
+++ b/npm-packages/convex/src/cli/init.ts
@@ -21,9 +21,25 @@ export const init = new Command("init")
       adminKey: undefined,
       envFile: undefined,
     });
+    const duplicateSigintGraceMs = 500;
+    let cleanupStartTime: number | null = null;
     process.on("SIGINT", async () => {
+      if (cleanupStartTime !== null) {
+        // `bun run <script>` can deliver an immediate duplicate SIGINT while the
+        // first handler is starting cleanup. Ignore that short-window signal, but
+        // keep a later Ctrl+C as a force-exit escape hatch.
+        if (Date.now() - cleanupStartTime < duplicateSigintGraceMs) {
+          logVerbose(
+            "Received SIGINT during cleanup, ignoring duplicate signal...",
+          );
+          return;
+        }
+        logVerbose("Received SIGINT during cleanup, exiting immediately...");
+        process.exit(130);
+      }
+      cleanupStartTime = Date.now();
       logVerbose("Received SIGINT, cleaning up...");
-      await ctx.flushAndExit(-2);
+      await ctx.flushAndExit(130);
     });
 
     const deploymentSelection = await getDeploymentSelection(ctx, {});

--- a/npm-packages/convex/src/cli/lib/dev.ts
+++ b/npm-packages/convex/src/cli/lib/dev.ts
@@ -140,6 +140,7 @@ export async function watchAndPush(
   let shellChild: ChildProcess | undefined;
   let shellExited: Promise<void> | undefined;
   let shellCleanupHandle: string | undefined;
+  let shellSigintListener: (() => void) | undefined;
   let tableNameTriggeringRetry;
   let shouldRetryOnDeploymentEnvVarChange;
   let isFirstPush = true; // Track if this is the first push in the session
@@ -210,32 +211,47 @@ export async function watchAndPush(
               // piping stdin/stdout/stderr. It runs alongside dev and is
               // waited on during clean exit or killed on signal exit.
               const shellCommand = cmdOptions.run.command;
+              const signalShellChild = (signal: NodeJS.Signals) => {
+                if (!shellChild) {
+                  return;
+                }
+                const child = shellChild;
+                // Kill the entire process group so children of the shell
+                // are also killed.
+                if (child.pid !== undefined) {
+                  try {
+                    process.kill(-child.pid, signal);
+                  } catch {
+                    // Process group may already be dead.
+                    child.kill(signal);
+                  }
+                } else {
+                  child.kill(signal);
+                }
+              };
+              const clearShellSigintListener = () => {
+                if (shellSigintListener) {
+                  process.off("SIGINT", shellSigintListener);
+                  shellSigintListener = undefined;
+                }
+              };
               shellChild = spawn(shellCommand, [], {
                 shell: true,
                 stdio: "inherit",
                 detached: true,
               });
+              shellSigintListener = () => {
+                signalShellChild("SIGINT");
+              };
+              process.prependListener("SIGINT", shellSigintListener);
               shellCleanupHandle = outerCtx.registerCleanup(async () => {
-                if (shellChild) {
-                  const child = shellChild;
-                  shellChild = undefined;
-                  // Kill the entire process group so children of the shell
-                  // are also killed.
-                  if (child.pid !== undefined) {
-                    try {
-                      process.kill(-child.pid, "SIGTERM");
-                    } catch {
-                      // Process group may already be dead.
-                      child.kill();
-                    }
-                  } else {
-                    child.kill();
-                  }
-                }
+                clearShellSigintListener();
+                signalShellChild("SIGTERM");
                 await shellExited;
               });
               shellExited = new Promise<void>((resolve) => {
                 shellChild!.on("error", (error) => {
+                  clearShellSigintListener();
                   logError(
                     `Failed to run command \`${shellCommand}\`: ${error.message}`,
                   );
@@ -244,6 +260,7 @@ export async function watchAndPush(
                   void outerCtx.flushAndExit(1);
                 });
                 shellChild!.on("exit", (code, signal) => {
+                  clearShellSigintListener();
                   shellChild = undefined;
                   resolve();
                   // If killed by a signal (e.g. from cleanup on shutdown),
@@ -360,6 +377,10 @@ export async function watchAndPush(
     // On clean exit (e.g. --once, --until-success), wait for the shell
     // command to finish naturally. On signal exit (e.g. Ctrl+C), the
     // registered cleanup handler will have already killed it.
+    if (shellSigintListener) {
+      process.off("SIGINT", shellSigintListener);
+      shellSigintListener = undefined;
+    }
     if (shellExited) {
       await shellExited;
     }


### PR DESCRIPTION
## Summary
- forward `SIGINT` immediately to detached `--start` commands so sidecar shutdown begins as soon as `convex dev` receives `Ctrl+C`
- keep the cleanup-time `SIGTERM` fallback for `--start` commands that do not exit promptly on `SIGINT`
- use the standard `130` exit code for `convex dev` and `convex init`, and ignore Bun's immediate duplicate `SIGINT` while preserving a later `Ctrl+C` force-exit path

Closes #441.

## Testing
- `pnpm exec eslint src/cli/lib/dev.ts src/cli/dev.ts src/cli/init.ts`
- `node common/scripts/install-run-rush.js build -t convex`
- `bun run dev` from `farmio-kokopilot` with `"dev": "convex dev --start 'next dev --turbopack'"`
- press `Ctrl+C` and confirm both Convex and Next.js stop cleanly
- `bunx convex dev --start 'next dev --turbopack'` still shuts down correctly

https://github.com/user-attachments/assets/b8749dee-009e-4ecd-9b5f-357601764f5a

## Disclosure
- This change was prepared with assistance from GPT-5.4-xhigh and behaviors reviewed and verified by me.