### PR TITLE
feat: Add generic invocation metadata to function calls and ctx.meta

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,8 @@
+{
+  "permissions": {
+    "allow": [
+      "Skill(pr-review-toolkit:review-pr)",
+      "Skill(pr-review-toolkit:review-pr:*)"
+    ]
+  }
+}

--- a/crates/application/src/api.rs
+++ b/crates/application/src/api.rs
@@ -57,6 +57,7 @@ use udf::{
 };
 use value::{
     sha256::Sha256Digest,
+    ConvexObject,
     DeveloperDocumentId,
 };
 
@@ -102,6 +103,7 @@ pub trait ApplicationApi: Send + Sync {
         path: ExportPath,
         args: SerializedArgs,
         caller: FunctionCaller,
+        invocation_metadata: Option<ConvexObject>,
         ts: ExecuteQueryTimestamp,
         journal: Option<SerializedQueryJournal>,
     ) -> anyhow::Result<RedactedQueryReturn>;
@@ -117,6 +119,7 @@ pub trait ApplicationApi: Send + Sync {
         path: CanonicalizedComponentFunctionPath,
         args: SerializedArgs,
         caller: FunctionCaller,
+        invocation_metadata: Option<ConvexObject>,
         ts: ExecuteQueryTimestamp,
         journal: Option<SerializedQueryJournal>,
     ) -> anyhow::Result<RedactedQueryReturn>;
@@ -130,6 +133,7 @@ pub trait ApplicationApi: Send + Sync {
         path: ExportPath,
         args: SerializedArgs,
         caller: FunctionCaller,
+        invocation_metadata: Option<ConvexObject>,
         // Identifier used to make this mutation idempotent.
         mutation_identifier: Option<SessionRequestIdentifier>,
         // The length of the mutation queue at the time the mutation was executed.
@@ -145,6 +149,7 @@ pub trait ApplicationApi: Send + Sync {
         path: CanonicalizedComponentFunctionPath,
         args: SerializedArgs,
         caller: FunctionCaller,
+        invocation_metadata: Option<ConvexObject>,
         mutation_identifier: Option<SessionRequestIdentifier>,
         // The length of the mutation queue at the time the mutation was executed.
         mutation_queue_length: Option<usize>,
@@ -159,6 +164,7 @@ pub trait ApplicationApi: Send + Sync {
         path: ExportPath,
         args: SerializedArgs,
         caller: FunctionCaller,
+        invocation_metadata: Option<ConvexObject>,
     ) -> anyhow::Result<Result<RedactedActionReturn, RedactedActionError>>;
 
     /// Execute an admin action for a particular component for the dashboard.
@@ -170,6 +176,7 @@ pub trait ApplicationApi: Send + Sync {
         path: CanonicalizedComponentFunctionPath,
         args: SerializedArgs,
         caller: FunctionCaller,
+        invocation_metadata: Option<ConvexObject>,
     ) -> anyhow::Result<Result<RedactedActionReturn, RedactedActionError>>;
 
     /// Execute an HTTP action on the root app.
@@ -194,6 +201,7 @@ pub trait ApplicationApi: Send + Sync {
         path: CanonicalizedComponentFunctionPath,
         args: SerializedArgs,
         caller: FunctionCaller,
+        invocation_metadata: Option<ConvexObject>,
     ) -> anyhow::Result<Result<FunctionReturn, FunctionError>>;
 
     async fn latest_timestamp(
@@ -278,6 +286,7 @@ impl<RT: Runtime> ApplicationApi for Application<RT> {
         path: ExportPath,
         args: SerializedArgs,
         caller: FunctionCaller,
+        invocation_metadata: Option<ConvexObject>,
         ts: ExecuteQueryTimestamp,
         journal: Option<SerializedQueryJournal>,
     ) -> anyhow::Result<RedactedQueryReturn> {
@@ -297,6 +306,7 @@ impl<RT: Runtime> ApplicationApi for Application<RT> {
             ts,
             journal,
             caller,
+            invocation_metadata,
         )
         .await
     }
@@ -309,6 +319,7 @@ impl<RT: Runtime> ApplicationApi for Application<RT> {
         path: CanonicalizedComponentFunctionPath,
         args: SerializedArgs,
         caller: FunctionCaller,
+        invocation_metadata: Option<ConvexObject>,
         ts: ExecuteQueryTimestamp,
         journal: Option<SerializedQueryJournal>,
     ) -> anyhow::Result<RedactedQueryReturn> {
@@ -328,6 +339,7 @@ impl<RT: Runtime> ApplicationApi for Application<RT> {
             ts,
             journal,
             caller,
+            invocation_metadata,
         )
         .await
     }
@@ -340,6 +352,7 @@ impl<RT: Runtime> ApplicationApi for Application<RT> {
         path: ExportPath,
         args: SerializedArgs,
         caller: FunctionCaller,
+        invocation_metadata: Option<ConvexObject>,
         // Identifier used to make this mutation idempotent.
         mutation_identifier: Option<SessionRequestIdentifier>,
         mutation_queue_length: Option<usize>,
@@ -356,6 +369,7 @@ impl<RT: Runtime> ApplicationApi for Application<RT> {
             mutation_identifier,
             caller,
             mutation_queue_length,
+            invocation_metadata,
         )
         .await
     }
@@ -368,6 +382,7 @@ impl<RT: Runtime> ApplicationApi for Application<RT> {
         path: CanonicalizedComponentFunctionPath,
         args: SerializedArgs,
         caller: FunctionCaller,
+        invocation_metadata: Option<ConvexObject>,
         mutation_identifier: Option<SessionRequestIdentifier>,
         mutation_queue_length: Option<usize>,
     ) -> anyhow::Result<Result<RedactedMutationReturn, RedactedMutationError>> {
@@ -383,6 +398,7 @@ impl<RT: Runtime> ApplicationApi for Application<RT> {
             mutation_identifier,
             caller,
             mutation_queue_length,
+            invocation_metadata,
         )
         .await
     }
@@ -395,6 +411,7 @@ impl<RT: Runtime> ApplicationApi for Application<RT> {
         path: ExportPath,
         args: SerializedArgs,
         caller: FunctionCaller,
+        invocation_metadata: Option<ConvexObject>,
     ) -> anyhow::Result<Result<RedactedActionReturn, RedactedActionError>> {
         anyhow::ensure!(
             caller.allowed_visibility() == AllowedVisibility::PublicOnly,
@@ -406,6 +423,7 @@ impl<RT: Runtime> ApplicationApi for Application<RT> {
             args,
             identity,
             caller,
+            invocation_metadata,
         )
         .await
     }
@@ -418,6 +436,7 @@ impl<RT: Runtime> ApplicationApi for Application<RT> {
         path: CanonicalizedComponentFunctionPath,
         args: SerializedArgs,
         caller: FunctionCaller,
+        invocation_metadata: Option<ConvexObject>,
     ) -> anyhow::Result<Result<RedactedActionReturn, RedactedActionError>> {
         anyhow::ensure!(
             path.component.is_root() || identity.is_admin() || identity.is_system(),
@@ -429,6 +448,7 @@ impl<RT: Runtime> ApplicationApi for Application<RT> {
             args,
             identity,
             caller,
+            invocation_metadata,
         )
         .await
     }
@@ -441,12 +461,14 @@ impl<RT: Runtime> ApplicationApi for Application<RT> {
         path: CanonicalizedComponentFunctionPath,
         args: SerializedArgs,
         caller: FunctionCaller,
+        invocation_metadata: Option<ConvexObject>,
     ) -> anyhow::Result<Result<FunctionReturn, FunctionError>> {
         anyhow::ensure!(
             path.component.is_root() || identity.is_admin() || identity.is_system(),
             "Only admin or system users can call functions on non-root components directly"
         );
-        self.any_udf(request_id, path, args, identity, caller).await
+        self.any_udf(request_id, path, args, identity, caller, invocation_metadata)
+            .await
     }
 
     async fn latest_timestamp(

--- a/crates/application/src/application_function_runner/mod.rs
+++ b/crates/application/src/application_function_runner/mod.rs
@@ -188,6 +188,7 @@ use value::{
     id_v6::DeveloperDocumentId,
     identifier::Identifier,
     serialized_args_ext::SerializedArgsExt,
+    ConvexObject,
     JsonPackedValue,
     Size as _,
     TableNamespace,
@@ -698,6 +699,7 @@ impl<RT: Runtime> ApplicationFunctionRunner<RT> {
         path: CanonicalizedComponentFunctionPath,
         arguments: SerializedArgs,
         caller: FunctionCaller,
+        invocation_metadata: Option<ConvexObject>,
     ) -> anyhow::Result<(Result<JsonPackedValue, JsError>, LogLines)> {
         if !(tx.identity().is_admin() || tx.identity().is_system()) {
             anyhow::bail!(unauthorized_error("query_without_caching"));
@@ -713,7 +715,7 @@ impl<RT: Runtime> ApplicationFunctionRunner<RT> {
             UdfType::Query,
         )
         .await?;
-        let context = ExecutionContext::new(request_id, &caller);
+        let context = ExecutionContext::new_with_metadata(request_id, &caller, invocation_metadata);
         let (mut tx, outcome) = match validate_result {
             Ok(path_and_args) => {
                 self.isolate_functions
@@ -772,6 +774,7 @@ impl<RT: Runtime> ApplicationFunctionRunner<RT> {
         mutation_identifier: Option<SessionRequestIdentifier>,
         caller: FunctionCaller,
         mutation_queue_length: Option<usize>,
+        invocation_metadata: Option<ConvexObject>,
     ) -> anyhow::Result<Result<MutationReturn, MutationError>> {
         let timer = mutation_timer();
         let result = self
@@ -783,6 +786,7 @@ impl<RT: Runtime> ApplicationFunctionRunner<RT> {
                 mutation_identifier,
                 caller,
                 mutation_queue_length,
+                invocation_metadata,
             )
             .await;
         match &result {
@@ -803,6 +807,7 @@ impl<RT: Runtime> ApplicationFunctionRunner<RT> {
         mutation_identifier: Option<SessionRequestIdentifier>,
         caller: FunctionCaller,
         mutation_queue_length: Option<usize>,
+        invocation_metadata: Option<ConvexObject>,
     ) -> anyhow::Result<Result<MutationReturn, MutationError>> {
         if path.is_system() && !(identity.is_admin() || identity.is_system()) {
             anyhow::bail!(unauthorized_error("mutation"));
@@ -827,7 +832,11 @@ impl<RT: Runtime> ApplicationFunctionRunner<RT> {
 
             // Note that we use different context for every mutation attempt.
             // This so every JS function run gets a different executionId.
-            let context = ExecutionContext::new(request_id.clone(), &caller);
+            let context = ExecutionContext::new_with_metadata(
+                request_id.clone(),
+                &caller,
+                invocation_metadata.clone(),
+            );
 
             let start = self.runtime.monotonic_now();
             let mut tx = self
@@ -1145,11 +1154,16 @@ impl<RT: Runtime> ApplicationFunctionRunner<RT> {
         arguments: SerializedArgs,
         identity: Identity,
         caller: FunctionCaller,
+        invocation_metadata: Option<ConvexObject>,
     ) -> anyhow::Result<Result<ActionReturn, ActionError>> {
         if path.is_system() && !(identity.is_admin() || identity.is_system()) {
             anyhow::bail!(unauthorized_error("action"));
         }
-        let context = ExecutionContext::new(request_id.clone(), &caller);
+        let context = ExecutionContext::new_with_metadata(
+            request_id.clone(),
+            &caller,
+            invocation_metadata,
+        );
         let usage_tracking = FunctionUsageTracker::new();
         let start = self.runtime.monotonic_now();
         let completion_result = self
@@ -1811,9 +1825,19 @@ impl<RT: Runtime> ApplicationFunctionRunner<RT> {
         ts: Timestamp,
         journal: Option<QueryJournal>,
         caller: FunctionCaller,
+        invocation_metadata: Option<ConvexObject>,
     ) -> anyhow::Result<QueryReturn> {
         let result = self
-            .run_query_at_ts_inner(request_id, path, args, identity, ts, journal, caller)
+            .run_query_at_ts_inner(
+                request_id,
+                path,
+                args,
+                identity,
+                ts,
+                journal,
+                caller,
+                invocation_metadata,
+            )
             .await;
         match result.as_ref() {
             Ok(udf_outcome) => {
@@ -1844,12 +1868,17 @@ impl<RT: Runtime> ApplicationFunctionRunner<RT> {
         ts: Timestamp,
         journal: Option<QueryJournal>,
         caller: FunctionCaller,
+        invocation_metadata: Option<ConvexObject>,
     ) -> anyhow::Result<QueryReturn> {
         if path.is_system() && !(identity.is_admin() || identity.is_system()) {
             anyhow::bail!(unauthorized_error("query"));
         }
         let start = self.runtime.monotonic_now();
-        let context = ExecutionContext::new(request_id.clone(), &caller);
+        let context = ExecutionContext::new_with_metadata(
+            request_id.clone(),
+            &caller,
+            invocation_metadata,
+        );
         let usage_tracker = FunctionUsageTracker::new();
         let result = self
             .cache_manager
@@ -1980,6 +2009,7 @@ impl<RT: Runtime> ActionCallbacks for ApplicationFunctionRunner<RT> {
                     parent_scheduled_job: context.parent_scheduled_job,
                     parent_execution_id: Some(context.execution_id),
                 },
+                context.invocation_metadata.clone(),
             )
             .await?
             .result;
@@ -2006,6 +2036,7 @@ impl<RT: Runtime> ActionCallbacks for ApplicationFunctionRunner<RT> {
                     parent_execution_id: Some(context.execution_id),
                 },
                 None,
+                context.invocation_metadata.clone(),
             )
             .await
             .map(|r| match r {
@@ -2034,6 +2065,7 @@ impl<RT: Runtime> ActionCallbacks for ApplicationFunctionRunner<RT> {
                     parent_scheduled_job: context.parent_scheduled_job,
                     parent_execution_id: Some(context.execution_id),
                 },
+                context.invocation_metadata.clone(),
             )
             .await
             .map(|r| match r {

--- a/crates/application/src/cron_jobs/mod.rs
+++ b/crates/application/src/cron_jobs/mod.rs
@@ -666,6 +666,7 @@ impl<RT: Runtime> CronJobContext<RT> {
                     execution_id.unwrap_or_else(ExecutionId::new),
                     caller.parent_scheduled_job(),
                     caller.is_root(),
+                    None,
                 );
                 sentry::configure_scope(|scope| context.add_sentry_tags(scope));
                 let mut model = CronModel::new(&mut tx, component);

--- a/crates/application/src/lib.rs
+++ b/crates/application/src/lib.rs
@@ -358,6 +358,7 @@ use usage_tracking::{
     UsageCounter,
 };
 use value::{
+    ConvexObject,
     id_v6::DeveloperDocumentId,
     sha256::Sha256Digest,
     JsonPackedValue,
@@ -1026,10 +1027,20 @@ impl<RT: Runtime> Application<RT> {
         args: SerializedArgs,
         identity: Identity,
         caller: FunctionCaller,
+        invocation_metadata: Option<ConvexObject>,
     ) -> anyhow::Result<RedactedQueryReturn> {
         let ts = *self.now_ts_for_reads();
-        self.read_only_udf_at_ts(request_id, path, args, identity, ts, None, caller)
-            .await
+        self.read_only_udf_at_ts(
+            request_id,
+            path,
+            args,
+            identity,
+            ts,
+            None,
+            caller,
+            invocation_metadata,
+        )
+        .await
     }
 
     #[fastrace::trace]
@@ -1042,6 +1053,7 @@ impl<RT: Runtime> Application<RT> {
         ts: Timestamp,
         journal: Option<Option<String>>,
         caller: FunctionCaller,
+        invocation_metadata: Option<ConvexObject>,
     ) -> anyhow::Result<RedactedQueryReturn> {
         let persistence_version = self.database.persistence_version();
         let block_logging = self
@@ -1065,12 +1077,13 @@ impl<RT: Runtime> Application<RT> {
                     request_id.clone(),
                     path,
                     args,
-                    identity,
-                    ts,
-                    journal,
-                    caller,
-                )
-                .await?
+                identity,
+                ts,
+                journal,
+                caller,
+                invocation_metadata,
+            )
+            .await?
         });
 
         let redacted_query_return = match query_return {
@@ -1115,6 +1128,7 @@ impl<RT: Runtime> Application<RT> {
         mutation_identifier: Option<SessionRequestIdentifier>,
         caller: FunctionCaller,
         mutation_queue_length: Option<usize>,
+        invocation_metadata: Option<ConvexObject>,
     ) -> anyhow::Result<Result<RedactedMutationReturn, RedactedMutationError>> {
         let block_logging = self
             .log_visibility
@@ -1134,6 +1148,7 @@ impl<RT: Runtime> Application<RT> {
                 mutation_identifier,
                 caller,
                 mutation_queue_length,
+                invocation_metadata,
             )
             .await
         {
@@ -1177,6 +1192,7 @@ impl<RT: Runtime> Application<RT> {
         args: SerializedArgs,
         identity: Identity,
         caller: FunctionCaller,
+        invocation_metadata: Option<ConvexObject>,
     ) -> anyhow::Result<Result<RedactedActionReturn, RedactedActionError>> {
         let block_logging = self
             .log_visibility
@@ -1195,7 +1211,14 @@ impl<RT: Runtime> Application<RT> {
             .unwrap_or(Span::noop());
         let run_action = async move {
             runner
-                .run_action(request_id_, name, args, identity, caller)
+                .run_action(
+                    request_id_,
+                    name,
+                    args,
+                    identity,
+                    caller,
+                    invocation_metadata,
+                )
                 .in_span(span)
                 .await
         };
@@ -1307,6 +1330,7 @@ impl<RT: Runtime> Application<RT> {
         args: SerializedArgs,
         identity: Identity,
         caller: FunctionCaller,
+        invocation_metadata: Option<ConvexObject>,
     ) -> anyhow::Result<Result<FunctionReturn, FunctionError>> {
         let block_logging = self
             .log_visibility
@@ -1357,6 +1381,7 @@ impl<RT: Runtime> Application<RT> {
                     args,
                     identity,
                     caller,
+                    invocation_metadata,
                 )
                 .await
                 .map(
@@ -1378,6 +1403,7 @@ impl<RT: Runtime> Application<RT> {
                     None,
                     caller,
                     None,
+                    invocation_metadata,
                 )
                 .await
                 .map(|res| {
@@ -1399,6 +1425,7 @@ impl<RT: Runtime> Application<RT> {
                     args,
                     identity,
                     caller,
+                    invocation_metadata,
                 )
                 .await
                 .map(|res| {
@@ -2500,7 +2527,7 @@ impl<RT: Runtime> Application<RT> {
         let (result, log_lines) = match analyzed_function.udf_type {
             UdfType::Query => {
                 self.runner
-                    .run_query_without_caching(request_id.clone(), tx, path, args, caller)
+                    .run_query_without_caching(request_id.clone(), tx, path, args, caller, None)
                     .await
             },
             UdfType::Mutation => {

--- a/crates/application/src/scheduled_jobs/mod.rs
+++ b/crates/application/src/scheduled_jobs/mod.rs
@@ -953,6 +953,7 @@ impl<RT: Runtime> ScheduledJobContext<RT> {
                     (*execution_id).unwrap_or_else(ExecutionId::new),
                     caller.parent_scheduled_job(),
                     caller.is_root(),
+                    None,
                 );
                 sentry::configure_scope(|scope| context.add_sentry_tags(scope));
                 let path = job.path.clone();

--- a/crates/common/src/execution_context.rs
+++ b/crates/common/src/execution_context.rs
@@ -17,6 +17,10 @@ use value::{
     heap_size::HeapSize,
     id_v6::DeveloperDocumentId,
     sha256,
+    ConvexObject,
+    ConvexValue,
+    JsonPackedValue,
+    Size,
 };
 
 use crate::{
@@ -38,15 +42,25 @@ pub struct ExecutionContext {
     /// version of this would be something like parent_execution_id:
     /// Option<ExecutionId>
     is_root: bool,
+    pub invocation_metadata: Option<ConvexObject>,
 }
 
 impl ExecutionContext {
     pub fn new(request_id: RequestId, caller: &FunctionCaller) -> Self {
+        Self::new_with_metadata(request_id, caller, None)
+    }
+
+    pub fn new_with_metadata(
+        request_id: RequestId,
+        caller: &FunctionCaller,
+        invocation_metadata: Option<ConvexObject>,
+    ) -> Self {
         Self {
             request_id,
             execution_id: ExecutionId::new(),
             parent_scheduled_job: caller.parent_scheduled_job(),
             is_root: caller.is_root(),
+            invocation_metadata,
         }
     }
 
@@ -55,17 +69,26 @@ impl ExecutionContext {
         execution_id: ExecutionId,
         parent_scheduled_job: Option<(ComponentId, DeveloperDocumentId)>,
         is_root: bool,
+        invocation_metadata: Option<ConvexObject>,
     ) -> Self {
         Self {
             request_id,
             execution_id,
             parent_scheduled_job,
             is_root,
+            invocation_metadata,
         }
     }
 
     pub fn is_root(&self) -> bool {
         self.is_root
+    }
+
+    pub fn merged_invocation_metadata(
+        &self,
+        invocation_metadata: Option<ConvexObject>,
+    ) -> Option<ConvexObject> {
+        merge_invocation_metadata(self.invocation_metadata.clone(), invocation_metadata)
     }
 
     pub fn add_sentry_tags(&self, scope: &mut sentry::Scope) {
@@ -82,6 +105,28 @@ impl HeapSize for ExecutionContext {
                 .parent_scheduled_job
                 .map_or(0, |(_, document_id)| document_id.heap_size())
             + self.is_root.heap_size()
+            + self.invocation_metadata.as_ref().map_or(0, |metadata| {
+                metadata
+                    .iter()
+                    .map(|(field_name, value)| field_name.heap_size() + value.size())
+                    .sum::<usize>()
+            })
+    }
+}
+
+fn merge_invocation_metadata(
+    parent: Option<ConvexObject>,
+    override_metadata: Option<ConvexObject>,
+) -> Option<ConvexObject> {
+    match (parent, override_metadata) {
+        (None, None) => None,
+        (Some(parent), None) => Some(parent),
+        (None, Some(override_metadata)) => Some(override_metadata),
+        (Some(parent), Some(override_metadata)) => Some(
+            parent
+                .shallow_merge(override_metadata)
+                .expect("Invocation metadata should always shallow-merge"),
+        ),
     }
 }
 
@@ -188,6 +233,13 @@ impl From<ExecutionContext> for pb::common::ExecutionContext {
                 .and_then(|id| id.serialize_to_string()),
             parent_scheduled_job: parent_document_id.map(Into::into),
             is_root: Some(value.is_root),
+            invocation_metadata_json_packed_value: value
+                .invocation_metadata
+                .map(|metadata| {
+                    JsonPackedValue::pack(ConvexValue::Object(metadata))
+                        .as_str()
+                        .to_owned()
+                }),
         }
     }
 }
@@ -208,6 +260,14 @@ impl TryFrom<pb::common::ExecutionContext> for ExecutionContext {
             },
             parent_scheduled_job: parent_document_id.map(|id| (parent_component_id, id)),
             is_root: value.is_root.unwrap_or_default(),
+            invocation_metadata: value
+                .invocation_metadata_json_packed_value
+                .map(JsonPackedValue::from_network)
+                .transpose()?
+                .map(|metadata| metadata.unpack())
+                .transpose()?
+                .map(ConvexObject::try_from)
+                .transpose()?,
         })
     }
 }
@@ -221,6 +281,80 @@ impl From<ExecutionContext> for JsonValue {
             "isRoot": value.is_root,
             "parentScheduledJob": parent_document_id.map(|id| id.to_string()),
             "parentScheduledJobComponentId": parent_component_id.unwrap_or(ComponentId::Root).serialize_to_string(),
+            "invocationMetadata": value.invocation_metadata.map(JsonValue::from),
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::str::FromStr;
+
+    use serde_json::json;
+    use value::{
+        ConvexObject,
+        ConvexValue,
+    };
+
+    use super::{
+        ExecutionContext,
+        ExecutionId,
+        JsonValue,
+        RequestId,
+    };
+
+    fn convex_object(value: JsonValue) -> ConvexObject {
+        ConvexObject::try_from(ConvexValue::try_from(value).unwrap()).unwrap()
+    }
+
+    #[test]
+    fn merged_invocation_metadata_shallow_overrides_top_level_keys() {
+        let context = ExecutionContext::new_from_parts(
+            RequestId::from_str("request-123").unwrap(),
+            ExecutionId::from_str("f4e8dbe9-071f-430f-8e76-2fda4b529d15").unwrap(),
+            None,
+            true,
+            Some(convex_object(json!({
+                "correlationId": "corr_123",
+                "origin": "nuxt",
+            }))),
+        );
+
+        let merged = context
+            .merged_invocation_metadata(Some(convex_object(json!({
+                "origin": "mcp",
+                "phase": "draft",
+            }))))
+            .unwrap();
+
+        assert_eq!(
+            JsonValue::from(ConvexValue::Object(merged)),
+            json!({
+                "correlationId": "corr_123",
+                "origin": "mcp",
+                "phase": "draft",
+            }),
+        );
+    }
+
+    #[test]
+    fn execution_context_proto_round_trips_invocation_metadata() {
+        let context = ExecutionContext::new_from_parts(
+            RequestId::from_str("request-456").unwrap(),
+            ExecutionId::from_str("56ef8d74-2681-46a4-8b11-a86fcdbdb51e").unwrap(),
+            None,
+            false,
+            Some(convex_object(json!({
+                "correlationId": "corr_456",
+                "origin": "browser",
+                "tenantHint": "acme",
+            }))),
+        );
+
+        let round_tripped =
+            ExecutionContext::try_from(pb::common::ExecutionContext::from(context.clone()))
+                .unwrap();
+
+        assert_eq!(round_tripped, context);
     }
 }

--- a/crates/isolate/src/environment/udf/async_syscall.rs
+++ b/crates/isolate/src/environment/udf/async_syscall.rs
@@ -387,6 +387,7 @@ pub trait AsyncSyscallProvider<RT: Runtime>: Sized {
         udf_type: NestedUdfType,
         path: ResolvedComponentFunctionPath,
         args: ConvexObject,
+        invocation_metadata: Option<ConvexObject>,
         udf_callback: impl UdfCallback<RT>,
     ) -> anyhow::Result<ConvexValue>;
 
@@ -550,6 +551,7 @@ impl<RT: Runtime> AsyncSyscallProvider<RT> for DatabaseUdfEnvironment<RT> {
         nested_udf_type: NestedUdfType,
         path: ResolvedComponentFunctionPath,
         args: ConvexObject,
+        invocation_metadata: Option<ConvexObject>,
         udf_callback: impl UdfCallback<RT>,
     ) -> anyhow::Result<ConvexValue> {
         match (self.udf_type, nested_udf_type) {
@@ -625,7 +627,13 @@ impl<RT: Runtime> AsyncSyscallProvider<RT> for DatabaseUdfEnvironment<RT> {
                     transaction: nested_tx,
                     unix_timestamp,
                     journal: query_journal,
-                    context: self.context.clone(),
+                    context: ExecutionContext::new_from_parts(
+                        self.context.request_id.clone(),
+                        self.context.execution_id,
+                        self.context.parent_scheduled_job.clone(),
+                        self.context.is_root(),
+                        self.context.merged_invocation_metadata(invocation_metadata),
+                    ),
                 },
                 EnvironmentData {
                     key_broker: self.key_broker.clone(),
@@ -777,6 +785,7 @@ impl<RT: Runtime, P: AsyncSyscallProvider<RT>> DatabaseSyscallsV1<RT, P> {
                     "1.0/queryPage" => Box::pin(Self::query_page(provider, args)).await,
                     "1.0/getTransactionMetrics" => Self::tx_metrics(provider),
                     "1.0/getFunctionMetadata" => Self::function_metadata(provider),
+                    "1.0/getInvocationContext" => Self::invocation_context(provider),
                     // Auth
                     "1.0/getUserIdentity" => {
                         Box::pin(Self::get_user_identity(provider, args)).await
@@ -850,6 +859,18 @@ impl<RT: Runtime, P: AsyncSyscallProvider<RT>> DatabaseSyscallsV1<RT, P> {
         Ok(json!({
             "name": udf_path.clone().strip().to_string(),
             "componentPath": component_path.to_string(),
+        }))
+    }
+
+    fn invocation_context(provider: &mut P) -> anyhow::Result<JsonValue> {
+        let context = provider.context();
+        Ok(json!({
+            "requestId": context.request_id.to_string(),
+            "executionId": context.execution_id.to_string(),
+            "isRoot": context.is_root(),
+            "parentScheduledJob": context.parent_scheduled_job.as_ref().map(|(_, job_id)| job_id.to_string()),
+            "parentScheduledJobComponentId": context.parent_scheduled_job.as_ref().and_then(|(component_id, _)| component_id.serialize_to_string()),
+            "metadata": context.invocation_metadata.clone().map(JsonValue::from),
         }))
     }
 
@@ -1424,6 +1445,7 @@ impl<RT: Runtime, P: AsyncSyscallProvider<RT>> DatabaseSyscallsV1<RT, P> {
             reference: Option<String>,
             function_handle: Option<String>,
             args: JsonValue,
+            metadata: Option<JsonValue>,
         }
         let RunUdfArgs {
             udf_type,
@@ -1431,14 +1453,24 @@ impl<RT: Runtime, P: AsyncSyscallProvider<RT>> DatabaseSyscallsV1<RT, P> {
             reference,
             function_handle,
             args,
+            metadata,
         } = with_argument_error("runUdf", || Ok(serde_json::from_value(args)?))?;
-        let (udf_type, args) = with_argument_error("runUdf", || {
+        let (udf_type, args, metadata) = with_argument_error("runUdf", || {
             let udf_type: NestedUdfType = udf_type.parse().context(ArgName("udfType"))?;
             let args: ConvexObject = ConvexValue::try_from(args)
                 .context(ArgName("args"))?
                 .try_into()
                 .context(ArgName("args"))?;
-            Ok((udf_type, args))
+            let metadata = match metadata {
+                Some(metadata) => Some(
+                    ConvexValue::try_from(metadata)
+                        .context(ArgName("metadata"))?
+                        .try_into()
+                        .context(ArgName("metadata"))?,
+                ),
+                None => None,
+            };
+            Ok((udf_type, args, metadata))
         })?;
         let path = match function_handle {
             Some(function_handle) => {
@@ -1478,7 +1510,9 @@ impl<RT: Runtime, P: AsyncSyscallProvider<RT>> DatabaseSyscallsV1<RT, P> {
                 }
             },
         };
-        let value = provider.run_udf(udf_type, path, args, udf_callback).await?;
+        let value = provider
+            .run_udf(udf_type, path, args, metadata, udf_callback)
+            .await?;
         Ok(value.into())
     }
 

--- a/crates/local_backend/src/args_structs.rs
+++ b/crates/local_backend/src/args_structs.rs
@@ -2,6 +2,7 @@ use common::components::ComponentPath;
 use isolate::UdfArgsJson;
 use keybroker::Identity;
 use serde::Deserialize;
+use serde_json::Value as JsonValue;
 use utoipa::ToSchema;
 
 use crate::admin::must_be_admin;
@@ -15,6 +16,8 @@ pub struct UdfPostRequestWithComponent {
     pub path: String,
     #[schema(value_type = Object)]
     pub args: UdfArgsJson,
+    #[schema(value_type = Option<Object>)]
+    pub metadata: Option<JsonValue>,
 
     pub format: Option<String>,
 }

--- a/crates/local_backend/src/node_action_callbacks.rs
+++ b/crates/local_backend/src/node_action_callbacks.rs
@@ -60,8 +60,11 @@ use sync_types::{
 use udf::ActionCallbacks;
 use usage_tracking::FunctionUsageTracker;
 use value::{
+    base64,
     export::ValueFormat,
     id_v6::DeveloperDocumentId,
+    ConvexObject,
+    ConvexValue,
 };
 use vector::{
     VectorSearch,
@@ -72,6 +75,7 @@ use crate::{
     authentication::ExtractAuthenticationToken,
     public_api::{
         export_value,
+        parse_invocation_metadata,
         UdfResponse,
     },
     LocalAppState,
@@ -84,6 +88,7 @@ pub struct NodeCallbackUdfPostRequest {
     pub reference: Option<String>,
     pub function_handle: Option<String>,
     pub args: UdfArgsJson,
+    pub metadata: Option<JsonValue>,
 
     pub format: Option<String>,
 }
@@ -113,6 +118,8 @@ pub async fn internal_query_post(
             req.function_handle,
         )
         .await?;
+    let invocation_metadata =
+        context.merged_invocation_metadata(parse_invocation_metadata(req.metadata)?);
     let udf_return = st
         .application
         .read_only_udf(
@@ -124,6 +131,7 @@ pub async fn internal_query_post(
                 parent_scheduled_job: context.parent_scheduled_job,
                 parent_execution_id: Some(context.execution_id),
             },
+            invocation_metadata,
         )
         .await?;
     if req.format.is_some() {
@@ -167,6 +175,8 @@ pub async fn internal_mutation_post(
             req.function_handle,
         )
         .await?;
+    let invocation_metadata =
+        context.merged_invocation_metadata(parse_invocation_metadata(req.metadata)?);
     let udf_result = st
         .application
         .mutation_udf(
@@ -180,6 +190,7 @@ pub async fn internal_mutation_post(
                 parent_execution_id: Some(context.execution_id),
             },
             None,
+            invocation_metadata,
         )
         .await?;
     if req.format.is_some() {
@@ -226,6 +237,8 @@ pub async fn internal_action_post(
             req.function_handle,
         )
         .await?;
+    let invocation_metadata =
+        context.merged_invocation_metadata(parse_invocation_metadata(req.metadata)?);
     let udf_result = st
         .application
         .action_udf(
@@ -237,6 +250,7 @@ pub async fn internal_action_post(
                 parent_scheduled_job: context.parent_scheduled_job,
                 parent_execution_id: Some(context.execution_id),
             },
+            invocation_metadata,
         )
         .await?;
     if req.format.is_some() {
@@ -677,6 +691,21 @@ impl<T: Sync> FromRequestParts<T> for ExtractExecutionContext {
             Some(v) => v.to_str().context("Convex-Root-Request must be a string")? == "true",
             None => false,
         };
+        let invocation_metadata = parts
+            .headers
+            .get("Convex-Invocation-Metadata")
+            .map(|v| v.to_str())
+            .transpose()
+            .context("Convex-Invocation-Metadata must be a string")?
+            .map(|metadata| {
+                let decoded = base64::decode_urlsafe(metadata)?;
+                let decoded = String::from_utf8(decoded)?;
+                let metadata: JsonValue = serde_json::from_str(&decoded)?;
+                let metadata = ConvexValue::try_from(metadata)?;
+                ConvexObject::try_from(metadata)
+            })
+            .transpose()
+            .context("Invalid Convex-Invocation-Metadata")?;
         let parent_job_id = parts
             .headers
             .get("Convex-Parent-Scheduled-Job")
@@ -701,6 +730,93 @@ impl<T: Sync> FromRequestParts<T> for ExtractExecutionContext {
             execution_id,
             parent_job_id.map(|id| (parent_component_id, id)),
             is_root,
+            invocation_metadata,
         )))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use axum::{
+        extract::FromRequestParts,
+        http::Request,
+    };
+    use common::{
+        execution_context::{
+            ExecutionContext,
+            ExecutionId,
+        },
+        RequestId,
+    };
+    use serde_json::json;
+    use value::{
+        base64,
+        ConvexObject,
+        ConvexValue,
+    };
+
+    use super::ExtractExecutionContext;
+
+    #[tokio::test]
+    async fn extract_execution_context_decodes_invocation_metadata_header() {
+        let request_id = RequestId::new();
+        let execution_id = ExecutionId::new();
+        let expected_metadata = json!({
+            "correlationId": "corr_123",
+            "origin": "nuxt",
+        });
+
+        let request = Request::builder()
+            .header("Convex-Request-Id", request_id.to_string())
+            .header("Convex-Execution-Id", execution_id.to_string())
+            .header("Convex-Root-Request", "true")
+            .header(
+                "Convex-Invocation-Metadata",
+                base64::encode_urlsafe(expected_metadata.to_string().as_bytes()),
+            )
+            .body(())
+            .unwrap();
+        let (mut parts, _) = request.into_parts();
+
+        let ExtractExecutionContext(context) =
+            ExtractExecutionContext::from_request_parts(&mut parts, &())
+                .await
+                .unwrap();
+
+        assert_eq!(
+            context,
+            ExecutionContext::new_from_parts(
+                request_id,
+                execution_id,
+                None,
+                true,
+                Some(
+                    ConvexObject::try_from(ConvexValue::try_from(expected_metadata).unwrap())
+                        .unwrap()
+                ),
+            )
+        );
+    }
+
+    #[tokio::test]
+    async fn extract_execution_context_rejects_invalid_invocation_metadata_header() {
+        let request = Request::builder()
+            .header(
+                "Convex-Invocation-Metadata",
+                base64::encode_urlsafe(json!("not-an-object").to_string().as_bytes()),
+            )
+            .body(())
+            .unwrap();
+        let (mut parts, _) = request.into_parts();
+
+        let result = ExtractExecutionContext::from_request_parts(&mut parts, &()).await;
+        let error = match result {
+            Ok(_) => panic!("expected invalid invocation metadata header to fail"),
+            Err(error) => anyhow::Error::from(error),
+        };
+
+        assert!(error
+            .to_string()
+            .contains("Invalid Convex-Invocation-Metadata"));
     }
 }

--- a/crates/local_backend/src/public_api.rs
+++ b/crates/local_backend/src/public_api.rs
@@ -46,6 +46,7 @@ use utoipa::ToSchema;
 use utoipa_axum::router::OpenApiRouter;
 use value::{
     export::ValueFormat,
+    ConvexObject,
     ConvexValue,
 };
 
@@ -65,6 +66,8 @@ pub struct UdfPostRequest {
     pub path: String,
     #[schema(value_type = Object)]
     pub args: UdfArgsJson,
+    #[schema(value_type = Option<Object>)]
+    pub metadata: Option<JsonValue>,
 
     pub format: Option<String>,
 }
@@ -82,6 +85,8 @@ pub struct UdfPostWithTsRequest {
     #[schema(value_type = Object)]
     pub args: UdfArgsJson,
     pub ts: SerializedTs,
+    #[schema(value_type = Option<Object>)]
+    pub metadata: Option<JsonValue>,
 
     pub format: Option<String>,
 }
@@ -234,6 +239,7 @@ pub async fn public_function_post(
             component_function_path,
             req.args.into_serialized_args()?,
             FunctionCaller::HttpApi(client_version.clone()),
+            parse_invocation_metadata(req.metadata)?,
         )
         .await?;
     let value_format = req.format.as_ref().map(|f| f.parse()).transpose()?;
@@ -256,7 +262,20 @@ pub async fn public_function_post(
 pub struct UdfPostRequestArgsOnly {
     #[schema(value_type = Object)]
     pub args: UdfArgsJson,
+    #[schema(value_type = Option<Object>)]
+    pub metadata: Option<JsonValue>,
     pub format: Option<String>,
+}
+
+pub(crate) fn parse_invocation_metadata(
+    metadata: Option<JsonValue>,
+) -> anyhow::Result<Option<ConvexObject>> {
+    metadata
+        .map(|metadata| {
+            let metadata: ConvexValue = metadata.try_into()?;
+            ConvexObject::try_from(metadata)
+        })
+        .transpose()
 }
 
 /// Execute function by URL path
@@ -324,6 +343,7 @@ pub async fn public_function_post_with_path(
             },
             req.args.into_serialized_args()?,
             FunctionCaller::HttpApi(client_version.clone()),
+            parse_invocation_metadata(req.metadata)?,
         )
         .await?;
     // Default to ConvexCleanJSON if no format is provided.
@@ -401,6 +421,7 @@ pub async fn public_query_get(
             export_path,
             req.args.into_serialized_args()?,
             FunctionCaller::HttpApi(client_version.clone()),
+            None,
             ExecuteQueryTimestamp::Latest,
             journal,
         )
@@ -455,6 +476,7 @@ pub async fn public_query_post(
             udf_path,
             req.args.into_serialized_args()?,
             FunctionCaller::HttpApi(client_version.clone()),
+            parse_invocation_metadata(req.metadata)?,
             ExecuteQueryTimestamp::Latest,
             journal,
         )
@@ -529,6 +551,7 @@ pub async fn public_query_at_ts_post(
             export_path,
             req.args.into_serialized_args()?,
             FunctionCaller::HttpApi(client_version.clone()),
+            parse_invocation_metadata(req.metadata)?,
             ExecuteQueryTimestamp::At(ts),
             journal,
         )
@@ -593,6 +616,7 @@ pub async fn public_query_batch_post(
                 export_path,
                 req.args.into_serialized_args()?,
                 FunctionCaller::HttpApi(client_version.clone()),
+                parse_invocation_metadata(req.metadata)?,
                 ExecuteQueryTimestamp::At(*ts),
                 None,
             )
@@ -651,6 +675,7 @@ pub async fn public_mutation_post(
             export_path,
             req.args.into_serialized_args()?,
             FunctionCaller::HttpApi(client_version.clone()),
+            parse_invocation_metadata(req.metadata)?,
             None,
             None,
         )
@@ -709,6 +734,7 @@ pub async fn public_action_post(
             export_path,
             req.args.into_serialized_args()?,
             FunctionCaller::HttpApi(client_version.clone()),
+            parse_invocation_metadata(req.metadata)?,
         )
         .await?;
     let value_format = req.format.as_ref().map(|f| f.parse()).transpose()?;
@@ -744,4 +770,39 @@ where
         .routes(utoipa_axum::routes!(public_function_post))
         .routes(utoipa_axum::routes!(public_function_post_with_path))
         .layer(DefaultBodyLimit::max(*MAX_BACKEND_PUBLIC_API_REQUEST_SIZE))
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::parse_invocation_metadata;
+    use value::{
+        ConvexValue,
+    };
+
+    #[test]
+    fn parse_invocation_metadata_accepts_objects() {
+        let metadata = parse_invocation_metadata(Some(json!({
+            "correlationId": "corr_123",
+            "origin": "nuxt",
+        })))
+        .unwrap()
+        .unwrap();
+
+        assert_eq!(
+            serde_json::Value::from(ConvexValue::Object(metadata)),
+            json!({
+                "correlationId": "corr_123",
+                "origin": "nuxt",
+            }),
+        );
+    }
+
+    #[test]
+    fn parse_invocation_metadata_rejects_non_objects() {
+        let error = parse_invocation_metadata(Some(json!("not-an-object"))).unwrap_err();
+
+        assert!(error.to_string().contains("metadata"));
+    }
 }

--- a/crates/pb/protos/common.proto
+++ b/crates/pb/protos/common.proto
@@ -98,6 +98,7 @@ message ExecutionContext {
   optional string request_id = 2;
   optional string execution_id = 3;
   optional bool is_root = 4;
+  optional string invocation_metadata_json_packed_value = 6;
 }
 
 enum UdfType {

--- a/crates/sync/src/worker.rs
+++ b/crates/sync/src/worker.rs
@@ -569,6 +569,7 @@ impl<RT: Runtime> SyncWorker<RT> {
                                     ExportPath::from(udf_path.canonicalize()),
                                     args,
                                     caller,
+                                    None,
                                     mutation_identifier,
                                     Some(mutation_queue_size),
                                 )
@@ -585,6 +586,7 @@ impl<RT: Runtime> SyncWorker<RT> {
                                     path,
                                     args,
                                     caller,
+                                    None,
                                     mutation_identifier,
                                     Some(mutation_queue_size),
                                 )
@@ -662,6 +664,7 @@ impl<RT: Runtime> SyncWorker<RT> {
                                 ExportPath::from(udf_path.canonicalize()),
                                 args,
                                 caller,
+                                None,
                             )
                             .in_span(root)
                             .await?
@@ -675,6 +678,7 @@ impl<RT: Runtime> SyncWorker<RT> {
                                 path,
                                 args,
                                 caller,
+                                None,
                             )
                             .in_span(root)
                             .await?
@@ -960,6 +964,7 @@ impl<RT: Runtime> SyncWorker<RT> {
                                             ExportPath::from(query.udf_path.clone().canonicalize()),
                                             query.args.clone(),
                                             caller.clone(),
+                                            None,
                                             ExecuteQueryTimestamp::At(new_ts),
                                             query.journal.clone(),
                                         )
@@ -978,6 +983,7 @@ impl<RT: Runtime> SyncWorker<RT> {
                                             path,
                                             query.args.clone(),
                                             caller.clone(),
+                                            None,
                                             ExecuteQueryTimestamp::At(new_ts),
                                             query.journal.clone(),
                                         )

--- a/npm-packages/convex/src/browser/http_client.test.ts
+++ b/npm-packages/convex/src/browser/http_client.test.ts
@@ -1,0 +1,132 @@
+import { afterEach, describe, expect, test, vi } from "vitest";
+
+import { makeFunctionReference } from "../server/api.js";
+import { ConvexHttpClient } from "./http_client.js";
+
+function successResponse(value: unknown = null) {
+  return {
+    ok: true,
+    status: 200,
+    json: async () => ({
+      status: "success",
+      value,
+      logLines: [],
+    }),
+    text: async () => "",
+  } as Response;
+}
+
+describe("ConvexHttpClient invocation metadata", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test("includes metadata in query requests", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(successResponse());
+    const client = new ConvexHttpClient(
+      "https://happy-animal-123.convex.cloud",
+      {
+        fetch: fetchMock as typeof fetch,
+        logger: false,
+      },
+    );
+
+    await client.query(
+      makeFunctionReference<"query">("tasks:list"),
+      {},
+      {
+        metadata: {
+          correlationId: "corr_123",
+          origin: "nuxt",
+        },
+      },
+    );
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock.mock.calls[0]?.[0]).toBe(
+      "https://happy-animal-123.convex.cloud/api/query",
+    );
+
+    const request = fetchMock.mock.calls[0]?.[1] as RequestInit;
+    expect(JSON.parse(request.body as string)).toMatchObject({
+      path: "tasks:list",
+      metadata: {
+        correlationId: "corr_123",
+        origin: "nuxt",
+      },
+    });
+  });
+
+  test("preserves metadata through the queued mutation path", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(successResponse());
+    const client = new ConvexHttpClient(
+      "https://happy-animal-123.convex.cloud",
+      {
+        fetch: fetchMock as typeof fetch,
+        logger: false,
+      },
+    );
+
+    await client.mutation(
+      makeFunctionReference<"mutation">("tasks:create"),
+      { title: "Hello" },
+      {
+        skipQueue: false,
+        metadata: {
+          correlationId: "corr_123",
+          phase: "draft",
+        },
+      },
+    );
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock.mock.calls[0]?.[0]).toBe(
+      "https://happy-animal-123.convex.cloud/api/mutation",
+    );
+
+    const request = fetchMock.mock.calls[0]?.[1] as RequestInit;
+    expect(JSON.parse(request.body as string)).toMatchObject({
+      path: "tasks:create",
+      metadata: {
+        correlationId: "corr_123",
+        phase: "draft",
+      },
+    });
+  });
+
+  test("includes metadata in action requests", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(successResponse());
+    const client = new ConvexHttpClient(
+      "https://happy-animal-123.convex.cloud",
+      {
+        fetch: fetchMock as typeof fetch,
+        logger: false,
+      },
+    );
+
+    await client.action(
+      makeFunctionReference<"action">("tasks:notify"),
+      {},
+      {
+        metadata: {
+          correlationId: "corr_123",
+          phase: "notify",
+        },
+      },
+    );
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock.mock.calls[0]?.[0]).toBe(
+      "https://happy-animal-123.convex.cloud/api/action",
+    );
+
+    const request = fetchMock.mock.calls[0]?.[1] as RequestInit;
+    expect(JSON.parse(request.body as string)).toMatchObject({
+      path: "tasks:notify",
+      metadata: {
+        correlationId: "corr_123",
+        phase: "notify",
+      },
+    });
+  });
+});

--- a/npm-packages/convex/src/browser/http_client.ts
+++ b/npm-packages/convex/src/browser/http_client.ts
@@ -23,6 +23,7 @@ import {
   FunctionArgs,
   UserIdentityAttributes,
 } from "../server/index.js";
+import { InvocationOptions } from "../server/meta.js";
 
 export const STATUS_CODE_OK = 200;
 export const STATUS_CODE_BAD_REQUEST = 400;
@@ -37,7 +38,9 @@ export function setFetch(f: typeof globalThis.fetch) {
   specifiedFetch = f;
 }
 
-export type HttpMutationOptions = {
+export type HttpFunctionOptions = InvocationOptions;
+
+export type HttpMutationOptions = InvocationOptions & {
   /**
    * Skip the default queue of mutations and run this immediately.
    *
@@ -70,6 +73,7 @@ export class ConvexHttpClient {
   private mutationQueue: Array<{
     mutation: FunctionReference<"mutation">;
     args: FunctionArgs<any>;
+    options?: HttpMutationOptions;
     resolve: (value: any) => void;
     reject: (error: any) => void;
   }> = [];
@@ -225,12 +229,16 @@ export class ConvexHttpClient {
    */
   async consistentQuery<Query extends FunctionReference<"query">>(
     query: Query,
-    ...args: OptionalRestArgs<Query>
+    ...args: ArgsAndOptions<Query, HttpFunctionOptions>
   ): Promise<FunctionReturnType<Query>> {
-    const queryArgs = parseArgs(args[0]);
+    const [queryArgsRaw, options] = args;
+    const queryArgs = parseArgs(queryArgsRaw);
 
     const timestampPromise = this.getTimestamp();
-    return await this.queryInner(query, queryArgs, { timestampPromise });
+    return await this.queryInner(query, queryArgs, {
+      timestampPromise,
+      metadata: options?.metadata,
+    });
   }
 
   private async getTimestamp() {
@@ -269,16 +277,22 @@ export class ConvexHttpClient {
    */
   async query<Query extends FunctionReference<"query">>(
     query: Query,
-    ...args: OptionalRestArgs<Query>
+    ...args: ArgsAndOptions<Query, HttpFunctionOptions>
   ): Promise<FunctionReturnType<Query>> {
-    const queryArgs = parseArgs(args[0]);
-    return await this.queryInner(query, queryArgs, {});
+    const [queryArgsRaw, options] = args;
+    const queryArgs = parseArgs(queryArgsRaw);
+    return await this.queryInner(query, queryArgs, {
+      metadata: options?.metadata,
+    });
   }
 
   private async queryInner<Query extends FunctionReference<"query">>(
     query: Query,
     queryArgs: FunctionArgs<Query>,
-    options: { timestampPromise?: Promise<string> },
+    options: {
+      metadata?: InvocationOptions["metadata"];
+      timestampPromise?: Promise<string>;
+    },
   ): Promise<FunctionReturnType<Query>> {
     const name = getFunctionName(query);
     const args = [convexToJson(queryArgs)];
@@ -301,6 +315,9 @@ export class ConvexHttpClient {
       path: name,
       format: "convex_encoded_json",
       args,
+      ...(options.metadata
+        ? { metadata: convexToJson(parseArgs(options.metadata)) }
+        : {}),
       ...(timestamp ? { ts: timestamp } : {}),
     });
     const endpoint = timestamp
@@ -342,12 +359,16 @@ export class ConvexHttpClient {
   private async mutationInner<Mutation extends FunctionReference<"mutation">>(
     mutation: Mutation,
     mutationArgs: FunctionArgs<Mutation>,
+    options?: HttpMutationOptions,
   ): Promise<FunctionReturnType<Mutation>> {
     const name = getFunctionName(mutation);
     const body = JSON.stringify({
       path: name,
       format: "convex_encoded_json",
       args: [convexToJson(mutationArgs)],
+      ...(options?.metadata
+        ? { metadata: convexToJson(parseArgs(options.metadata)) }
+        : {}),
     });
     const headers: Record<string, string> = {
       "Content-Type": "application/json",
@@ -397,9 +418,10 @@ export class ConvexHttpClient {
 
     this.isProcessingQueue = true;
     while (this.mutationQueue.length > 0) {
-      const { mutation, args, resolve, reject } = this.mutationQueue.shift()!;
+      const { mutation, args, options, resolve, reject } =
+        this.mutationQueue.shift()!;
       try {
-        const result = await this.mutationInner(mutation, args);
+        const result = await this.mutationInner(mutation, args, options);
         resolve(result);
       } catch (error) {
         reject(error);
@@ -411,9 +433,16 @@ export class ConvexHttpClient {
   private enqueueMutation<Mutation extends FunctionReference<"mutation">>(
     mutation: Mutation,
     args: FunctionArgs<Mutation>,
+    options?: HttpMutationOptions,
   ): Promise<FunctionReturnType<Mutation>> {
     return new Promise((resolve, reject) => {
-      this.mutationQueue.push({ mutation, args, resolve, reject });
+      this.mutationQueue.push({
+        mutation,
+        args,
+        ...(options ? { options } : {}),
+        resolve,
+        reject,
+      });
       void this.processMutationQueue();
     });
   }
@@ -436,9 +465,9 @@ export class ConvexHttpClient {
     const queued = !options?.skipQueue;
 
     if (queued) {
-      return await this.enqueueMutation(mutation, mutationArgs);
+      return await this.enqueueMutation(mutation, mutationArgs, options);
     } else {
-      return await this.mutationInner(mutation, mutationArgs);
+      return await this.mutationInner(mutation, mutationArgs, options);
     }
   }
 
@@ -452,14 +481,18 @@ export class ConvexHttpClient {
    */
   async action<Action extends FunctionReference<"action">>(
     action: Action,
-    ...args: OptionalRestArgs<Action>
+    ...args: ArgsAndOptions<Action, HttpFunctionOptions>
   ): Promise<FunctionReturnType<Action>> {
-    const actionArgs = parseArgs(args[0]);
+    const [actionArgsRaw, options] = args;
+    const actionArgs = parseArgs(actionArgsRaw);
     const name = getFunctionName(action);
     const body = JSON.stringify({
       path: name,
       format: "convex_encoded_json",
       args: [convexToJson(actionArgs)],
+      ...(options?.metadata
+        ? { metadata: convexToJson(parseArgs(options.metadata)) }
+        : {}),
     });
     const headers: Record<string, string> = {
       "Content-Type": "application/json",

--- a/npm-packages/convex/src/server/impl/actions_impl.ts
+++ b/npm-packages/convex/src/server/impl/actions_impl.ts
@@ -4,16 +4,21 @@ import { performAsyncSyscall } from "./syscall.js";
 import { parseArgs } from "../../common/index.js";
 import { FunctionReference } from "../../server/api.js";
 import { getFunctionAddress } from "../components/paths.js";
+import { InvocationOptions } from "../meta.js";
 
 function syscallArgs(
   requestId: string,
   functionReference: any,
   args?: Record<string, Value>,
+  options?: InvocationOptions,
 ) {
   const address = getFunctionAddress(functionReference);
   return {
     ...address,
     args: convexToJson(parseArgs(args)),
+    metadata: options?.metadata
+      ? convexToJson(parseArgs(options.metadata))
+      : undefined,
     version,
     requestId,
   };
@@ -24,30 +29,33 @@ export function setupActionCalls(requestId: string) {
     runQuery: async (
       query: FunctionReference<"query", "public" | "internal">,
       args?: Record<string, Value>,
+      options?: InvocationOptions,
     ): Promise<any> => {
       const result = await performAsyncSyscall(
         "1.0/actions/query",
-        syscallArgs(requestId, query, args),
+        syscallArgs(requestId, query, args, options),
       );
       return jsonToConvex(result);
     },
     runMutation: async (
       mutation: FunctionReference<"mutation", "public" | "internal">,
       args?: Record<string, Value>,
+      options?: InvocationOptions,
     ): Promise<any> => {
       const result = await performAsyncSyscall(
         "1.0/actions/mutation",
-        syscallArgs(requestId, mutation, args),
+        syscallArgs(requestId, mutation, args, options),
       );
       return jsonToConvex(result);
     },
     runAction: async (
       action: FunctionReference<"action", "public" | "internal">,
       args?: Record<string, Value>,
+      options?: InvocationOptions,
     ): Promise<any> => {
       const result = await performAsyncSyscall(
         "1.0/actions/action",
-        syscallArgs(requestId, action, args),
+        syscallArgs(requestId, action, args, options),
       );
       return jsonToConvex(result);
     },

--- a/npm-packages/convex/src/server/impl/meta_impl.test.ts
+++ b/npm-packages/convex/src/server/impl/meta_impl.test.ts
@@ -1,0 +1,37 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+vi.mock("./syscall.js", () => ({
+  performAsyncSyscall: vi.fn(),
+}));
+
+import { performAsyncSyscall } from "./syscall.js";
+import { setupQueryMeta } from "./meta_impl.js";
+
+describe("setupQueryMeta", () => {
+  beforeEach(() => {
+    vi.mocked(performAsyncSyscall).mockReset();
+  });
+
+  test("reads invocation context through the syscall bridge", async () => {
+    const invocationContext = {
+      requestId: "req_123",
+      executionId: "exec_123",
+      isRoot: true,
+      parentScheduledJob: null,
+      parentScheduledJobComponentId: null,
+      metadata: {
+        correlationId: "corr_123",
+        origin: "nuxt",
+      },
+    };
+    vi.mocked(performAsyncSyscall).mockResolvedValue(invocationContext);
+
+    const context = await setupQueryMeta("public").getInvocationContext();
+
+    expect(performAsyncSyscall).toHaveBeenCalledWith(
+      "1.0/getInvocationContext",
+      {},
+    );
+    expect(context).toEqual(invocationContext);
+  });
+});

--- a/npm-packages/convex/src/server/impl/meta_impl.ts
+++ b/npm-packages/convex/src/server/impl/meta_impl.ts
@@ -1,6 +1,7 @@
 import { jsonToConvex } from "../../values/index.js";
 import {
   ActionMeta,
+  InvocationContext,
   MutationMeta,
   QueryMeta,
   FunctionMetadata,
@@ -35,6 +36,10 @@ async function getFunctionMetadata(): Promise<{
   return { name, componentPath };
 }
 
+async function getInvocationContext(): Promise<InvocationContext> {
+  return await performAsyncSyscall("1.0/getInvocationContext", {});
+}
+
 export function setupQueryMeta(
   visibility: FunctionMetadata["visibility"],
 ): QueryMeta {
@@ -45,6 +50,7 @@ export function setupQueryMeta(
       visibility,
     }),
     getTransactionMetrics,
+    getInvocationContext,
   };
 }
 
@@ -58,6 +64,7 @@ export function setupMutationMeta(
       visibility,
     }),
     getTransactionMetrics,
+    getInvocationContext,
   };
 }
 
@@ -70,5 +77,6 @@ export function setupActionMeta(
       type: "action",
       visibility,
     }),
+    getInvocationContext,
   };
 }

--- a/npm-packages/convex/src/server/impl/registration_impl.ts
+++ b/npm-packages/convex/src/server/impl/registration_impl.ts
@@ -45,6 +45,7 @@ import {
   setupMutationMeta,
   setupActionMeta,
 } from "./meta_impl.js";
+import { InvocationOptions } from "../meta.js";
 
 async function invokeMutation<
   F extends (ctx: GenericMutationCtx<GenericDataModel>, ...args: any) => any,
@@ -60,11 +61,15 @@ async function invokeMutation<
     scheduler: setupMutationScheduler(),
     meta: setupMutationMeta(visibility),
 
-    runQuery: (reference: any, args?: any) => runUdf("query", reference, args),
-    runSnapshotQuery: (reference: any, args?: any) =>
-      runUdf("snapshotQuery", reference, args),
-    runMutation: (reference: any, args?: any) =>
-      runUdf("mutation", reference, args),
+    runQuery: (reference: any, args?: any, options?: InvocationOptions) =>
+      runUdf("query", reference, args, options),
+    runSnapshotQuery: (
+      reference: any,
+      args?: any,
+      options?: InvocationOptions,
+    ) => runUdf("snapshotQuery", reference, args, options),
+    runMutation: (reference: any, args?: any, options?: InvocationOptions) =>
+      runUdf("mutation", reference, args, options),
   };
   const result = await invokeFunction(func, mutationCtx, args as any);
   validateReturnValue(result);
@@ -337,7 +342,8 @@ async function invokeQuery<
     auth: setupAuth(requestId),
     storage: setupStorageReader(requestId),
     meta: setupQueryMeta(visibility),
-    runQuery: (reference: any, args?: any) => runUdf("query", reference, args),
+    runQuery: (reference: any, args?: any, options?: InvocationOptions) =>
+      runUdf("query", reference, args, options),
   };
   const result = await invokeFunction(func, queryCtx, args as any);
   validateReturnValue(result);
@@ -748,11 +754,15 @@ async function runUdf(
   udfType: "query" | "mutation" | "snapshotQuery",
   f: any,
   args?: Record<string, Value>,
+  options?: InvocationOptions,
 ): Promise<any> {
   const queryArgs = parseArgs(args);
   const syscallArgs = {
     udfType,
     args: convexToJson(queryArgs),
+    metadata: options?.metadata
+      ? convexToJson(parseArgs(options.metadata))
+      : undefined,
     ...getFunctionAddress(f),
   };
   const result = await performAsyncSyscall("1.0/runUdf", syscallArgs);

--- a/npm-packages/convex/src/server/meta.ts
+++ b/npm-packages/convex/src/server/meta.ts
@@ -1,5 +1,6 @@
 import { FunctionType } from "./api.js";
 import { FunctionVisibility } from "./registration.js";
+import { Value } from "../values/value.js";
 
 /**
  * Used and remaining amounts for a single transaction limit.
@@ -50,6 +51,42 @@ export type FunctionMetadata = {
 };
 
 /**
+ * Invocation metadata propagated alongside a Convex function invocation.
+ *
+ * Values follow the same serialization rules as function arguments and return
+ * values.
+ *
+ * @public
+ */
+export type InvocationMetadata = Record<string, Value>;
+
+/**
+ * Runtime invocation context for the currently executing function.
+ *
+ * @public
+ */
+export type InvocationContext = {
+  requestId: string;
+  executionId: string;
+  isRoot: boolean;
+  parentScheduledJob?: string | null;
+  parentScheduledJobComponentId?: string | null;
+  metadata: InvocationMetadata | null;
+};
+
+/**
+ * Optional call-site metadata for nested or one-shot function calls.
+ *
+ * Nested calls inherit parent invocation metadata by default. Passing
+ * `metadata` overrides top-level keys for that call.
+ *
+ * @public
+ */
+export type InvocationOptions = {
+  metadata?: InvocationMetadata;
+};
+
+/**
  * Extra context available in Convex query functions.
  *
  * @public
@@ -57,6 +94,8 @@ export type FunctionMetadata = {
 export interface QueryMeta {
   getFunctionMetadata(): Promise<FunctionMetadata>;
   getTransactionMetrics(): Promise<TransactionMetrics>;
+  /** Read the invocation context for the current function call. */
+  getInvocationContext(): Promise<InvocationContext>;
 }
 
 /**
@@ -73,4 +112,6 @@ export interface MutationMeta extends QueryMeta {}
  */
 export interface ActionMeta {
   getFunctionMetadata(): Promise<FunctionMetadata>;
+  /** Read the invocation context for the current function call. */
+  getInvocationContext(): Promise<InvocationContext>;
 }

--- a/npm-packages/convex/src/server/registration.ts
+++ b/npm-packages/convex/src/server/registration.ts
@@ -8,8 +8,9 @@ import {
   StorageReader,
   StorageWriter,
 } from "./index.js";
-import { ActionMeta, MutationMeta, QueryMeta } from "./meta.js";
+import { ActionMeta, InvocationOptions, MutationMeta, QueryMeta } from "./meta.js";
 import {
+  ArgsAndOptions,
   FunctionReference,
   FunctionReturnType,
   OptionalRestArgs,
@@ -129,7 +130,7 @@ export interface GenericMutationCtx<DataModel extends GenericDataModel> {
    */
   runQuery: <Query extends FunctionReference<"query", "public" | "internal">>(
     query: Query,
-    ...args: OptionalRestArgs<Query>
+    ...args: ArgsAndOptions<Query, InvocationOptions>
   ) => Promise<FunctionReturnType<Query>>;
 
   /**
@@ -144,7 +145,7 @@ export interface GenericMutationCtx<DataModel extends GenericDataModel> {
     Query extends FunctionReference<"query", "public" | "internal">,
   >(
     query: Query,
-    ...args: OptionalRestArgs<Query>
+    ...args: ArgsAndOptions<Query, InvocationOptions>
   ) => Promise<FunctionReturnType<Query>>;
 
   /**
@@ -161,7 +162,7 @@ export interface GenericMutationCtx<DataModel extends GenericDataModel> {
     Mutation extends FunctionReference<"mutation", "public" | "internal">,
   >(
     mutation: Mutation,
-    ...args: OptionalRestArgs<Mutation>
+    ...args: ArgsAndOptions<Mutation, InvocationOptions>
   ) => Promise<FunctionReturnType<Mutation>>;
 
   meta: MutationMeta;
@@ -254,7 +255,7 @@ export interface GenericQueryCtx<DataModel extends GenericDataModel> {
    */
   runQuery: <Query extends FunctionReference<"query", "public" | "internal">>(
     query: Query,
-    ...args: OptionalRestArgs<Query>
+    ...args: ArgsAndOptions<Query, InvocationOptions>
   ) => Promise<FunctionReturnType<Query>>;
 
   meta: QueryMeta;
@@ -337,7 +338,7 @@ export interface GenericActionCtx<DataModel extends GenericDataModel> {
    */
   runQuery<Query extends FunctionReference<"query", "public" | "internal">>(
     query: Query,
-    ...args: OptionalRestArgs<Query>
+    ...args: ArgsAndOptions<Query, InvocationOptions>
   ): Promise<FunctionReturnType<Query>>;
 
   /**
@@ -359,7 +360,7 @@ export interface GenericActionCtx<DataModel extends GenericDataModel> {
     Mutation extends FunctionReference<"mutation", "public" | "internal">,
   >(
     mutation: Mutation,
-    ...args: OptionalRestArgs<Mutation>
+    ...args: ArgsAndOptions<Mutation, InvocationOptions>
   ): Promise<FunctionReturnType<Mutation>>;
 
   /**
@@ -380,7 +381,7 @@ export interface GenericActionCtx<DataModel extends GenericDataModel> {
    */
   runAction<Action extends FunctionReference<"action", "public" | "internal">>(
     action: Action,
-    ...args: OptionalRestArgs<Action>
+    ...args: ArgsAndOptions<Action, InvocationOptions>
   ): Promise<FunctionReturnType<Action>>;
 
   /**

--- a/npm-packages/docs/docs/client/javascript.mdx
+++ b/npm-packages/docs/docs/client/javascript.mdx
@@ -46,6 +46,10 @@ See the [Node.js Quickstart](/quickstart/nodejs.mdx).
 
 <Snippet title="script.ts" source={Example} />
 
+The HTTP client also accepts optional
+[invocation metadata](/functions/invocation-metadata.mdx) when calling
+point-in-time queries, mutations, and actions.
+
 ## Using Convex without generated `convex/_generated/api.js`
 
 If the source code for your Convex function isn't located in the same project or

--- a/npm-packages/docs/docs/functions/actions.mdx
+++ b/npm-packages/docs/docs/functions/actions.mdx
@@ -74,6 +74,9 @@ do:
   because we don't want to expose it to the client directly. Actions, mutations
   and queries can be defined in the same file.
 
+  `runQuery` accepts an optional third argument for
+  [invocation metadata](/functions/invocation-metadata.mdx).
+
 - To write data to the database use the `runMutation` field, and call a mutation
   that performs the write:
 
@@ -85,11 +88,16 @@ do:
   As with queries, it's often convenient to define actions and mutations in the
   same file.
 
+  `runMutation` and `runAction` also accept an optional third argument for
+  [invocation metadata](/functions/invocation-metadata.mdx).
+
 - To generate upload URLs for storing files use the `storage` field. Read on
   about [File Storage](/file-storage.mdx).
 - To check user authentication use the `auth` field. Auth is propagated
   automatically when calling queries and mutations from the action. Read on
   about [Authentication](/auth.mdx).
+- To inspect invocation metadata use the `meta` field. Read on about
+  [Invocation metadata](/functions/invocation-metadata.mdx).
 - To schedule functions to run in the future, use the `scheduler` field. Read on
   about [Scheduled Functions](/scheduling/scheduled-functions.mdx).
 - To search a vector index, use the `vectorSearch` field. Read on about

--- a/npm-packages/docs/docs/functions/invocation-metadata.mdx
+++ b/npm-packages/docs/docs/functions/invocation-metadata.mdx
@@ -1,0 +1,68 @@
+---
+title: Invocation metadata
+sidebar_position: 40
+description: "Propagate request-scoped metadata across Convex function calls"
+---
+
+import ClientExample from "!!raw-loader!@site/../private-demos/snippets/nodeInvocationMetadata.ts";
+import ServerExample from "!!raw-loader!@site/../private-demos/snippets/convex/invocationMetadata.ts";
+
+Invocation metadata is optional request-scoped data passed alongside a Convex
+function call. It can be useful for correlation IDs, tracing context, or other
+metadata your app or framework wants to propagate.
+
+Unlike function arguments, invocation metadata is not part of your function's
+`args` object. Read it from `ctx.meta.getInvocationContext()`.
+
+## Passing invocation metadata from clients
+
+The JavaScript [HTTP client](/api/classes/browser.ConvexHttpClient) accepts an
+optional `metadata` field when calling point-in-time queries, mutations, and
+actions:
+
+<Snippet title="script.ts" source={ClientExample} />
+
+Invocation metadata values follow the same serialization rules as function
+arguments and return values.
+
+## Reading invocation metadata in functions
+
+Use `ctx.meta.getInvocationContext()` inside a query, mutation, or action to
+read the current invocation metadata:
+
+<Snippet title="convex/invocationMetadata.ts" source={ServerExample} />
+
+The invocation context includes:
+
+- `requestId`, the request that started the current function
+- `executionId`, the current execution within that request
+- `isRoot`, whether this function is the root of the invocation tree
+- `parentScheduledJob` and `parentScheduledJobComponentId` when running from a
+  scheduled function
+- `metadata`, the metadata object passed to the function or inherited from its
+  caller
+
+## Nested calls inherit invocation metadata
+
+Nested calls made with `ctx.runQuery`, `ctx.runMutation`, and `ctx.runAction`
+inherit the parent invocation metadata by default.
+
+To override metadata for a nested call, pass a `metadata` object as the third
+argument. Overrides are shallow: top-level keys from the nested call replace the
+same keys from the parent invocation.
+
+## What invocation metadata is for
+
+Invocation metadata is useful for request-scoped information such as:
+
+- correlation IDs
+- trace context
+- workflow or phase labels
+- framework-specific request metadata
+
+Invocation metadata is not a substitute for authentication or authorization. Use
+[Authentication](/auth.mdx) and the `ctx.auth` field for identity and access
+control.
+
+Invocation metadata is available for one-shot function calls and nested function
+calls. Reactive query subscriptions do not attach invocation metadata.

--- a/npm-packages/node-executor/src/executor.ts
+++ b/npm-packages/node-executor/src/executor.ts
@@ -230,6 +230,7 @@ export type ExecutionContext = {
   isRoot: boolean | undefined;
   parentScheduledJob: string | null;
   parentScheduledJobComponentId: string | null;
+  invocationMetadata?: JSONValue | null;
 };
 
 export type ExecuteResponseInner =

--- a/npm-packages/node-executor/src/syscalls.test.ts
+++ b/npm-packages/node-executor/src/syscalls.test.ts
@@ -1,0 +1,126 @@
+import { afterEach, describe, expect, test, vi } from "vitest";
+
+import { ExecutionContext } from "./executor";
+import { SyscallsImpl } from "./syscalls";
+
+function makeExecutionContext(): ExecutionContext {
+  return {
+    requestId: "req_123",
+    executionId: "exec_123",
+    isRoot: true,
+    parentScheduledJob: null,
+    parentScheduledJobComponentId: null,
+    invocationMetadata: {
+      correlationId: "corr_123",
+      origin: "nuxt",
+    },
+  };
+}
+
+function successResponse(value: unknown = null) {
+  return {
+    ok: true,
+    status: 200,
+    json: async () => ({
+      status: "success",
+      value,
+    }),
+    text: async () => "",
+  } as Response;
+}
+
+function makeSyscalls() {
+  return new SyscallsImpl(
+    {
+      canonicalizedPath: "tasks.ts",
+      function: "run",
+    },
+    "lambda_123",
+    "https://example.com",
+    "callback-token",
+    null,
+    null,
+    makeExecutionContext(),
+    null,
+  );
+}
+
+describe("SyscallsImpl invocation metadata", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  test("encodes inherited invocation metadata in callback headers", () => {
+    const headers = makeSyscalls().headers("1.0");
+    const encoded = headers["Convex-Invocation-Metadata"];
+
+    expect(encoded).toBeDefined();
+    expect(
+      JSON.parse(Buffer.from(encoded!, "base64url").toString("utf8")),
+    ).toEqual({
+      correlationId: "corr_123",
+      origin: "nuxt",
+    });
+  });
+
+  test("returns the current invocation context through the syscall", async () => {
+    const result = JSON.parse(
+      await makeSyscalls().asyncSyscall("1.0/getInvocationContext", "{}"),
+    );
+
+    expect(result).toEqual({
+      requestId: "req_123",
+      executionId: "exec_123",
+      isRoot: true,
+      parentScheduledJob: null,
+      parentScheduledJobComponentId: null,
+      metadata: {
+        correlationId: "corr_123",
+        origin: "nuxt",
+      },
+    });
+  });
+
+  test("sends override metadata in the callback body while preserving inherited headers", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(successResponse());
+    vi.stubGlobal("fetch", fetchMock as typeof fetch);
+
+    await makeSyscalls().syscallQuery(
+      JSON.stringify({
+        requestId: "lambda_123",
+        version: "1.0",
+        name: "tasks:list",
+        args: {},
+        metadata: {
+          phase: "draft",
+        },
+      }),
+    );
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect((fetchMock.mock.calls[0]?.[0] as URL).href).toBe(
+      "https://example.com/api/actions/query",
+    );
+
+    const request = fetchMock.mock.calls[0]?.[1] as RequestInit;
+    const headers = request.headers as Record<string, string>;
+    expect(
+      JSON.parse(
+        Buffer.from(
+          headers["Convex-Invocation-Metadata"],
+          "base64url",
+        ).toString("utf8"),
+      ),
+    ).toEqual({
+      correlationId: "corr_123",
+      origin: "nuxt",
+    });
+    expect(JSON.parse(request.body as string)).toMatchObject({
+      path: "tasks:list",
+      metadata: {
+        phase: "draft",
+      },
+    });
+  });
+});

--- a/npm-packages/node-executor/src/syscalls.ts
+++ b/npm-packages/node-executor/src/syscalls.ts
@@ -18,6 +18,7 @@ const runFunctionArgs = z.object({
   reference: z.optional(z.string()),
   functionHandle: z.optional(z.string()),
   args: z.any(),
+  metadata: z.optional(z.any()),
   version: z.string(),
 });
 
@@ -166,6 +167,11 @@ export class SyscallsImpl {
     }
     if (this.executionContext.isRoot !== undefined) {
       headers["Convex-Root-Request"] = this.executionContext.isRoot.toString();
+    }
+    if (this.executionContext.invocationMetadata != null) {
+      headers["Convex-Invocation-Metadata"] = Buffer.from(
+        JSON.stringify(this.executionContext.invocationMetadata),
+      ).toString("base64url");
     }
     if (this.authHeader !== null) {
       headers["Authorization"] = this.authHeader;
@@ -328,6 +334,16 @@ export class SyscallsImpl {
             // support node actions for components.
             componentPath: "",
           });
+        case "1.0/getInvocationContext":
+          return JSON.stringify({
+            requestId: this.executionContext.requestId,
+            executionId: this.executionContext.executionId ?? null,
+            isRoot: this.executionContext.isRoot,
+            parentScheduledJob: this.executionContext.parentScheduledJob,
+            parentScheduledJobComponentId:
+              this.executionContext.parentScheduledJobComponentId,
+            metadata: this.executionContext.invocationMetadata ?? null,
+          });
         default:
           throw new Error(`Unknown operation ${op}`);
       }
@@ -383,6 +399,7 @@ export class SyscallsImpl {
         reference: queryArgs.reference,
         functionHandle: queryArgs.functionHandle,
         args: queryArgs.args,
+        metadata: queryArgs.metadata,
       },
       path: "/api/actions/query",
       operationName,
@@ -425,6 +442,7 @@ export class SyscallsImpl {
         reference: mutationArgs.reference,
         functionHandle: mutationArgs.functionHandle,
         args: mutationArgs.args,
+        metadata: mutationArgs.metadata,
       },
       path: "/api/actions/mutation",
       operationName,
@@ -467,6 +485,7 @@ export class SyscallsImpl {
         reference: actionArgs.reference,
         functionHandle: actionArgs.functionHandle,
         args: actionArgs.args,
+        metadata: actionArgs.metadata,
       },
       path: "/api/actions/action",
       operationName,

--- a/npm-packages/private-demos/snippets/convex/invocationMetadata.ts
+++ b/npm-packages/private-demos/snippets/convex/invocationMetadata.ts
@@ -1,0 +1,42 @@
+import { v } from "convex/values";
+import { action, internalQuery } from "./_generated/server";
+import { internal } from "./_generated/api";
+
+export const readInvocationMetadata = internalQuery({
+  args: {},
+  handler: async (ctx) => {
+    const invocation = await ctx.meta.getInvocationContext();
+    const metadata = invocation.metadata;
+    return {
+      requestId: invocation.requestId,
+      correlationId:
+        typeof metadata?.correlationId === "string"
+          ? metadata.correlationId
+          : null,
+      phase: typeof metadata?.phase === "string" ? metadata.phase : "initial",
+    };
+  },
+});
+
+export const processOrder = action({
+  args: { orderId: v.string() },
+  handler: async (ctx, args) => {
+    const invocation = await ctx.meta.getInvocationContext();
+    const metadata = invocation.metadata;
+    const correlationId =
+      typeof metadata?.correlationId === "string"
+        ? metadata.correlationId
+        : `order:${args.orderId}`;
+
+    return await ctx.runQuery(
+      internal.invocationMetadata.readInvocationMetadata,
+      {},
+      {
+        metadata: {
+          correlationId,
+          phase: "authorize",
+        },
+      },
+    );
+  },
+});

--- a/npm-packages/private-demos/snippets/nodeInvocationMetadata.ts
+++ b/npm-packages/private-demos/snippets/nodeInvocationMetadata.ts
@@ -1,0 +1,15 @@
+import { ConvexHttpClient } from "convex/browser";
+import { api } from "./convex/_generated/api";
+
+const client = new ConvexHttpClient(process.env["CONVEX_URL"]);
+
+await client.action(
+  api.invocationMetadata.processOrder,
+  { orderId: "order_123" },
+  {
+    metadata: {
+      correlationId: "req_123",
+      origin: "checkout",
+    },
+  },
+);


### PR DESCRIPTION
Solves: #446 

## Summary

This PR adds optional invocation metadata to Convex function calls.

Invocation metadata is:

- passed beside args, not inside args
- propagated through nested `runQuery` / `runMutation` / `runAction`
- readable from `ctx.meta.getInvocationContext()`

This is an additive runtime primitive for request-scoped metadata such as
correlation IDs, tracing context, origin hints, and workflow phase labels.

## What changed

### Runtime / backend

- Extended `ExecutionContext` with optional invocation metadata.
- Added protobuf round-trip support.
- Threaded metadata through public function execution paths.
- Threaded metadata through nested function execution paths.
- Added `1.0/getInvocationContext` to the async syscall surface.

### TypeScript API

- Added `InvocationMetadata`
- Added `InvocationOptions`
- Added `InvocationContext`
- Added `ctx.meta.getInvocationContext()`
- Updated nested `ctx.runQuery`, `ctx.runMutation`, and `ctx.runAction`
  signatures to accept optional invocation metadata
- Updated `ConvexHttpClient` query / mutation / action methods to accept
  optional invocation metadata

### Node executor / action callbacks

- Propagates inherited invocation metadata in callback headers
- Sends nested override metadata in callback bodies
- Decodes invocation metadata into `ExecutionContext` on callback ingress

### Docs / examples

- Added a new docs page for invocation metadata
- Added snippets for client-side and server-side usage
- Added cross-links from related docs

## Behavior

- Metadata is optional.
- Metadata is not part of `args`.
- Nested calls inherit parent metadata by default.
- Nested call metadata shallowly overrides top-level keys.
- Metadata is accessible via `ctx.meta.getInvocationContext()`.
- Reactive subscriptions are not in scope for this PR.

## Motivation

Without this primitive, frameworks and advanced integrations have to encode
request-scoped metadata into function args using reserved fields. That mixes
business input with runtime context and forces validators and wrappers to
account for framework internals.

This PR keeps business args pure and uses the existing execution-context layer
for runtime metadata.

## Non-goals

This PR does not add:

- subscription metadata semantics
- tracing APIs
- logging APIs
- auth changes

## Tests

Added targeted coverage for:

- metadata merge semantics
- execution context protobuf round-trip
- public metadata parsing
- callback header decoding
- HTTP client request shapes
- node-executor propagation
- `ctx.meta.getInvocationContext()` syscall behavior

## Notes

The implementation is generic and not framework-specific. It is intended as a
low-level runtime primitive that can support multiple higher-level use cases
without changing the Convex function model.
