### PR TITLE
fix: Do not mark UseQueryResult as an internal export

### DIFF
--- a/npm-packages/convex/src/react/index.ts
+++ b/npm-packages/convex/src/react/index.ts
@@ -82,6 +82,7 @@ export {
   type MutationOptions,
   type ConvexReactClientOptions,
   type OptionalRestArgsOrSkip,
+  type UseQueryResult,
   ConvexReactClient,
   useConvex,
   ConvexProvider,
@@ -91,8 +92,6 @@ export {
   useAction,
   useConvexConnectionState,
 } from "./client.js";
-/** @internal */
-export type { UseQueryResult } from "./client.js";
 /** @internal */
 export { convexQueryOptions } from "../browser/query_options.js";
 export type { QueryOptions } from "../browser/query_options.js";


### PR DESCRIPTION
In https://github.com/get-convex/convex-backend/commit/0f8d1cb52b31dfa7c50b8986030104b9bf660437, the experimental object-form `useQuery_experimental` hook was exposed.
However, it appears that a previous version of that was reverted in https://github.com/get-convex/convex-backend/commit/b68d5d0dcbe57dfd169f8d43fa1f574b77bb202f, marking exports as internal.

This PR reverts the change in https://github.com/get-convex/convex-backend/commit/b68d5d0dcbe57dfd169f8d43fa1f574b77bb202f to export the return type, to let users infer the return type (e.g. when creating custom hooks) of `useQuery_experimental` without facing TS2742 (The inferred type of 'X' cannot be named without a reference to '{...}/convex/dist/esm-types/react/client'. This is likely not portable. A type annotation is necessary.) when using TypeScript.

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
