### PR TITLE
fix: make just run-local-backend work in OSS checkouts

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -19,10 +19,12 @@ _default:
 set positional-arguments
 
 # (*) Run the open source convex backend on port 3210
+# The first instance-name/secret path matches the layout in the upstream Convex monorepo
+# where keybroker/ is a sibling directory; the fallback is the OSS layout at crates/keybroker/.
 run-local-backend *ARGS:
   cargo run -p local_backend --bin convex-local-backend -- \
-    --instance-name "$(cat {{justfile_directory()}}/../keybroker/dev/instance_name.txt)" \
-    --instance-secret "$(cat {{justfile_directory()}}/../keybroker/dev/secret.txt)" \
+    --instance-name "$(cat {{justfile_directory()}}/../keybroker/dev/instance_name.txt 2>/dev/null || cat {{justfile_directory()}}/crates/keybroker/dev/instance_name.txt)" \
+    --instance-secret "$(cat {{justfile_directory()}}/../keybroker/dev/secret.txt 2>/dev/null || cat {{justfile_directory()}}/crates/keybroker/dev/secret.txt)" \
     "$@"
 
 run-dashboard *ARGS:


### PR DESCRIPTION
## Problem

`just run-local-backend` reads `--instance-name` and `--instance-secret` from `{{justfile_directory()}}/../keybroker/dev/` — a sibling path that exists in the upstream Convex monorepo, but not in OSS checkouts where `convex-backend` lives on its own. On an OSS checkout the `cat` calls produce empty strings, and the binary then errors:

```
ERROR common::errors: Caught error error: Hex-decoded key was 0 bytes, not 32
Error: Hex-decoded key was 0 bytes, not 32
```

The recipe's comment says it's meant to run "the open source convex backend on port 3210", so the broken state is a regression for the audience it advertises.

## Changes

Fall back to `crates/keybroker/dev/` when the sibling path isn't present. That directory is required by `include_str!` in the keybroker crate (`crates/keybroker/src/lib.rs`), so it's guaranteed to exist in any checkout — internal or OSS. Convex employees keep their current behavior because the sibling path is tried first; everyone else picks up the in-tree fallback. The dev keys in `crates/keybroker/dev/` already produce the admin key (`0135d8598…`) that's hardcoded in the `just convex` recipe further down, so the recipes stay consistent.

## How did you test this code?

Ran `just run-local-backend --help` from this branch in an OSS checkout. The expanded command now picks up `--instance-name carnitas --instance-secret 4361726e69…` from `crates/keybroker/dev/`, and the binary parses both flags successfully — the previous `Hex-decoded key was 0 bytes` error no longer appears.


<!--
  The following applies to third-party contributors.
  Convex employees and contractors can delete or ignore.
-->

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.