### PR TITLE
fix(cli): tolerate EINVAL on fsync for FIFOs/pipes (.env.local)

### DIFF
--- a/npm-packages/convex/src/bundler/fs.ts
+++ b/npm-packages/convex/src/bundler/fs.ts
@@ -193,7 +193,18 @@ export class NodeFs implements Filesystem {
     const fd = stdFs.openSync(path, "w", mode);
     try {
       stdFs.writeFileSync(fd, contents, { encoding: "utf-8" });
-      stdFs.fsyncSync(fd);
+      try {
+        stdFs.fsyncSync(fd);
+      } catch (e: any) {
+        // fsync(2) returns EINVAL on file descriptors that don't support
+        // synchronization, e.g. FIFOs/pipes. Some integrations (such as
+        // 1Password's Local Environment File) expose `.env.local` as a
+        // FIFO so secrets can be streamed on demand; the write itself
+        // succeeded, so treat the missing sync as best-effort.
+        if (e?.code !== "EINVAL") {
+          throw e;
+        }
+      }
     } finally {
       stdFs.closeSync(fd);
     }


### PR DESCRIPTION
### Summary

`NodeFs.writeUtf8File` (in `npm-packages/convex/src/bundler/fs.ts`) always calls `fsyncSync` after writing. `fsync(2)` returns `EINVAL` when the underlying file descriptor is bound to a special file that does not support synchronization, such as a FIFO or socket.

This breaks `npx convex dev` for users whose `.env.local` is a named pipe. The 1Password [Local Environment File integration](https://developer.1password.com/docs/environments/local-env-file) exposes `.env.local` as a FIFO so secrets can be streamed on demand. The CLI now reaches `writeDeploymentEnvVar` (and other writers that call `writeUtf8File`) on every dev start, so every run fails with `Unexpected Error: Error: EINVAL: invalid argument, fsync` and on subsequent runs hangs silently because the failed write left the env file in a broken state.

### Fix

Catch `EINVAL` from `fsyncSync` and treat it as a no-op while still propagating every other error code. Durability is preserved for regular files. Special files (FIFOs, pipes, sockets) become best-effort, which matches what fsync semantics already imply for them.

### Reproduction

```sh
mkfifo .env.local
# In another terminal, keep feeding it:
# while true; do cat real.env > .env.local; done
npx convex@1.36.1 dev
# Before: Unexpected Error: Error: EINVAL: invalid argument, fsync
# After:  proceeds normally
```

I verified the fix locally with a small Node script that calls the original and patched `writeUtf8File` against a FIFO (with a background reader so the writer does not block). The original throws `EINVAL`. The patched version succeeds. Regular files still write and fsync as before, and other error codes (`EBADF`, `EIO`, etc.) are still propagated.

### Notes

- Only catches the documented `EINVAL` code so genuine I/O errors keep surfacing.
- No behavior change for regular files. For them fsync still runs and any error is still raised.
- No changes to the public `Filesystem` interface, only the implementation in `NodeFs`.

Fixes #458

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.