### PR TITLE
Fix dry-run push to roll back schema changes and skip index creation

### DIFF
--- a/crates/application/src/deploy_config.rs
+++ b/crates/application/src/deploy_config.rs
@@ -15,6 +15,7 @@ use common::{
     auth::AuthInfo,
     bootstrap_model::{
         components::definition::ComponentDefinitionMetadata,
+        push_mode::PushMode,
         schema::{
             SchemaMetadata,
             SchemaState,
@@ -46,6 +47,7 @@ use database::{
     BootstrapComponentsModel,
     IndexModel,
     OccRetryStats,
+    SchemaModel,
     Token,
     WriteSource,
     SCHEMAS_TABLE,
@@ -170,7 +172,11 @@ struct EvaluatedPushContents {
 
 impl<RT: Runtime> Application<RT> {
     #[fastrace::trace]
-    pub async fn start_push(&self, config: &ProjectConfig) -> anyhow::Result<StartPushResult> {
+    pub async fn start_push(
+        &self,
+        config: &ProjectConfig,
+        push_mode: PushMode,
+    ) -> anyhow::Result<StartPushResult> {
         let EvaluatedPushContents {
             app,
             auth_info,
@@ -182,7 +188,7 @@ impl<RT: Runtime> Application<RT> {
         } = self.evaluate_push_contents(config).await?;
 
         let schema_change = self
-            .handle_schema_change_in_start_push(&app, &evaluated_components)
+            .handle_schema_change_in_start_push(&app, &evaluated_components, push_mode)
             .await?;
         self.database
             .load_indexes_into_memory(btreeset! { SCHEMAS_TABLE.clone() })
@@ -314,9 +320,11 @@ impl<RT: Runtime> Application<RT> {
         &self,
         app: &CheckedComponent,
         evaluated_components: &BTreeMap<ComponentDefinitionPath, EvaluatedComponentDefinition>,
+        push_mode: PushMode,
     ) -> anyhow::Result<SchemaChange> {
-        // Even in dry run mode, we need to commit the schema changes so that
-        // wait_for_schema can validate the schema against existing data.
+        // We commit schema changes (even for dry runs) so that wait_for_schema can
+        // validate the schema against existing data. For dry runs, finish_push will
+        // roll back these changes instead of activating them.
         let (_ts, schema_change) = self
             .execute_with_occ_retries(
                 Identity::system(),
@@ -325,7 +333,7 @@ impl<RT: Runtime> Application<RT> {
                 |tx| {
                     async move {
                         let schema_change = ComponentConfigModel::new(tx)
-                            .start_component_schema_changes(app, evaluated_components)
+                            .start_component_schema_changes(app, evaluated_components, push_mode)
                             .await?;
                         Ok(schema_change)
                     }
@@ -344,7 +352,7 @@ impl<RT: Runtime> Application<RT> {
     ) -> anyhow::Result<SchemaChange> {
         let mut tx = self.begin(Identity::system()).await?;
         let schema_change = ComponentConfigModel::new(&mut tx)
-            .start_component_schema_changes(app, evaluated_components)
+            .start_component_schema_changes(app, evaluated_components, PushMode::Normal)
             .await?;
         drop(tx);
         Ok(schema_change)
@@ -536,11 +544,12 @@ impl<RT: Runtime> Application<RT> {
         identity: Identity,
         schema_change: SchemaChange,
         timeout: Duration,
+        push_mode: PushMode,
     ) -> anyhow::Result<SchemaStatus> {
         let deadline = self.runtime().monotonic_now() + timeout;
         loop {
             let (status, token) = self
-                .load_component_schema_status(&identity, &schema_change)
+                .load_component_schema_status(&identity, &schema_change, push_mode)
                 .await?;
             let now = self.runtime().monotonic_now();
             let in_progress = matches!(status, SchemaStatus::InProgress { .. });
@@ -562,6 +571,7 @@ impl<RT: Runtime> Application<RT> {
         &self,
         identity: &Identity,
         schema_change: &SchemaChange,
+        push_mode: PushMode,
     ) -> anyhow::Result<(SchemaStatus, Token)> {
         let mut tx = self.begin(identity.clone()).await?;
         let mut components_status = BTreeMap::new();
@@ -609,21 +619,29 @@ impl<RT: Runtime> Application<RT> {
                 ComponentId::Child(internal_id)
             };
             let namespace = TableNamespace::from(component_id);
-            let mut indexes_complete = 0;
-            let mut indexes_total = 0;
-            for index in IndexModel::new(&mut tx)
-                .get_application_indexes(namespace)
-                .await?
-            {
-                // Skip counting indexes that are staged
-                if index.config.is_staged() {
-                    continue;
+            // Dry-run pushes never create index documents, so there is nothing
+            // to backfill. Treat all indexes as done so that only
+            // schema_validation_complete gates progress.
+            let (indexes_complete, indexes_total) = if push_mode.is_dry_run() {
+                (0, 0)
+            } else {
+                let mut complete = 0;
+                let mut total = 0;
+                for index in IndexModel::new(&mut tx)
+                    .get_application_indexes(namespace)
+                    .await?
+                {
+                    // Skip counting indexes that are staged
+                    if index.config.is_staged() {
+                        continue;
+                    }
+                    if !index.config.is_backfilling() {
+                        complete += 1;
+                    }
+                    total += 1;
                 }
-                if !index.config.is_backfilling() {
-                    indexes_complete += 1;
-                }
-                indexes_total += 1;
-            }
+                (complete, total)
+            };
             components_status.insert(
                 component_path.clone(),
                 ComponentSchemaStatus {
@@ -642,6 +660,64 @@ impl<RT: Runtime> Application<RT> {
         };
         let token = tx.into_token()?;
         Ok((status, token))
+    }
+
+    /// Roll back schema changes committed during a dry-run start_push.
+    ///
+    /// Marks each pending/validated schema as Overwritten, stopping the
+    /// SchemaWorker and preventing enforcement of the dry-run schema against
+    /// live writes. Idempotent: safe to call multiple times on the same
+    /// schema_change.
+    #[fastrace::trace]
+    pub async fn rollback_dry_run_schema_change(
+        &self,
+        schema_change: &SchemaChange,
+    ) -> anyhow::Result<()> {
+        self.execute_with_occ_retries(
+            Identity::system(),
+            FunctionUsageTracker::new(),
+            WriteSource::system("rollback_dry_run"),
+            |tx| {
+                async move {
+                    for (component_path, schema_id) in &schema_change.schema_ids {
+                        let Some(schema_id) = schema_id else {
+                            continue;
+                        };
+                        let component_id = if component_path.is_root() {
+                            ComponentId::Root
+                        } else {
+                            let existing =
+                                BootstrapComponentsModel::new(tx).resolve_path(component_path)?;
+                            let allocated =
+                                schema_change.allocated_component_ids.get(component_path);
+                            let internal_id = match (existing, allocated) {
+                                (None, Some(id)) => *id,
+                                (Some(doc), None) => doc.id().into(),
+                                r => anyhow::bail!("Invalid existing component state: {r:?}"),
+                            };
+                            ComponentId::Child(internal_id)
+                        };
+                        let namespace = TableNamespace::from(component_id);
+                        let schema_table_number =
+                            tx.table_mapping().tablet_number(schema_id.table())?;
+                        let resolved_schema_id = ResolvedDocumentId::new(
+                            schema_id.table(),
+                            DeveloperDocumentId::new(
+                                schema_table_number,
+                                schema_id.internal_id(),
+                            ),
+                        );
+                        SchemaModel::new(tx, namespace)
+                            .mark_overwritten(resolved_schema_id)
+                            .await?;
+                    }
+                    Ok(())
+                }
+                .into()
+            },
+        )
+        .await?;
+        Ok(())
     }
 
     #[fastrace::trace]
@@ -913,6 +989,13 @@ impl<RT: Runtime> InitializerEvaluator for ApplicationInitializerEvaluator<'_, R
 #[serde(rename_all = "camelCase")]
 pub struct StartPushRequest {
     pub admin_key: String,
+
+    /// Whether this is a dry-run push. Dry-run pushes commit schema changes
+    /// so validation runs against real data, then roll them back in finish_push
+    /// instead of activating functions. Old clients that don't send this field
+    /// default to false (non-dry-run behavior).
+    #[serde(default)]
+    pub dry_run: bool,
 
     pub functions: String,
 

--- a/crates/common/src/bootstrap_model/mod.rs
+++ b/crates/common/src/bootstrap_model/mod.rs
@@ -11,6 +11,7 @@
 //! colocated in database crate.
 pub mod components;
 pub mod index;
+pub mod push_mode;
 pub mod schema;
 pub mod schema_metadata;
 mod schema_state;

--- a/crates/common/src/bootstrap_model/push_mode.rs
+++ b/crates/common/src/bootstrap_model/push_mode.rs
@@ -1,0 +1,16 @@
+/// Whether a push is a dry run or a normal live push.
+///
+/// Dry-run pushes commit schema and index changes so that `wait_for_schema`
+/// can validate existing data, but `finish_push` rolls them back instead of
+/// activating them. Normal pushes activate the changes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PushMode {
+    Normal,
+    DryRun,
+}
+
+impl PushMode {
+    pub fn is_dry_run(self) -> bool {
+        self == PushMode::DryRun
+    }
+}

--- a/crates/database/src/bootstrap_model/index.rs
+++ b/crates/database/src/bootstrap_model/index.rs
@@ -1084,7 +1084,11 @@ impl<'a, RT: Runtime> IndexModel<'a, RT> {
                 IndexConfig::Database {
                     spec: DatabaseIndexSpec { fields },
                     ..
-                } => IndexMetadata::new_backfilling(*self.tx.begin_timestamp(), index_name, fields),
+                } => IndexMetadata::new_backfilling(
+                    *self.tx.begin_timestamp(),
+                    index_name,
+                    fields,
+                ),
                 IndexConfig::Text {
                     spec:
                         TextIndexSpec {

--- a/crates/database/src/bootstrap_model/schema/mod.rs
+++ b/crates/database/src/bootstrap_model/schema/mod.rs
@@ -464,7 +464,7 @@ impl<'a, RT: Runtime> SchemaModel<'a, RT> {
         Ok(num_deleted)
     }
 
-    async fn mark_overwritten(&mut self, id: ResolvedDocumentId) -> anyhow::Result<()> {
+    pub async fn mark_overwritten(&mut self, id: ResolvedDocumentId) -> anyhow::Result<()> {
         SystemMetadataModel::new(self.tx, self.namespace)
             .patch(
                 id,

--- a/crates/local_backend/src/deploy_config2.rs
+++ b/crates/local_backend/src/deploy_config2.rs
@@ -10,6 +10,7 @@ use application::deploy_config::{
     StartPushRequest,
     StartPushResponse,
 };
+use common::bootstrap_model::push_mode::PushMode;
 use axum::{
     debug_handler,
     extract::State,
@@ -207,13 +208,19 @@ pub async fn start_push(
     )
     .await?;
     _identity.require_operation(keybroker::DeploymentOp::Deploy)?;
+    let push_mode = if req.dry_run {
+        PushMode::DryRun
+    } else {
+        PushMode::Normal
+    };
     let config = req.into_project_config().map_err(|e| {
         anyhow::Error::new(ErrorMetadata::bad_request("InvalidConfig", e.to_string()))
     })?;
-    let result =
-        st.application.start_push(&config).await.map_err(|e| {
-            e.wrap_error_message(|msg| format!("Hit an error while pushing:\n{msg}"))
-        })?;
+    let result = st
+        .application
+        .start_push(&config, push_mode)
+        .await
+        .map_err(|e| e.wrap_error_message(|msg| format!("Hit an error while pushing:\n{msg}")))?;
     Ok(Json(SerializedStartPushResponse::try_from(
         result.response,
     )?))
@@ -253,6 +260,11 @@ pub struct WaitForSchemaRequest {
     admin_key: String,
     schema_change: SerializedSchemaChange,
     timeout_ms: Option<u32>,
+    /// When true, return complete as soon as the schema reaches Validated
+    /// without waiting for index backfill to finish. Dry-run pushes never
+    /// create index documents, so there is nothing to backfill.
+    #[serde(default)]
+    dry_run: bool,
 }
 
 pub async fn wait_for_schema(
@@ -268,12 +280,14 @@ pub async fn wait_for_schema(
     identity.require_operation(keybroker::DeploymentOp::Deploy)?;
     let timeout = Duration::from_millis(req.timeout_ms.unwrap_or(DEFAULT_SCHEMA_TIMEOUT_MS) as u64);
     let schema_change = req.schema_change.try_into()?;
-
-    // In dry_run mode, we commit the schema changes in start_push so we can
-    // validate the schema against existing data.
+    let push_mode = if req.dry_run {
+        PushMode::DryRun
+    } else {
+        PushMode::Normal
+    };
     let resp = st
         .application
-        .wait_for_schema(identity, schema_change, timeout)
+        .wait_for_schema(identity, schema_change, timeout, push_mode)
         .await?;
     Ok(Json(SchemaStatusJson::from(resp)))
 }
@@ -303,10 +317,16 @@ pub async fn finish_push_internal(
     let start_push = StartPushResponse::try_from(req.start_push)?;
     let message = req.message.map(PushMessage::try_from).transpose()?;
 
-    // We can't actually run `finish_push` in a dry run, since we rolled back all of
-    // our changes during start push.
     if req.dry_run {
-        tracing::info!("Skipping finish_push in dry run");
+        tracing::info!("Rolling back dry-run schema and index changes");
+        st.application
+            .rollback_dry_run_schema_change(&start_push.schema_change)
+            .await
+            .map_err(|e| {
+                e.wrap_error_message(|msg| {
+                    format!("Hit an error while rolling back dry-run push:\n{msg}")
+                })
+            })?;
         let empty_diff = FinishPushDiff::default();
         return Ok((SerializedFinishPushDiff::try_from(empty_diff)?, None));
     }

--- a/crates/model/src/components/config.rs
+++ b/crates/model/src/components/config.rs
@@ -15,6 +15,7 @@ use common::{
             ComponentState,
             ComponentType,
         },
+        push_mode::PushMode,
         schema::SchemaState,
     },
     components::{
@@ -266,6 +267,7 @@ impl<'a, RT: Runtime> ComponentConfigModel<'a, RT> {
         &mut self,
         app: &CheckedComponent,
         new_definitions: &BTreeMap<ComponentDefinitionPath, EvaluatedComponentDefinition>,
+        push_mode: PushMode,
     ) -> anyhow::Result<SchemaChange> {
         let existing_components_by_parent = BootstrapComponentsModel::new(self.tx)
             .load_all_components()
@@ -309,10 +311,17 @@ impl<'a, RT: Runtime> ComponentConfigModel<'a, RT> {
                     .get(&new_node.definition_path)
                     .context("Missing definition for component")?;
                 let schema_id = if let Some(ref schema) = definition.schema {
-                    let index_diff = IndexModel::new(self.tx)
-                        .prepare_new_and_mutated_indexes(namespace, schema)
-                        .await?;
-
+                    // Dry runs only need the index diff for reporting — don't create
+                    // index documents or wake the IndexWorker.
+                    let index_diff = if push_mode.is_dry_run() {
+                        IndexModel::new(self.tx)
+                            .get_index_diff(namespace, &schema.tables)
+                            .await?
+                    } else {
+                        IndexModel::new(self.tx)
+                            .prepare_new_and_mutated_indexes(namespace, schema)
+                            .await?
+                    };
                     let (schema_id, schema_state) = SchemaModel::new(self.tx, namespace)
                         .submit_pending(schema.clone())
                         .await?;


### PR DESCRIPTION
# Fix dry-run push to roll back schema changes and skip index creation

## What's broken

`convex deploy --dry-run` is not dry. Since `dcc7519ce` ("Use components push path as default", Oct 2025), every dry-run push commits schema changes to the real deployment and leaves them there. Concretely:

- A new schema is written to `_schemas` in `Pending`/`Validated` state
- That schema is enforced on live writes immediately — if the dry-run schema is more restrictive than the current active schema, production writes start failing
- The schema stays enforced until the next real deploy overwrites it
- New indexes are created and the IndexWorker starts backfilling them

The only thing dry-run correctly skips is function activation in `finish_push`.

## How it got here

The history across three commits tells the story:

**September 2024** (`33e4a3eee`) — dry-run was enabled for the components push path for the first time, removing the `"dryRun not allowed yet"` crash. The design assumed `start_push` was non-mutating for dry runs. It wasn't — `StartPushRequest` had no `dry_run` field on the backend, so the flag the CLI sent was silently dropped and schema changes were committed unconditionally.

**January 2025** (`04a69fdfe`) — `_handle_schema_change_in_start_push` was introduced with an explicit `if dry_run { drop(tx) }` branch. This was correct: the transaction was dropped without committing for dry runs, so no schema or index changes were persisted.

**October 2025** (`dcc7519ce`) — the `dry_run` branch and the `dry_run` field from `StartPushRequest` were removed, with the comment: *"Even in dry run mode, we need to commit the schema changes so that wait_for_schema can validate the schema against existing data."* The intent — schema validation against real data — is sound. The gap: `finish_push` was updated to skip function activation for dry runs, but nothing was added to roll back the schema changes that were now unconditionally committed. The comment *"We can't actually run finish_push in a dry run, since we rolled back all of our changes during start push"* described intended behavior that was never implemented.

## What this PR does

**1. Wire `dry_run` through the push pipeline**

Adds `dry_run: bool` (with `#[serde(default)]` for backwards compatibility) to `StartPushRequest` and `WaitForSchemaRequest`. Introduces a `PushMode` enum (`Normal` / `DryRun`) that propagates through the stack as a typed value rather than a raw boolean.

**2. Roll back schema changes in `finish_push`**

When `dry_run: true`, `finish_push` now calls `rollback_dry_run_schema_change` before returning. This calls `mark_overwritten` on each schema document created by `start_push`, which:
- Transitions the schema `Pending`/`Validated` → `Overwritten`
- Stops `enforce` from validating live writes against the dry-run schema
- Deletes the `_schema_validation_progress` document, signalling the SchemaWorker to stop

**3. Skip index creation entirely for dry runs**

In `start_component_schema_changes`, dry runs now call `get_index_diff` instead of `prepare_new_and_mutated_indexes`. The diff is computed for reporting (so "Would add table indexes" output is preserved) but no index documents are written, so the IndexWorker never wakes up. This is safe because `wait_for_schema` is already gated on schema validation only for dry runs — index backfill was never meaningful to wait for in a dry-run context.

**4. `wait_for_schema` returns at `Validated`, not full backfill**

Since dry runs don't create index documents, `load_component_schema_status` short-circuits the index count when `dry_run: true`, returning `complete` as soon as the schema reaches `Validated`. This avoids a spurious wait on backfill that will never happen.

## What dry-run now does (and doesn't do)

| | Before | After |
|---|---|---|
| Schema committed to `_schemas` | ✓ always | ✓ always (needed for SchemaWorker validation) |
| Schema enforced on live writes | ✓ until next deploy | ✗ rolled back at end of dry run |
| Index documents created | ✓ IndexWorker backfills | ✗ never created |
| Index diff reported to CLI | ✓ | ✓ (via `get_index_diff`) |
| Function activation | ✗ | ✗ |

Schema validation against real data is preserved — that's the valuable part of Jordan's October 2025 intent, and this PR keeps it.

## Backwards compatibility

Old CLI versions that don't send `dry_run` in `StartPushRequest` or `WaitForSchemaRequest` get `false` via `#[serde(default)]` and see identical behaviour to today. New CLI with old backend: the flag is present in request bodies but ignored — same broken behaviour as today until backend is updated. The migration path is: ship backend, CLI follows.