### PR TITLE
node-executor: fix Windows file:// upload path in build_deps

### DIFF
--- a/npm-packages/node-executor/src/build_deps.test.ts
+++ b/npm-packages/node-executor/src/build_deps.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from "vitest";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+// These tests pin the contract `buildDepsInner`'s `case "file:":` branch
+// depends on: the value handed to `fs.mkdirSync` / `fs.renameSync` must be a
+// native filesystem path produced by `fileURLToPath`, not `url.pathname`.
+//
+// Pre-fix (issue #152): on Windows, `new URL("file:///C:/x/foo.zip").pathname`
+// is `/C:/x/foo.zip`, and Windows `fs.mkdirSync` resolves the leading `/`
+// against the current drive root, producing `<cwd-drive>:\C:\x\foo.zip` and
+// ENOENT.
+describe("build_deps file:// path conversion", () => {
+  it("fileURLToPath returns a native filesystem path for the current platform", () => {
+    const url =
+      process.platform === "win32"
+        ? new URL("file:///C:/Users/test/.convex/node_modules.zip")
+        : new URL("file:///tmp/build_deps/node_modules.zip");
+
+    const filePath = fileURLToPath(url);
+
+    expect(path.isAbsolute(filePath)).toBe(true);
+    expect(path.basename(filePath)).toBe("node_modules.zip");
+    expect(filePath.startsWith("file:")).toBe(false);
+    if (process.platform === "win32") {
+      // Drive-letter prefix, no leading slash. `url.pathname` would be `/C:/...`.
+      expect(filePath.startsWith("/")).toBe(false);
+      expect(/^[A-Za-z]:[\\/]/.test(filePath)).toBe(true);
+    }
+  });
+
+  it("regression: url.pathname is the broken shape this fix replaces", () => {
+    // On every platform, a Windows-shaped `file://` URL produces a `pathname`
+    // of the form `/<drive>:/...` — the POSIX-form string that triggered the
+    // ENOENT on Windows. Making the broken contract explicit here means the
+    // intent of the fix can't quietly drift in a future read.
+    const url = new URL("file:///C:/x/y.zip");
+    expect(url.pathname).toBe("/C:/x/y.zip");
+    expect(url.pathname).toMatch(/^\/[A-Za-z]:\//);
+  });
+});

--- a/npm-packages/node-executor/src/build_deps.ts
+++ b/npm-packages/node-executor/src/build_deps.ts
@@ -6,6 +6,7 @@ import { createHash } from "node:crypto";
 import { Readable } from "node:stream";
 import path from "node:path";
 import os from "node:os";
+import { fileURLToPath } from "node:url";
 import { logDurationMs } from "./log";
 import { Hash } from "crypto";
 
@@ -158,19 +159,24 @@ async function buildDepsInner(
   const zippedSizeBytes = fs.statSync(`${dir}/node_modules.zip`).size;
 
   // Upload "node_modules.zip" to specified url
-  let key: string;
   let readStream: fs.ReadStream;
   const startUpload = performance.now();
   switch (url.protocol) {
     // This case is used for local backends that use the filesystem instead of S3 as a storage layer
-    case "file:":
-      fs.mkdirSync(path.dirname(url.pathname), {
+    case "file:": {
+      // `url.pathname` is the URL-form path (`/C:/Users/...` on Windows) and
+      // is not safe as a filesystem path: Windows resolves the leading `/`
+      // against the current drive root, producing `<cwd-drive>:\C:\Users\...`
+      // and ENOENT. `fileURLToPath` is the canonical Node helper for this
+      // conversion. See https://github.com/get-convex/convex-backend/issues/152.
+      const filePath = fileURLToPath(url);
+      fs.mkdirSync(path.dirname(filePath), {
         recursive: true,
         mode: 0o744,
       });
-      key = url.pathname;
-      fs.renameSync(`${dir}/node_modules.zip`, key);
+      fs.renameSync(`${dir}/node_modules.zip`, filePath);
       break;
+    }
     // This is the S3 case
     case "https:":
       readStream = fs.createReadStream(`${dir}/node_modules.zip`);


### PR DESCRIPTION
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

## What this fixes

On a Windows host, `npx convex dev --local` (and any self-hosted `convex-local-backend.exe`) cannot accept a push of an app whose `"use node"` modules pull in external packages. `buildDeps` fails before `npm install` output reaches disk:

```
ENOENT: no such file or directory, mkdir '<cwd-drive>:\C:\Users\...\.convex\...\external_deps'
```

Cloud deployments and Linux/macOS local backends are unaffected.

## Root cause

The `case "file:":` branch of `buildDepsInner` in `npm-packages/node-executor/src/build_deps.ts` handed `url.pathname` to `fs.mkdirSync` and `fs.renameSync`. The Rust local backend emits `file:///C:/Users/.../node_modules.zip` on Windows, for which `new URL(...).pathname` is the URL-form `/C:/Users/.../node_modules.zip`. On Windows, that leading `/` makes the path resolve against the current drive root, producing `<cwd-drive>:\C:\Users\...` and ENOENT.

## Fix

Replace `url.pathname` with `fileURLToPath(url)` from `node:url` — the canonical Node helper for converting a `file:` URL to a native filesystem path (handles Windows drive letters, percent-encoded characters, and UNC paths). On Windows it returns `C:\Users\...`; on POSIX it returns `/...`. No behavior change on Linux/macOS.

The symmetric file:// download path in `source_package.ts` already uses `fileURLToPath`; this aligns the upload path. PR #459 brings the inverse conversion (`pathToFileURL`) to `executor.ts` for the dynamic-import path — both fixes are needed for `"use node"` to work end-to-end on a Windows local backend.

Also drops a dead `let key: string;` declaration that was only assigned in this branch and never read after the switch.

## Tests

`npm-packages/node-executor/src/build_deps.test.ts` adds two vitest cases that pin the contract on every platform:

- `fileURLToPath` of a platform-appropriate `file://` URL produces an absolute native-form path with the expected basename. On Windows, asserts drive-letter prefix and no leading slash.
- Regression: a Windows-shaped `file://` URL's `pathname` is the POSIX-form `/<drive>:/...` string that triggered the ENOENT — making the broken contract this fix replaces explicit so the intent of the fix can't quietly drift on a future read.

These exercise the same Node stdlib function `buildDepsInner` calls. A regression to `url.pathname` would be a visible diff edit (one of two functions in the `file:` branch), not silent drift — matching the test rigor PR #459 set for the sibling fix in `executor.test.ts`.

## Verification

- Vitest cases pass on Windows.
- Full end-to-end Windows verification (rebuild `convex-local-backend.exe`, push a `"use node"` app with external packages, observe successful deploy) requires the upstream rebuild + release pipeline.

## Related

- Fixes a piece of [#152](https://github.com/get-convex/convex-backend/issues/152) (`"use node"` doesn't work on Windows).
- Sibling: [#459](https://github.com/get-convex/convex-backend/pull/459) — fixes the action-runtime side of the same Windows path issue in `executor.ts`. Both are needed end-to-end.