### PR TITLE
fix: typos in dashboard UI strings and code comments

### DIFF
--- a/npm-packages/convex/src/cli/lib/utils/utils.ts
+++ b/npm-packages/convex/src/cli/lib/utils/utils.ts
@@ -109,7 +109,7 @@ export type ErrorData = {
 };
 
 /**
- * Error thrown on non-2XX reponse codes to make most `fetch()` error handling
+ * Error thrown on non-2XX response codes to make most `fetch()` error handling
  * follow a single code path.
  */
 export class ThrowingFetchError extends Error {

--- a/npm-packages/dashboard-common/src/features/settings/components/integrations/Integrations.tsx
+++ b/npm-packages/dashboard-common/src/features/settings/components/integrations/Integrations.tsx
@@ -72,7 +72,7 @@ export function Integrations({
     ? [
         {
           kind: "workos",
-          // Consider this integration to exist if a WorkOS enviroment has been provisioned
+          // Consider this integration to exist if a WorkOS environment has been provisioned
           existing: workosData?.environment ?? null,
         },
       ]

--- a/npm-packages/dashboard/src/components/teamSettings/OauthApps.tsx
+++ b/npm-packages/dashboard/src/components/teamSettings/OauthApps.tsx
@@ -221,7 +221,7 @@ function OauthAppForm({
             htmlFor="redirect-uris"
             className="flex flex-col gap-1 text-sm text-content-primary"
           >
-            Redirect URIs (seperated by commas)
+            Redirect URIs (separated by commas)
             <textarea
               id="redirect-uris"
               name="redirectUris"

--- a/npm-packages/dashboard/src/components/teamSettings/TeamSSO.tsx
+++ b/npm-packages/dashboard/src/components/teamSettings/TeamSSO.tsx
@@ -223,7 +223,7 @@ export function TeamSSO({ team }: { team: TeamResponse }) {
                               ? "This domain has been verified and may be used with SSO"
                               : isPending
                                 ? "This domain has not yet completed verification. Check the status by clicking 'Manage domains' below."
-                                : "An error occured verifying this domain. Check the status by clicking 'Manage domains' below.";
+                                : "An error occurred verifying this domain. Check the status by clicking 'Manage domains' below.";
 
                             // Check if user has a verified email for this domain
                             const hasVerifiedEmailForDomain =


### PR DESCRIPTION
Four small typo fixes — two in user-visible dashboard strings, two in code comments.

**User-visible:**
- `npm-packages/dashboard/src/components/teamSettings/OauthApps.tsx`: seperated -> separated (label on the OAuth Apps redirect-URIs textarea)
- `npm-packages/dashboard/src/components/teamSettings/TeamSSO.tsx`: occured -> occurred (tooltip shown when domain verification fails)

**Comments only:**
- `npm-packages/dashboard-common/src/features/settings/components/integrations/Integrations.tsx`: enviroment -> environment
- `npm-packages/convex/src/cli/lib/utils/utils.ts`: reponse -> response (in `ThrowingFetchError` doc-comment)

No behaviour, type, or API changes.