### PR TITLE
node-executor: use file:// URL for dynamic action import

### DIFF
--- a/npm-packages/node-executor/src/executor.test.ts
+++ b/npm-packages/node-executor/src/executor.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from "vitest";
+import path from "node:path";
+
+import { makeModuleImportUrl } from "./executor";
+
+describe("makeModuleImportUrl", () => {
+  it("produces a file:// URL Node's ESM loader accepts", () => {
+    const url = makeModuleImportUrl(
+      path.join("/tmp", "modules"),
+      "actions/auth.js",
+      "abc123",
+    );
+    expect(() => new URL(url)).not.toThrow();
+    expect(new URL(url).protocol).toBe("file:");
+  });
+
+  it("includes the envHash as a query parameter", () => {
+    const url = makeModuleImportUrl("/x", "y.js", "envhash99");
+    expect(url).toContain("?envHash=envhash99");
+  });
+
+  it("regression: never returns a raw filesystem path", () => {
+    // Pre-fix bug (issue #152): on Windows, returning
+    // `C:\...\foo.js?envHash=...` made Node's ESM loader throw
+    // "Only URLs with a scheme in: file, data, and node are supported.
+    //  Received protocol 'c:'". The contract here — applicable on every
+    // platform — is that the import argument is always a `file:` URL.
+    const url = makeModuleImportUrl("/whatever", "foo.js", "h");
+    expect(url.startsWith("file://")).toBe(true);
+  });
+});

--- a/npm-packages/node-executor/src/executor.ts
+++ b/npm-packages/node-executor/src/executor.ts
@@ -341,6 +341,27 @@ export async function execute(
   };
 }
 
+/**
+ * Build the URL string passed to dynamic `import()` for a user action module.
+ *
+ * Always returns a `file://` URL via `pathToFileURL`. Node's ESM loader rejects
+ * raw filesystem paths whose first segment parses as a URL scheme — on Windows
+ * `C:\...` parses with protocol `c:` and the loader throws
+ * "Only URLs with a scheme in: file, data, and node are supported". See
+ * https://github.com/get-convex/convex-backend/issues/152.
+ *
+ * The `envHash` query parameter forces re-evaluation when env vars change,
+ * since they may be referenced at module top level.
+ */
+export function makeModuleImportUrl(
+  modulesDir: string,
+  relPath: string,
+  envHash: string,
+): string {
+  const fileUrl = pathToFileURL(path.join(modulesDir, relPath)).href;
+  return `${fileUrl}?envHash=${envHash}`;
+}
+
 export async function executeInner(
   lambdaExecuteId: string,
   dir: string,
@@ -361,7 +382,7 @@ export async function executeInner(
 
   setupGlobals(`${modulesDir}/${relPath}`);
   const module = await import(
-    path.join(modulesDir, `${relPath}?envHash=${envHash}`)
+    makeModuleImportUrl(modulesDir, relPath, envHash)
   );
   const importTimeMs = logDurationMs("importTimeMs", start);
 


### PR DESCRIPTION
## What this fixes

Any time the Convex local backend runs on a Windows host — whether via `npx convex dev --local` for local development, or as a self-hosted deployment — every action marked `"use node"` fails the moment it's invoked, with:

> Only URLs with a scheme in: file, data, and node are supported by the default ESM loader. On Windows, absolute paths must be valid file:// URLs. Received protocol 'c:'

The error fires before the action's own code runs, so there's no user-space workaround. In our case the trigger was the WorkOS sign-in action — every login attempt failed immediately. Effectively, the local backend is unusable on native Windows for any `"use node"` flow: auth, password reset, image processing, anything pulling in Node-only dependencies. Cloud deployments are unaffected because they run on Linux.

This PR fixes the underlying loader-argument bug so the local backend works natively on Windows.

## Root cause

`executeInner` builds the argument to dynamic `import()` by passing `path.join(modulesDir, relPath + "?envHash=...")` directly. On Windows that produces a raw `C:\...\foo.js?envHash=...` string, and Node's ESM loader parses the leading `C:` as the URL scheme — which it refuses.

## Fix

Extract the URL construction into a small `makeModuleImportUrl()` helper that wraps the joined path with `pathToFileURL(...)` and then appends the `?envHash=...` query, so the value handed to `import()` is always a `file://` URL.

This is the same pattern `analyzeModule` already uses correctly elsewhere in the same file — just brought to the second call site.

## Tests

`executor.test.ts` adds three vitest unit tests against the helper:

- the result parses as a URL with `file:` protocol
- the result contains the `?envHash=...` query parameter
- regression: the result always starts with `file://` (the contract that prevents the Windows failure mode)

These run on every platform — Linux CI included — and pin the contract.

## Verification

Built `convex-local-backend.exe` from this branch on Windows and ran it as the local backend in our development environment. `"use node"` actions that previously failed with `Received protocol 'c:'` now execute correctly — tested end-to-end with a WorkOS authentication action that failed every time on this same machine before the fix.

## Notes

- `pathToFileURL` is already imported at the top of the file.
- No behavior change on Linux/macOS: Node already accepts both raw absolute paths and `file://` URLs there. The pre-fix code happened to work on those platforms because Node tolerates raw absolute paths; the new code uses the explicit form that works everywhere.

Fixes #152.