### PR TITLE
Allow local backend startup timeout override + better timeout message

### DIFF
--- a/npm-packages/convex/src/cli/lib/localDeployment/run.ts
+++ b/npm-packages/convex/src/cli/lib/localDeployment/run.ts
@@ -132,7 +132,12 @@ export async function runLocalBackend(
   await ensureBackendRunning(ctx, {
     cloudPort: ports.cloud,
     deploymentName: args.deploymentName,
-    maxTimeSecs: 30,
+    maxTimeSecs: parseInt(
+      process.env.CONVEX_LOCAL_BACKEND_STARTUP_TIMEOUT_SECS ?? "30",
+      10,
+    ),
+    timeoutMessage:
+      "If your local database is large, increase the timeout by setting CONVEX_LOCAL_BACKEND_STARTUP_TIMEOUT_SECS (e.g. CONVEX_LOCAL_BACKEND_STARTUP_TIMEOUT_SECS=120).",
   });
 
   return {
@@ -181,6 +186,7 @@ export async function ensureBackendRunning(
     cloudPort: number;
     deploymentName: string;
     maxTimeSecs: number;
+    timeoutMessage?: string;
   },
 ): Promise<void> {
   logVerbose(`Ensuring backend running on port ${args.cloudPort} is running`);
@@ -215,7 +221,10 @@ export async function ensureBackendRunning(
       timeElapsedSecs += 0.5;
     }
   }
-  const message = `Local backend did not start on port ${args.cloudPort} within ${args.maxTimeSecs} seconds.`;
+  const baseMessage = `Local backend did not start on port ${args.cloudPort} within ${args.maxTimeSecs} seconds.`;
+  const message = args.timeoutMessage
+    ? `${baseMessage} ${args.timeoutMessage}`
+    : baseMessage;
   return await ctx.crash({
     exitCode: 1,
     errorType: "fatal",


### PR DESCRIPTION
## Summary
- Adds `CONVEX_LOCAL_BACKEND_STARTUP_TIMEOUT_SECS` env var to override the hardcoded 30s timeout in `runLocalBackend` (`npm-packages/convex/src/cli/lib/localDeployment/run.ts`).
- Adds an optional `timeoutMessage` arg to `ensureBackendRunning` so the boot call site can append a hint pointing users at the env var when the timeout fires. Status-poll callers omit it; their error message is unchanged.
- Default behavior (no env var set) is unchanged.

## Why
Local dev deployments with large databases (>1GB) can fail to start within 30s on first boot. Today the only workaround is patching `node_modules`, and the timeout error gives no hint that the limit is configurable.

After this change, the timeout error reads:
> Local backend did not start on port 3210 within 30 seconds. If your local database is large, increase the timeout by setting CONVEX_LOCAL_BACKEND_STARTUP_TIMEOUT_SECS (e.g. CONVEX_LOCAL_BACKEND_STARTUP_TIMEOUT_SECS=120).

## Notes
- Minimal change; no new CLI flag. Happy to switch to a flag, add validation on the env var, or add a changelog entry if preferred.
- No new tests — change is a `process.env` read plus a string concat.