### PR TITLE
Add eslint-plugin rule no-unexported-convex-function

### DIFF
--- a/npm-packages/@convex-dev/eslint-plugin/src/index.ts
+++ b/npm-packages/@convex-dev/eslint-plugin/src/index.ts
@@ -4,6 +4,7 @@ import { requireArgsValidator } from "./lib/require-args-validator.js";
 import { noFilterInQuery } from "./lib/no-filter-in-query.js";
 import { explicitTableIds } from "./lib/explicit-table-ids.js";
 import { noCollectInQuery } from "./lib/no-collect-in-query.js";
+import { noUnexportedConvexFunction } from "./lib/no-unexported-convex-function.js";
 import type { RuleModule } from "@typescript-eslint/utils/ts-eslint";
 import { version } from "./version.js";
 
@@ -14,6 +15,7 @@ const rules = {
   "explicit-table-ids": explicitTableIds,
   "no-filter-in-query": noFilterInQuery,
   "no-collect-in-query": noCollectInQuery,
+  "no-unexported-convex-function": noUnexportedConvexFunction,
 } satisfies Record<string, RuleModule<string, unknown[]>>;
 
 const recommendedRules = {

--- a/npm-packages/@convex-dev/eslint-plugin/src/lib/no-unexported-convex-function.test.ts
+++ b/npm-packages/@convex-dev/eslint-plugin/src/lib/no-unexported-convex-function.test.ts
@@ -1,0 +1,66 @@
+import { RuleTester } from "@typescript-eslint/rule-tester";
+import tseslint from "typescript-eslint";
+import { noUnexportedConvexFunction } from "./no-unexported-convex-function.js";
+
+const ruleTester = new RuleTester({
+  languageOptions: {
+    parser: tseslint.parser,
+    parserOptions: {
+      ecmaVersion: "latest",
+      sourceType: "module",
+    },
+  },
+});
+
+const filename = "convex/messages.ts";
+
+ruleTester.run(
+  "no-unexported-convex-function",
+  noUnexportedConvexFunction,
+  {
+    valid: [
+      {
+        filename,
+        code: 'export const send = mutation({ handler: async () => null });',
+      },
+      {
+        filename,
+        code: [
+          'const send = mutation({ handler: async () => null });',
+          "export { send };",
+        ].join("\n"),
+      },
+      {
+        filename,
+        code: 'const send = authMutation({ handler: async () => null });',
+      },
+      {
+        filename: "convex\\_generated\\server.ts",
+        code: 'const send = mutation({ handler: async () => null });',
+      },
+    ],
+    invalid: [
+      {
+        filename,
+        code: 'const send = mutation({ handler: async () => null });',
+        errors: [
+          {
+            messageId: "no-unexported-convex-function",
+            data: { name: "send", registrar: "mutation" },
+          },
+        ],
+      },
+      {
+        filename,
+        code: 'const send = authMutation({ handler: async () => null });',
+        options: [{ additionalRegistrars: ["authMutation"] }],
+        errors: [
+          {
+            messageId: "no-unexported-convex-function",
+            data: { name: "send", registrar: "authMutation" },
+          },
+        ],
+      },
+    ],
+  },
+);

--- a/npm-packages/@convex-dev/eslint-plugin/src/lib/no-unexported-convex-function.ts
+++ b/npm-packages/@convex-dev/eslint-plugin/src/lib/no-unexported-convex-function.ts
@@ -2,7 +2,11 @@ import type { TSESTree } from "@typescript-eslint/types";
 import { AST_NODE_TYPES } from "@typescript-eslint/types";
 import { CONVEX_REGISTRARS, createRule, isEntryPoint } from "../util.js";
 
-type Options = [];
+type Options = [
+  {
+    additionalRegistrars: string[];
+  },
+];
 type MessageIds = "no-unexported-convex-function";
 
 /**
@@ -25,17 +29,35 @@ export const noUnexportedConvexFunction = createRule<Options, MessageIds>({
       description:
         "Disallow declaring Convex functions (`query`, `mutation`, `action`, and their `internal*` variants) that are never exported.",
     },
-    schema: [],
+    schema: [
+      {
+        type: "object",
+        properties: {
+          additionalRegistrars: {
+            type: "array",
+            items: { type: "string" },
+            description:
+              "Additional function names to treat as Convex function registrars, for custom wrappers like authMutation.",
+          },
+        },
+        additionalProperties: false,
+      },
+    ],
     messages: {
       "no-unexported-convex-function":
         "Convex function `{{name}}` is declared with `{{registrar}}()` but is never exported. Convex only registers functions that are exported from a module in `convex/`, so this declaration has no effect at runtime — add `export` or remove it.",
     },
   },
-  defaultOptions: [],
-  create(context) {
+  defaultOptions: [{ additionalRegistrars: [] }],
+  create(context, options) {
     // Only check files that the Convex bundler treats as entry points; helper
     // modules and `_generated/*` are not walked for function registration.
     if (!isEntryPoint(context.filename)) return {};
+
+    const registrars = new Set<string>([
+      ...CONVEX_REGISTRARS,
+      ...options[0].additionalRegistrars,
+    ]);
 
     const candidates = new Map<
       string,
@@ -59,7 +81,7 @@ export const noUnexportedConvexFunction = createRule<Options, MessageIds>({
           const init = declarator.init;
           if (!init || init.type !== AST_NODE_TYPES.CallExpression) continue;
           if (init.callee.type !== AST_NODE_TYPES.Identifier) continue;
-          if (!CONVEX_REGISTRARS.includes(init.callee.name)) continue;
+          if (!registrars.has(init.callee.name)) continue;
 
           if (isExported) {
             exportedNames.add(declarator.id.name);

--- a/npm-packages/@convex-dev/eslint-plugin/src/lib/no-unexported-convex-function.ts
+++ b/npm-packages/@convex-dev/eslint-plugin/src/lib/no-unexported-convex-function.ts
@@ -1,0 +1,98 @@
+import type { TSESTree } from "@typescript-eslint/types";
+import { AST_NODE_TYPES } from "@typescript-eslint/types";
+import { CONVEX_REGISTRARS, createRule, isEntryPoint } from "../util.js";
+
+type Options = [];
+type MessageIds = "no-unexported-convex-function";
+
+/**
+ * Rule to disallow declaring Convex functions that are never exported.
+ *
+ * Convex registers functions by walking the exports of each entry-point
+ * module under `convex/`. A top-level `const foo = query({ ... })` that is
+ * never exported is dead code at runtime — the registration walker never
+ * sees it. This is almost always an oversight (a missing `export` keyword)
+ * rather than intentional, and silently fails: the developer thinks they
+ * have a callable function but the client cannot reach it.
+ *
+ * See https://github.com/get-convex/convex-backend/issues/129.
+ */
+export const noUnexportedConvexFunction = createRule<Options, MessageIds>({
+  name: "no-unexported-convex-function",
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Disallow declaring Convex functions (`query`, `mutation`, `action`, and their `internal*` variants) that are never exported.",
+    },
+    schema: [],
+    messages: {
+      "no-unexported-convex-function":
+        "Convex function `{{name}}` is declared with `{{registrar}}()` but is never exported. Convex only registers functions that are exported from a module in `convex/`, so this declaration has no effect at runtime — add `export` or remove it.",
+    },
+  },
+  defaultOptions: [],
+  create(context) {
+    // Only check files that the Convex bundler treats as entry points; helper
+    // modules and `_generated/*` are not walked for function registration.
+    if (!isEntryPoint(context.filename)) return {};
+
+    const candidates = new Map<
+      string,
+      { node: TSESTree.Node; registrar: string }
+    >();
+    const exportedNames = new Set<string>();
+
+    return {
+      VariableDeclaration(node) {
+        const parent = node.parent;
+        if (!parent) return;
+        const isExported =
+          parent.type === AST_NODE_TYPES.ExportNamedDeclaration;
+        const atTopLevel =
+          parent.type === AST_NODE_TYPES.Program ||
+          (isExported && parent.parent?.type === AST_NODE_TYPES.Program);
+        if (!atTopLevel) return;
+
+        for (const declarator of node.declarations) {
+          if (declarator.id.type !== AST_NODE_TYPES.Identifier) continue;
+          const init = declarator.init;
+          if (!init || init.type !== AST_NODE_TYPES.CallExpression) continue;
+          if (init.callee.type !== AST_NODE_TYPES.Identifier) continue;
+          if (!CONVEX_REGISTRARS.includes(init.callee.name)) continue;
+
+          if (isExported) {
+            exportedNames.add(declarator.id.name);
+          } else {
+            candidates.set(declarator.id.name, {
+              node: declarator,
+              registrar: init.callee.name,
+            });
+          }
+        }
+      },
+      // `export { foo }` and `export { foo as bar }` (re-exports too).
+      ExportSpecifier(node) {
+        if (node.local.type === AST_NODE_TYPES.Identifier) {
+          exportedNames.add(node.local.name);
+        }
+      },
+      // `export default foo` where `foo` is a previously-declared identifier.
+      ExportDefaultDeclaration(node) {
+        if (node.declaration.type === AST_NODE_TYPES.Identifier) {
+          exportedNames.add(node.declaration.name);
+        }
+      },
+      "Program:exit"() {
+        for (const [name, { node, registrar }] of candidates) {
+          if (exportedNames.has(name)) continue;
+          context.report({
+            node,
+            messageId: "no-unexported-convex-function",
+            data: { name, registrar },
+          });
+        }
+      },
+    };
+  },
+});


### PR DESCRIPTION
Added an ESLint rule to catch Convex function registrations that are declared but not exported from entry-point modules.

This prevents runtime dead code in `convex/` by flagging top-level `query`, `mutation`, `action`, `internalQuery`, `internalMutation`, and `internalAction` declarations that are never exported.