### PR TITLE
[RFC] Narrow query result types from literal equality predicates

### DIFF
--- a/npm-packages/convex/package.json
+++ b/npm-packages/convex/package.json
@@ -197,6 +197,7 @@
     "test": "vitest --silent",
     "test-not-silent": "vitest",
     "typecheck": "tsc --noEmit --emitDeclarationOnly false",
+    "typecheck:type-tests": "tsc -p tsconfig.type-tests.json",
     "test-esm": "node ./scripts/test-esm.mjs && ./scripts/checkdeps.mjs && ./scripts/checkimports.mjs",
     "compare-codegen": "node scripts/compare-codegen.mjs",
     "generateApiSpec": "npm run generateManagementApiSpec && npm run generateFunctionLogsApiSpec",

--- a/npm-packages/convex/src/server/data_model.ts
+++ b/npm-packages/convex/src/server/data_model.ts
@@ -1,4 +1,5 @@
 import { Value } from "../values/index.js";
+import { BetterOmit, Expand } from "../type_utils.js";
 import type { SystemIndexes } from "./system_fields.js";
 
 // Document Types  /////////////////////////////////////////////////////////////
@@ -136,6 +137,76 @@ export type FieldTypeFromFieldPathInner<
       : undefined
     : undefined
   : ValueFromUnion<Document, FieldPath, undefined>;
+
+type NarrowableEqualityPart<ValueType> = ValueType extends unknown
+  ? ValueType extends string | number | bigint | boolean | null
+    ? ValueType
+    : never
+  : never;
+
+type NonNarrowableEqualityPart<ValueType> = ValueType extends unknown
+  ? [NarrowableEqualityPart<ValueType>] extends [never]
+    ? ValueType
+    : never
+  : never;
+
+type NarrowableEqualityValue<ValueType> = string extends ValueType
+  ? never
+  : number extends ValueType
+    ? never
+    : bigint extends ValueType
+      ? never
+      : boolean extends ValueType
+        ? never
+        : [NonNarrowableEqualityPart<ValueType>] extends [never]
+          ? ValueType
+          : never;
+
+type NarrowDocumentVariantByTopLevelEquality<
+  Document extends GenericDocument,
+  FieldName extends string,
+  EqualityValue,
+> = Document extends unknown
+  ? FieldName extends keyof Document
+    ? Extract<EqualityValue, Document[FieldName]> extends infer NarrowedValue
+      ? [NarrowedValue] extends [never]
+        ? never
+        : Expand<
+            BetterOmit<Document, FieldName> & {
+              [Property in FieldName]: NarrowedValue;
+            }
+          >
+      : never
+    : never
+  : never;
+
+/**
+ * Narrow a document type based on a top-level literal equality predicate.
+ *
+ * This intentionally does not narrow nested field paths or equality values with
+ * broad primitive/object types. Those cases can be added later without changing
+ * the public query builder API.
+ * @public
+ */
+export type NarrowedDocumentByEquality<
+  Document extends GenericDocument,
+  FieldPath extends string,
+  EqualityValue,
+> = string extends FieldPath
+  ? Document
+  : FieldPath extends `${string}.${string}`
+    ? Document
+    : [NarrowableEqualityValue<EqualityValue>] extends [never]
+      ? Document
+      : NarrowDocumentVariantByTopLevelEquality<
+            Document,
+            FieldPath,
+            NarrowableEqualityValue<EqualityValue>
+          > extends infer NarrowedDocument
+        ? NarrowedDocument extends GenericDocument
+          ? NarrowedDocument
+          : never
+        : never;
 
 // Table Types /////////////////////////////////////////////////////////////////
 

--- a/npm-packages/convex/src/server/filter_builder.ts
+++ b/npm-packages/convex/src/server/filter_builder.ts
@@ -3,6 +3,7 @@ import {
   DocumentByInfo,
   FieldPaths,
   FieldTypeFromFieldPath,
+  GenericDocument,
   GenericTableInfo,
 } from "./data_model.js";
 
@@ -76,7 +77,10 @@ export type ExpressionOrValue<T extends Value | undefined> = Expression<T> | T;
  * | [`field(fieldPath)`](#field)  | Evaluates to the field at `fieldPath`.        |
  * @public
  */
-export interface FilterBuilder<TableInfo extends GenericTableInfo> {
+export interface FilterBuilder<
+  TableInfo extends GenericTableInfo,
+  Document extends GenericDocument = DocumentByInfo<TableInfo>,
+> {
   //  Comparisons  /////////////////////////////////////////////////////////////
 
   /**
@@ -245,5 +249,5 @@ export interface FilterBuilder<TableInfo extends GenericTableInfo> {
    */
   field<FieldPath extends FieldPaths<TableInfo>>(
     fieldPath: FieldPath,
-  ): Expression<FieldTypeFromFieldPath<DocumentByInfo<TableInfo>, FieldPath>>;
+  ): Expression<FieldTypeFromFieldPath<Document, FieldPath>>;
 }

--- a/npm-packages/convex/src/server/impl/query_impl.ts
+++ b/npm-packages/convex/src/server/impl/query_impl.ts
@@ -16,6 +16,7 @@ import {
   SearchFilterBuilderImpl,
   SerializedSearchFilter,
 } from "./search_filter_builder_impl.js";
+import type { SearchFilter } from "../search_filter_builder.js";
 import { validateArg, validateArgIsNonNegativeInteger } from "./validate.js";
 import { version } from "../../index.js";
 
@@ -41,9 +42,7 @@ type SerializedQuery = {
   operators: Array<QueryOperator>;
 };
 
-export class QueryInitializerImpl
-  implements QueryInitializer<GenericTableInfo>
-{
+export class QueryInitializerImpl implements QueryInitializer<GenericTableInfo> {
   private tableName: string;
 
   constructor(tableName: string) {
@@ -70,9 +69,9 @@ export class QueryInitializerImpl
     });
   }
 
-  withSearchIndex(
+  withSearchIndex<Filter extends SearchFilter>(
     indexName: string,
-    searchFilter: (q: SearchFilterBuilderImpl) => SearchFilterBuilderImpl,
+    searchFilter: (q: SearchFilterBuilderImpl) => Filter,
   ): QueryImpl {
     validateArg(indexName, 1, "withSearchIndex", "indexName");
     validateArg(searchFilter, 2, "withSearchIndex", "searchFilter");
@@ -81,7 +80,11 @@ export class QueryInitializerImpl
       source: {
         type: "Search",
         indexName: this.tableName + "." + indexName,
-        filters: searchFilter(searchFilterBuilder).export(),
+        filters: (
+          searchFilter(
+            searchFilterBuilder,
+          ) as unknown as SearchFilterBuilderImpl
+        ).export(),
       },
       operators: [],
     });

--- a/npm-packages/convex/src/server/impl/query_impl.ts
+++ b/npm-packages/convex/src/server/impl/query_impl.ts
@@ -42,7 +42,9 @@ type SerializedQuery = {
   operators: Array<QueryOperator>;
 };
 
-export class QueryInitializerImpl implements QueryInitializer<GenericTableInfo> {
+export class QueryInitializerImpl
+  implements QueryInitializer<GenericTableInfo>
+{
   private tableName: string;
 
   constructor(tableName: string) {

--- a/npm-packages/convex/src/server/impl/search_filter_builder_impl.ts
+++ b/npm-packages/convex/src/server/impl/search_filter_builder_impl.ts
@@ -3,6 +3,7 @@ import {
   FieldTypeFromFieldPath,
   GenericDocument,
   GenericSearchIndexConfig,
+  NarrowedDocumentByEquality,
 } from "../data_model.js";
 import {
   SearchFilter,
@@ -65,10 +66,16 @@ export class SearchFilterBuilderImpl
       }),
     );
   }
-  eq<FieldName extends string>(
+  eq<
+    FieldName extends string,
+    Value extends FieldTypeFromFieldPath<GenericDocument, FieldName>,
+  >(
     fieldName: FieldName,
-    value: FieldTypeFromFieldPath<GenericDocument, FieldName>,
-  ): SearchFilterFinalizer<GenericDocument, GenericSearchIndexConfig> {
+    value: Value,
+  ): SearchFilterFinalizer<
+    NarrowedDocumentByEquality<GenericDocument, FieldName, Value>,
+    GenericSearchIndexConfig
+  > {
     validateArg(fieldName, 1, "eq", "fieldName");
     // when `undefined` is passed explicitly, it is allowed.
     if (arguments.length !== 2) {
@@ -81,7 +88,10 @@ export class SearchFilterBuilderImpl
         fieldPath: fieldName,
         value: convexOrUndefinedToJson(value),
       }),
-    );
+    ) as unknown as SearchFilterFinalizer<
+      NarrowedDocumentByEquality<GenericDocument, FieldName, Value>,
+      GenericSearchIndexConfig
+    >;
   }
 
   export() {

--- a/npm-packages/convex/src/server/index.ts
+++ b/npm-packages/convex/src/server/index.ts
@@ -70,6 +70,7 @@ export type {
   GenericTableVectorIndexes,
   FieldTypeFromFieldPath,
   FieldTypeFromFieldPathInner,
+  NarrowedDocumentByEquality,
   GenericTableInfo,
   DocumentByInfo,
   FieldPaths,
@@ -113,7 +114,11 @@ export type {
   MutationMeta,
   ActionMeta,
 } from "./meta.js";
-export type { IndexRange, IndexRangeBuilder } from "./index_range_builder.js";
+export type {
+  IndexRange,
+  IndexRangeBuilder,
+  ResultDocumentFromIndexRange,
+} from "./index_range_builder.js";
 export * from "./pagination.js";
 export type { OrderedQuery, Query, QueryInitializer } from "./query.js";
 export type {

--- a/npm-packages/convex/src/server/index_range_builder.ts
+++ b/npm-packages/convex/src/server/index_range_builder.ts
@@ -2,7 +2,17 @@ import {
   GenericIndexFields,
   GenericDocument,
   FieldTypeFromFieldPath,
+  NarrowedDocumentByEquality,
 } from "./data_model.js";
+
+declare const indexRangeResultDocument: unique symbol;
+
+/**
+ * Extract the document type carried by an {@link IndexRange}.
+ * @public
+ */
+export type ResultDocumentFromIndexRange<Range extends IndexRange> =
+  Range[typeof indexRangeResultDocument];
 
 /**
  * A type that adds 1 to a number literal type (up to 14).
@@ -73,10 +83,14 @@ export interface IndexRangeBuilder<
    * in the index.
    * @param value - The value to compare against.
    */
-  eq(
+  eq<Value extends FieldTypeFromFieldPath<Document, IndexFields[FieldNum]>>(
     fieldName: IndexFields[FieldNum],
-    value: FieldTypeFromFieldPath<Document, IndexFields[FieldNum]>,
-  ): NextIndexRangeBuilder<Document, IndexFields, FieldNum>;
+    value: Value,
+  ): NextIndexRangeBuilder<
+    NarrowedDocumentByEquality<Document, IndexFields[FieldNum], Value>,
+    IndexFields,
+    FieldNum
+  >;
 }
 
 /**
@@ -139,7 +153,7 @@ export interface LowerBoundIndexRangeBuilder<
 export interface UpperBoundIndexRangeBuilder<
   Document extends GenericDocument,
   IndexFieldName extends string,
-> extends IndexRange {
+> extends IndexRange<Document> {
   /**
    * Restrict this range to documents where `doc[fieldName] < value`.
    *
@@ -151,7 +165,7 @@ export interface UpperBoundIndexRangeBuilder<
   lt(
     fieldName: IndexFieldName,
     value: FieldTypeFromFieldPath<Document, IndexFieldName>,
-  ): IndexRange;
+  ): IndexRange<Document>;
 
   /**
    * Restrict this range to documents where `doc[fieldName] <= value`.
@@ -164,7 +178,7 @@ export interface UpperBoundIndexRangeBuilder<
   lte(
     fieldName: IndexFieldName,
     value: FieldTypeFromFieldPath<Document, IndexFieldName>,
-  ): IndexRange;
+  ): IndexRange<Document>;
 }
 
 /**
@@ -172,9 +186,12 @@ export interface UpperBoundIndexRangeBuilder<
  * {@link IndexRangeBuilder}.
  * @public
  */
-export abstract class IndexRange {
+export abstract class IndexRange<
+  ResultDocument extends GenericDocument = GenericDocument,
+> {
   // Property for nominal type support.
   private _isIndexRange: undefined;
+  declare readonly [indexRangeResultDocument]: ResultDocument;
 
   /**
    * @internal

--- a/npm-packages/convex/src/server/query.ts
+++ b/npm-packages/convex/src/server/query.ts
@@ -1,5 +1,6 @@
 import {
   DocumentByInfo,
+  GenericDocument,
   GenericTableInfo,
   IndexNames,
   NamedIndex,
@@ -7,9 +8,17 @@ import {
   SearchIndexNames,
 } from "./data_model.js";
 import { ExpressionOrValue, FilterBuilder } from "./filter_builder.js";
-import { IndexRange, IndexRangeBuilder } from "./index_range_builder.js";
+import {
+  IndexRange,
+  IndexRangeBuilder,
+  ResultDocumentFromIndexRange,
+} from "./index_range_builder.js";
 import { PaginationResult, PaginationOptions } from "./pagination.js";
-import { SearchFilter, SearchFilterBuilder } from "./search_filter_builder.js";
+import {
+  SearchFilter,
+  SearchFilterBuilder,
+  ResultDocumentFromSearchFilter,
+} from "./search_filter_builder.js";
 
 /**
  * The {@link QueryInitializer} interface is the entry point for building a {@link Query}
@@ -26,8 +35,9 @@ import { SearchFilter, SearchFilterBuilder } from "./search_filter_builder.js";
  *
  * @public
  */
-export interface QueryInitializer<TableInfo extends GenericTableInfo>
-  extends Query<TableInfo> {
+export interface QueryInitializer<
+  TableInfo extends GenericTableInfo,
+> extends Query<TableInfo> {
   /**
    * Query by reading all of the values out of this table.
    *
@@ -58,13 +68,17 @@ export interface QueryInitializer<TableInfo extends GenericTableInfo>
    */
   withIndex<IndexName extends IndexNames<TableInfo>>(
     indexName: IndexName,
-    indexRange?: (
+  ): Query<TableInfo>;
+
+  withIndex<IndexName extends IndexNames<TableInfo>, Range extends IndexRange>(
+    indexName: IndexName,
+    indexRange: (
       q: IndexRangeBuilder<
         DocumentByInfo<TableInfo>,
         NamedIndex<TableInfo, IndexName>
       >,
-    ) => IndexRange,
-  ): Query<TableInfo>;
+    ) => Range,
+  ): Query<TableInfo, ResultDocumentFromIndexRange<Range>>;
 
   /**
    * Query by running a full text search against a search index.
@@ -85,15 +99,18 @@ export interface QueryInitializer<TableInfo extends GenericTableInfo>
    * @returns - A query that searches for matching documents, returning them
    * in relevancy order.
    */
-  withSearchIndex<IndexName extends SearchIndexNames<TableInfo>>(
+  withSearchIndex<
+    IndexName extends SearchIndexNames<TableInfo>,
+    Filter extends SearchFilter,
+  >(
     indexName: IndexName,
     searchFilter: (
       q: SearchFilterBuilder<
         DocumentByInfo<TableInfo>,
         NamedSearchIndex<TableInfo, IndexName>
       >,
-    ) => SearchFilter,
-  ): OrderedQuery<TableInfo>;
+    ) => Filter,
+  ): OrderedQuery<TableInfo, ResultDocumentFromSearchFilter<Filter>>;
 
   /**
    * The number of documents in the table.
@@ -163,15 +180,17 @@ export interface QueryInitializer<TableInfo extends GenericTableInfo>
  *
  * @public
  */
-export interface Query<TableInfo extends GenericTableInfo>
-  extends OrderedQuery<TableInfo> {
+export interface Query<
+  TableInfo extends GenericTableInfo,
+  ResultDocument extends GenericDocument = DocumentByInfo<TableInfo>,
+> extends OrderedQuery<TableInfo, ResultDocument> {
   /**
    * Define the order of the query output.
    *
    * Use `"asc"` for an ascending order and `"desc"` for a descending order. If not specified, the order defaults to ascending.
    * @param order - The order to return results in.
    */
-  order(order: "asc" | "desc"): OrderedQuery<TableInfo>;
+  order(order: "asc" | "desc"): OrderedQuery<TableInfo, ResultDocument>;
 }
 
 /**
@@ -179,8 +198,10 @@ export interface Query<TableInfo extends GenericTableInfo>
  *
  * @public
  */
-export interface OrderedQuery<TableInfo extends GenericTableInfo>
-  extends AsyncIterable<DocumentByInfo<TableInfo>> {
+export interface OrderedQuery<
+  TableInfo extends GenericTableInfo,
+  ResultDocument extends GenericDocument = DocumentByInfo<TableInfo>,
+> extends AsyncIterable<ResultDocument> {
   /**
    * Filter the query output, returning only the values for which `predicate` evaluates to true.
    *
@@ -223,7 +244,7 @@ export interface OrderedQuery<TableInfo extends GenericTableInfo>
    */
   paginate(
     paginationOpts: PaginationOptions,
-  ): Promise<PaginationResult<DocumentByInfo<TableInfo>>>;
+  ): Promise<PaginationResult<ResultDocument>>;
 
   /**
    * Execute the query and return all of the results as an array.
@@ -240,7 +261,7 @@ export interface OrderedQuery<TableInfo extends GenericTableInfo>
    *
    * @returns - An array of all of the query's results.
    */
-  collect(): Promise<Array<DocumentByInfo<TableInfo>>>;
+  collect(): Promise<Array<ResultDocument>>;
 
   /**
    * Execute the query and return the first `n` results.
@@ -249,14 +270,14 @@ export interface OrderedQuery<TableInfo extends GenericTableInfo>
    * @returns - An array of the first `n` results of the query (or less if the
    * query doesn't have `n` results).
    */
-  take(n: number): Promise<Array<DocumentByInfo<TableInfo>>>;
+  take(n: number): Promise<Array<ResultDocument>>;
 
   /**
    * Execute the query and return the first result if there is one.
    *
    * @returns - The first value of the query or `null` if the query returned no results.
    * */
-  first(): Promise<DocumentByInfo<TableInfo> | null>;
+  first(): Promise<ResultDocument | null>;
 
   /**
    * Execute the query and return the singular result if there is one.
@@ -276,5 +297,5 @@ export interface OrderedQuery<TableInfo extends GenericTableInfo>
    * @returns - The single result returned from the query or null if none exists.
    * @throws Will throw an error if the query returns more than one result.
    */
-  unique(): Promise<DocumentByInfo<TableInfo> | null>;
+  unique(): Promise<ResultDocument | null>;
 }

--- a/npm-packages/convex/src/server/query.ts
+++ b/npm-packages/convex/src/server/query.ts
@@ -35,9 +35,8 @@ import {
  *
  * @public
  */
-export interface QueryInitializer<
-  TableInfo extends GenericTableInfo,
-> extends Query<TableInfo> {
+export interface QueryInitializer<TableInfo extends GenericTableInfo>
+  extends Query<TableInfo> {
   /**
    * Query by reading all of the values out of this table.
    *
@@ -214,7 +213,9 @@ export interface OrderedQuery<
    * @returns - A new {@link OrderedQuery} with the given filter predicate applied.
    */
   filter(
-    predicate: (q: FilterBuilder<TableInfo>) => ExpressionOrValue<boolean>,
+    predicate: (
+      q: FilterBuilder<TableInfo, ResultDocument>,
+    ) => ExpressionOrValue<boolean>,
   ): this;
 
   /**

--- a/npm-packages/convex/src/server/search_filter_builder.ts
+++ b/npm-packages/convex/src/server/search_filter_builder.ts
@@ -2,7 +2,17 @@ import {
   FieldTypeFromFieldPath,
   GenericDocument,
   GenericSearchIndexConfig,
+  NarrowedDocumentByEquality,
 } from "./data_model.js";
+
+declare const searchFilterResultDocument: unique symbol;
+
+/**
+ * Extract the document type carried by a {@link SearchFilter}.
+ * @public
+ */
+export type ResultDocumentFromSearchFilter<Filter extends SearchFilter> =
+  Filter[typeof searchFilterResultDocument];
 
 /**
  * Builder for defining search filters.
@@ -55,7 +65,7 @@ export interface SearchFilterBuilder<
 export interface SearchFilterFinalizer<
   Document extends GenericDocument,
   SearchIndexConfig extends GenericSearchIndexConfig,
-> extends SearchFilter {
+> extends SearchFilter<Document> {
   /**
    * Restrict this query to documents where `doc[fieldName] === value`.
    *
@@ -63,10 +73,16 @@ export interface SearchFilterFinalizer<
    * the search index's `filterFields`.
    * @param value - The value to compare against.
    */
-  eq<FieldName extends SearchIndexConfig["filterFields"]>(
+  eq<
+    FieldName extends SearchIndexConfig["filterFields"],
+    Value extends FieldTypeFromFieldPath<Document, FieldName>,
+  >(
     fieldName: FieldName,
-    value: FieldTypeFromFieldPath<Document, FieldName>,
-  ): SearchFilterFinalizer<Document, SearchIndexConfig>;
+    value: Value,
+  ): SearchFilterFinalizer<
+    NarrowedDocumentByEquality<Document, FieldName, Value>,
+    SearchIndexConfig
+  >;
 }
 
 /**
@@ -75,9 +91,12 @@ export interface SearchFilterFinalizer<
  *
  * @public
  */
-export abstract class SearchFilter {
+export abstract class SearchFilter<
+  ResultDocument extends GenericDocument = GenericDocument,
+> {
   // Property for nominal type support.
   private _isSearchFilter: undefined;
+  declare readonly [searchFilterResultDocument]: ResultDocument;
 
   /**
    * @internal

--- a/npm-packages/convex/tsconfig.type-tests.json
+++ b/npm-packages/convex/tsconfig.type-tests.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "include": ["type-tests/**/*.ts"],
+  "compilerOptions": {
+    "declaration": false,
+    "declarationMap": false,
+    "emitDeclarationOnly": false,
+    "noEmit": true,
+    "rootDir": "."
+  }
+}

--- a/npm-packages/convex/type-tests/query_result_narrowing.ts
+++ b/npm-packages/convex/type-tests/query_result_narrowing.ts
@@ -4,6 +4,7 @@ import type {
   IndexRangeBuilder,
   ResultDocumentFromIndexRange,
 } from "../src/server/index_range_builder.js";
+import type { Expression } from "../src/server/filter_builder.js";
 import type { GenericId } from "../src/values/index.js";
 
 type Equal<Left, Right> =
@@ -17,6 +18,7 @@ type AwaitedPaginationElement<T> =
   Awaited<T> extends { page: Array<infer Element> } ? Element : never;
 type AsyncIterableElement<T> =
   T extends AsyncIterable<infer Element> ? Element : never;
+type ExpressionValue<T> = T extends Expression<infer Value> ? Value : never;
 
 type FlashcardVisibility = "private" | "unlisted" | "public";
 
@@ -127,13 +129,13 @@ declare const indexRangeBuilder: IndexRangeBuilder<
   ["visibility", "_creationTime"]
 >;
 
-const directRange = indexRangeBuilder.eq("visibility", "public" as const);
+const directRange = indexRangeBuilder.eq("visibility", "public");
 type DirectRangeDoc = ResultDocumentFromIndexRange<typeof directRange>;
 type DirectRangeNarrows = Expect<Equal<DirectRangeDoc["visibility"], "public">>;
 
 const publicDocs = flashcardSets
   .withIndex("by_visibility_and_createdAt", (q) =>
-    q.eq("visibility", "public" as const),
+    q.eq("visibility", "public"),
   )
   .take(10);
 type PublicDoc = AwaitedArrayElement<typeof publicDocs>;
@@ -141,7 +143,7 @@ type PublicVisibilityNarrows = Expect<Equal<PublicDoc["visibility"], "public">>;
 
 const orderedPublicDocs = flashcardSets
   .withIndex("by_visibility_and_createdAt", (q) =>
-    q.eq("visibility", "public" as const),
+    q.eq("visibility", "public"),
   )
   .order("desc")
   .take(10);
@@ -152,9 +154,16 @@ type OrderedPublicVisibilityNarrows = Expect<
 
 const filteredPublicDocs = flashcardSets
   .withIndex("by_visibility_and_createdAt", (q) =>
-    q.eq("visibility", "public" as const),
+    q.eq("visibility", "public"),
   )
-  .filter(() => true)
+  .filter((q) => {
+    const visibilityField = q.field("visibility");
+    type FilterVisibilityField = ExpressionValue<typeof visibilityField>;
+    type FilterVisibilityFieldNarrows = Expect<
+      Equal<FilterVisibilityField, "public">
+    >;
+    return q.eq(visibilityField, "public");
+  })
   .take(10);
 type FilteredPublicDoc = AwaitedArrayElement<typeof filteredPublicDocs>;
 type FilteredPublicVisibilityNarrows = Expect<
@@ -163,7 +172,7 @@ type FilteredPublicVisibilityNarrows = Expect<
 
 const boundedPublicDocs = flashcardSets
   .withIndex("by_visibility_and_createdAt", (q) =>
-    q.eq("visibility", "public" as const).lt("_creationTime", Date.now()),
+    q.eq("visibility", "public").lt("_creationTime", Date.now()),
   )
   .take(10);
 type BoundedPublicDoc = AwaitedArrayElement<typeof boundedPublicDocs>;
@@ -173,7 +182,7 @@ type BoundedPublicVisibilityNarrows = Expect<
 
 const firstPublicDoc = flashcardSets
   .withIndex("by_visibility_and_createdAt", (q) =>
-    q.eq("visibility", "public" as const),
+    q.eq("visibility", "public"),
   )
   .first();
 type FirstPublicDoc = NonNullable<Awaited<typeof firstPublicDoc>>;
@@ -183,7 +192,7 @@ type FirstPublicVisibilityNarrows = Expect<
 
 const uniquePublicDoc = flashcardSets
   .withIndex("by_visibility_and_createdAt", (q) =>
-    q.eq("visibility", "public" as const),
+    q.eq("visibility", "public"),
   )
   .unique();
 type UniquePublicDoc = NonNullable<Awaited<typeof uniquePublicDoc>>;
@@ -193,7 +202,7 @@ type UniquePublicVisibilityNarrows = Expect<
 
 const paginatedPublicDocs = flashcardSets
   .withIndex("by_visibility_and_createdAt", (q) =>
-    q.eq("visibility", "public" as const),
+    q.eq("visibility", "public"),
   )
   .paginate({ numItems: 10, cursor: null });
 type PaginatedPublicDoc = AwaitedPaginationElement<typeof paginatedPublicDocs>;
@@ -203,7 +212,7 @@ type PaginatedPublicVisibilityNarrows = Expect<
 
 const iterablePublicDocs = flashcardSets.withIndex(
   "by_visibility_and_createdAt",
-  (q) => q.eq("visibility", "public" as const),
+  (q) => q.eq("visibility", "public"),
 );
 type IterablePublicDoc = AsyncIterableElement<typeof iterablePublicDocs>;
 type IterablePublicVisibilityNarrows = Expect<
@@ -212,7 +221,7 @@ type IterablePublicVisibilityNarrows = Expect<
 
 const chainedDocs = flashcardSets
   .withIndex("by_visibility_and_target", (q) =>
-    q.eq("visibility", "public" as const).eq("targetId", userId),
+    q.eq("visibility", "public").eq("targetId", userId),
   )
   .collect();
 type ChainedDoc = AwaitedArrayElement<typeof chainedDocs>;
@@ -225,7 +234,7 @@ type ChainedIdBrandNarrows = Expect<
 
 const searchDocs = flashcardSets
   .withSearchIndex("search_title", (q) =>
-    q.search("title", "biology").eq("visibility", "public" as const),
+    q.search("title", "biology").eq("visibility", "public"),
   )
   .take(10);
 type SearchDoc = AwaitedArrayElement<typeof searchDocs>;
@@ -235,7 +244,7 @@ const chainedSearchDocs = flashcardSets
   .withSearchIndex("search_title", (q) =>
     q
       .search("title", "biology")
-      .eq("visibility", "public" as const)
+      .eq("visibility", "public")
       .eq("targetId", userId),
   )
   .take(10);
@@ -248,7 +257,7 @@ type ChainedSearchIdBrandNarrows = Expect<
 >;
 
 const titleLiteralDocs = flashcardSets
-  .withIndex("by_title", (q) => q.eq("title", "Biology 101" as const))
+  .withIndex("by_title", (q) => q.eq("title", "Biology 101"))
   .take(10);
 type TitleLiteralDoc = AwaitedArrayElement<typeof titleLiteralDocs>;
 type TitleLiteralNarrows = Expect<
@@ -291,7 +300,7 @@ type IdentityIndexRangeDoesNotNarrow = Expect<
 
 const nestedFieldDocs = flashcardSets
   .withIndex("by_metadata_visibility", (q) =>
-    q.eq("metadata.visibility", "public" as const),
+    q.eq("metadata.visibility", "public"),
   )
   .take(10);
 type NestedFieldDoc = AwaitedArrayElement<typeof nestedFieldDocs>;
@@ -316,13 +325,13 @@ type ArrayEqualityDoesNotNarrow = Expect<
 >;
 
 const optionalFieldDocs = flashcardSets
-  .withIndex("by_kind", (q) => q.eq("kind", "deck" as const))
+  .withIndex("by_kind", (q) => q.eq("kind", "deck"))
   .take(10);
 type OptionalFieldDoc = AwaitedArrayElement<typeof optionalFieldDocs>;
 type OptionalFieldNarrows = Expect<Equal<OptionalFieldDoc["kind"], "deck">>;
 
 const unionDocs = unionFlashcardSets
-  .withIndex("by_kind", (q) => q.eq("kind", "publicSet" as const))
+  .withIndex("by_kind", (q) => q.eq("kind", "publicSet"))
   .collect();
 type UnionDoc = AwaitedArrayElement<typeof unionDocs>;
 type UnionKindNarrows = Expect<Equal<UnionDoc["kind"], "publicSet">>;

--- a/npm-packages/convex/type-tests/query_result_narrowing.ts
+++ b/npm-packages/convex/type-tests/query_result_narrowing.ts
@@ -1,0 +1,332 @@
+import type { GenericTableInfo } from "../src/server/data_model.js";
+import type { QueryInitializer } from "../src/server/query.js";
+import type {
+  IndexRangeBuilder,
+  ResultDocumentFromIndexRange,
+} from "../src/server/index_range_builder.js";
+import type { GenericId } from "../src/values/index.js";
+
+type Equal<Left, Right> =
+  (<T>() => T extends Left ? 1 : 2) extends <T>() => T extends Right ? 1 : 2
+    ? true
+    : false;
+type Expect<T extends true> = T;
+type AwaitedArrayElement<T> =
+  Awaited<T> extends Array<infer Element> ? Element : never;
+type AwaitedPaginationElement<T> =
+  Awaited<T> extends { page: Array<infer Element> } ? Element : never;
+type AsyncIterableElement<T> =
+  T extends AsyncIterable<infer Element> ? Element : never;
+
+type FlashcardVisibility = "private" | "unlisted" | "public";
+
+type FlashcardSet = {
+  _id: GenericId<"flashcardSets">;
+  _creationTime: number;
+  kind?: "deck" | "folder";
+  metadata: {
+    visibility: FlashcardVisibility;
+  };
+  profile: {
+    topic: "biology" | "math";
+  };
+  tags: string[];
+  targetId: GenericId<"users"> | GenericId<"teams">;
+  title: string;
+  visibility: FlashcardVisibility;
+};
+
+type FlashcardSetsTableInfo = {
+  document: FlashcardSet;
+  fieldPaths:
+    | "_creationTime"
+    | "_id"
+    | "kind"
+    | "metadata"
+    | "metadata.visibility"
+    | "profile"
+    | "profile.topic"
+    | "tags"
+    | "targetId"
+    | "title"
+    | "visibility";
+  indexes: {
+    by_id: ["_id"];
+    by_creation_time: ["_creationTime"];
+    by_kind: ["kind", "_creationTime"];
+    by_metadata_visibility: ["metadata.visibility", "_creationTime"];
+    by_profile: ["profile", "_creationTime"];
+    by_tags: ["tags", "_creationTime"];
+    by_title: ["title", "_creationTime"];
+    by_visibility_and_createdAt: ["visibility", "_creationTime"];
+    by_visibility_and_target: ["visibility", "targetId", "_creationTime"];
+  };
+  searchIndexes: {
+    search_title: {
+      searchField: "title";
+      filterFields: "kind" | "targetId" | "visibility";
+    };
+  };
+  vectorIndexes: {};
+};
+
+type PublicFlashcardSet = {
+  _id: GenericId<"unionFlashcardSets">;
+  _creationTime: number;
+  kind: "publicSet";
+  title: string;
+  visibility: "public";
+};
+
+type PrivateFlashcardSet = {
+  _id: GenericId<"unionFlashcardSets">;
+  _creationTime: number;
+  kind: "privateSet";
+  ownerId: GenericId<"users">;
+  title: string;
+  visibility: "private";
+};
+
+type UnionFlashcardSetsTableInfo = {
+  document: PublicFlashcardSet | PrivateFlashcardSet;
+  fieldPaths:
+    | "_creationTime"
+    | "_id"
+    | "kind"
+    | "ownerId"
+    | "title"
+    | "visibility";
+  indexes: {
+    by_id: ["_id"];
+    by_creation_time: ["_creationTime"];
+    by_kind: ["kind", "_creationTime"];
+  };
+  searchIndexes: {};
+  vectorIndexes: {};
+};
+
+type TestDataModel = {
+  flashcardSets: FlashcardSetsTableInfo;
+  unionFlashcardSets: UnionFlashcardSetsTableInfo;
+};
+
+type AssertTableInfoConstraints = [
+  Expect<FlashcardSetsTableInfo extends GenericTableInfo ? true : false>,
+  Expect<UnionFlashcardSetsTableInfo extends GenericTableInfo ? true : false>,
+];
+
+declare const flashcardSets: QueryInitializer<TestDataModel["flashcardSets"]>;
+declare const unionFlashcardSets: QueryInitializer<
+  TestDataModel["unionFlashcardSets"]
+>;
+declare const visibilityVariable: FlashcardVisibility;
+declare const titleVariable: string;
+declare const userId: GenericId<"users">;
+declare const indexRangeBuilder: IndexRangeBuilder<
+  FlashcardSet,
+  ["visibility", "_creationTime"]
+>;
+
+const directRange = indexRangeBuilder.eq("visibility", "public" as const);
+type DirectRangeDoc = ResultDocumentFromIndexRange<typeof directRange>;
+type DirectRangeNarrows = Expect<Equal<DirectRangeDoc["visibility"], "public">>;
+
+const publicDocs = flashcardSets
+  .withIndex("by_visibility_and_createdAt", (q) =>
+    q.eq("visibility", "public" as const),
+  )
+  .take(10);
+type PublicDoc = AwaitedArrayElement<typeof publicDocs>;
+type PublicVisibilityNarrows = Expect<Equal<PublicDoc["visibility"], "public">>;
+
+const orderedPublicDocs = flashcardSets
+  .withIndex("by_visibility_and_createdAt", (q) =>
+    q.eq("visibility", "public" as const),
+  )
+  .order("desc")
+  .take(10);
+type OrderedPublicDoc = AwaitedArrayElement<typeof orderedPublicDocs>;
+type OrderedPublicVisibilityNarrows = Expect<
+  Equal<OrderedPublicDoc["visibility"], "public">
+>;
+
+const filteredPublicDocs = flashcardSets
+  .withIndex("by_visibility_and_createdAt", (q) =>
+    q.eq("visibility", "public" as const),
+  )
+  .filter(() => true)
+  .take(10);
+type FilteredPublicDoc = AwaitedArrayElement<typeof filteredPublicDocs>;
+type FilteredPublicVisibilityNarrows = Expect<
+  Equal<FilteredPublicDoc["visibility"], "public">
+>;
+
+const boundedPublicDocs = flashcardSets
+  .withIndex("by_visibility_and_createdAt", (q) =>
+    q.eq("visibility", "public" as const).lt("_creationTime", Date.now()),
+  )
+  .take(10);
+type BoundedPublicDoc = AwaitedArrayElement<typeof boundedPublicDocs>;
+type BoundedPublicVisibilityNarrows = Expect<
+  Equal<BoundedPublicDoc["visibility"], "public">
+>;
+
+const firstPublicDoc = flashcardSets
+  .withIndex("by_visibility_and_createdAt", (q) =>
+    q.eq("visibility", "public" as const),
+  )
+  .first();
+type FirstPublicDoc = NonNullable<Awaited<typeof firstPublicDoc>>;
+type FirstPublicVisibilityNarrows = Expect<
+  Equal<FirstPublicDoc["visibility"], "public">
+>;
+
+const uniquePublicDoc = flashcardSets
+  .withIndex("by_visibility_and_createdAt", (q) =>
+    q.eq("visibility", "public" as const),
+  )
+  .unique();
+type UniquePublicDoc = NonNullable<Awaited<typeof uniquePublicDoc>>;
+type UniquePublicVisibilityNarrows = Expect<
+  Equal<UniquePublicDoc["visibility"], "public">
+>;
+
+const paginatedPublicDocs = flashcardSets
+  .withIndex("by_visibility_and_createdAt", (q) =>
+    q.eq("visibility", "public" as const),
+  )
+  .paginate({ numItems: 10, cursor: null });
+type PaginatedPublicDoc = AwaitedPaginationElement<typeof paginatedPublicDocs>;
+type PaginatedPublicVisibilityNarrows = Expect<
+  Equal<PaginatedPublicDoc["visibility"], "public">
+>;
+
+const iterablePublicDocs = flashcardSets.withIndex(
+  "by_visibility_and_createdAt",
+  (q) => q.eq("visibility", "public" as const),
+);
+type IterablePublicDoc = AsyncIterableElement<typeof iterablePublicDocs>;
+type IterablePublicVisibilityNarrows = Expect<
+  Equal<IterablePublicDoc["visibility"], "public">
+>;
+
+const chainedDocs = flashcardSets
+  .withIndex("by_visibility_and_target", (q) =>
+    q.eq("visibility", "public" as const).eq("targetId", userId),
+  )
+  .collect();
+type ChainedDoc = AwaitedArrayElement<typeof chainedDocs>;
+type ChainedVisibilityNarrows = Expect<
+  Equal<ChainedDoc["visibility"], "public">
+>;
+type ChainedIdBrandNarrows = Expect<
+  Equal<ChainedDoc["targetId"], GenericId<"users">>
+>;
+
+const searchDocs = flashcardSets
+  .withSearchIndex("search_title", (q) =>
+    q.search("title", "biology").eq("visibility", "public" as const),
+  )
+  .take(10);
+type SearchDoc = AwaitedArrayElement<typeof searchDocs>;
+type SearchVisibilityNarrows = Expect<Equal<SearchDoc["visibility"], "public">>;
+
+const chainedSearchDocs = flashcardSets
+  .withSearchIndex("search_title", (q) =>
+    q
+      .search("title", "biology")
+      .eq("visibility", "public" as const)
+      .eq("targetId", userId),
+  )
+  .take(10);
+type ChainedSearchDoc = AwaitedArrayElement<typeof chainedSearchDocs>;
+type ChainedSearchVisibilityNarrows = Expect<
+  Equal<ChainedSearchDoc["visibility"], "public">
+>;
+type ChainedSearchIdBrandNarrows = Expect<
+  Equal<ChainedSearchDoc["targetId"], GenericId<"users">>
+>;
+
+const titleLiteralDocs = flashcardSets
+  .withIndex("by_title", (q) => q.eq("title", "Biology 101" as const))
+  .take(10);
+type TitleLiteralDoc = AwaitedArrayElement<typeof titleLiteralDocs>;
+type TitleLiteralNarrows = Expect<
+  Equal<TitleLiteralDoc["title"], "Biology 101">
+>;
+
+const titleVariableDocs = flashcardSets
+  .withIndex("by_title", (q) => q.eq("title", titleVariable))
+  .take(10);
+type TitleVariableDoc = AwaitedArrayElement<typeof titleVariableDocs>;
+type TitleVariableDoesNotNarrow = Expect<
+  Equal<TitleVariableDoc["title"], string>
+>;
+
+const visibilityVariableDocs = flashcardSets
+  .withIndex("by_visibility_and_createdAt", (q) =>
+    q.eq("visibility", visibilityVariable),
+  )
+  .take(10);
+type VisibilityVariableDoc = AwaitedArrayElement<typeof visibilityVariableDocs>;
+type VisibilityVariableDoesNotOverNarrow = Expect<
+  Equal<VisibilityVariableDoc["visibility"], FlashcardVisibility>
+>;
+
+const noEqualityDocs = flashcardSets
+  .withIndex("by_visibility_and_createdAt")
+  .take(10);
+type NoEqualityDoc = AwaitedArrayElement<typeof noEqualityDocs>;
+type NoEqualityDoesNotNarrow = Expect<
+  Equal<NoEqualityDoc["visibility"], FlashcardVisibility>
+>;
+
+const identityIndexRangeDocs = flashcardSets
+  .withIndex("by_visibility_and_createdAt", (q) => q)
+  .take(10);
+type IdentityIndexRangeDoc = AwaitedArrayElement<typeof identityIndexRangeDocs>;
+type IdentityIndexRangeDoesNotNarrow = Expect<
+  Equal<IdentityIndexRangeDoc["visibility"], FlashcardVisibility>
+>;
+
+const nestedFieldDocs = flashcardSets
+  .withIndex("by_metadata_visibility", (q) =>
+    q.eq("metadata.visibility", "public" as const),
+  )
+  .take(10);
+type NestedFieldDoc = AwaitedArrayElement<typeof nestedFieldDocs>;
+type NestedFieldDoesNotNarrow = Expect<
+  Equal<NestedFieldDoc["metadata"]["visibility"], FlashcardVisibility>
+>;
+
+const objectEqualityDocs = flashcardSets
+  .withIndex("by_profile", (q) => q.eq("profile", { topic: "biology" }))
+  .take(10);
+type ObjectEqualityDoc = AwaitedArrayElement<typeof objectEqualityDocs>;
+type ObjectEqualityDoesNotNarrow = Expect<
+  Equal<ObjectEqualityDoc["profile"]["topic"], "biology" | "math">
+>;
+
+const arrayEqualityDocs = flashcardSets
+  .withIndex("by_tags", (q) => q.eq("tags", ["biology"]))
+  .take(10);
+type ArrayEqualityDoc = AwaitedArrayElement<typeof arrayEqualityDocs>;
+type ArrayEqualityDoesNotNarrow = Expect<
+  Equal<ArrayEqualityDoc["tags"], string[]>
+>;
+
+const optionalFieldDocs = flashcardSets
+  .withIndex("by_kind", (q) => q.eq("kind", "deck" as const))
+  .take(10);
+type OptionalFieldDoc = AwaitedArrayElement<typeof optionalFieldDocs>;
+type OptionalFieldNarrows = Expect<Equal<OptionalFieldDoc["kind"], "deck">>;
+
+const unionDocs = unionFlashcardSets
+  .withIndex("by_kind", (q) => q.eq("kind", "publicSet" as const))
+  .collect();
+type UnionDoc = AwaitedArrayElement<typeof unionDocs>;
+type UnionKindNarrows = Expect<Equal<UnionDoc["kind"], "publicSet">>;
+type UnionVisibilityNarrows = Expect<Equal<UnionDoc["visibility"], "public">>;
+type UnionBranchNarrows = Expect<
+  Equal<"ownerId" extends keyof UnionDoc ? true : false, false>
+>;


### PR DESCRIPTION
## Summary

This is a prototype/RFC for carrying literal equality predicates from Convex index and search-index builders into the returned document type.

Today, a query like this still returns the full schema union for `visibility`:

```ts
const docs = await ctx.db
  .query("flashcardSets")
  .withIndex("by_visibility_and_createdAt", (q) =>
    q.eq("visibility", "public" as const),
  )
  .take(10);
```

Even though the index range requires `visibility === "public"`, `docs[number]["visibility"]` remains something like `"private" | "unlisted" | "public"`.

The concrete app motivation: in our app we currently need post-query guards like `isPublicFlashcardSet` immediately after `q.eq("visibility", "public")`, because Convex returns the full `Doc<...>` type instead of reflecting the invariant established by the query.

This PR makes that invariant visible to TypeScript for top-level literal equality predicates.

## What changed

- Add a carried result-document generic to `Query` and `OrderedQuery`, defaulting to the existing document type.
- Give `IndexRange` and `SearchFilter` a type-only carried result document.
- Make `IndexRangeBuilder.eq(...)` and `SearchFilterFinalizer.eq(...)` accumulate conservative top-level literal equality narrowing.
- Thread the narrowed document type through `withIndex(...)` and `withSearchIndex(...)` so query consumers return the narrowed document.
- Preserve runtime behavior. The implementation changes are generic annotations/casts around the existing builder objects and serialization paths.

## Deliberate scope limits

This is intentionally conservative for an RFC/prototype:

- Only top-level field paths narrow.
- Nested field paths like `metadata.visibility` do not narrow yet.
- Broad primitive variables, object equality values, and array equality values do not narrow.
- Non-literal/no-equality queries keep the existing full document type.

Those limits keep the type design readable and avoid trying to solve every field-path case in the first patch.

## Type tests

Added focused type tests covering:

- `withIndex(... q.eq("visibility", "public" as const))`
- chained index `.eq(...)` calls
- search index `.search(...).eq(...)`
- chained search filter `.eq(...)` calls
- preservation through `order`, `filter`, `first`, `unique`, `paginate`, and async iteration
- equality followed by range bounds
- no-narrowing behavior for non-literal variables, no equality, identity index ranges, nested paths, objects, and arrays
- optional fields, union document types, and branded Convex IDs

## Verification

Ran from `npm-packages/convex`:

```sh
npx --yes --package typescript@5.0.3 tsc -p tsconfig.type-tests.json --pretty false
```

Also checked:

```sh
git diff --check
```

The full package `tsc` command is blocked in this checkout because npm dependencies are not installed, but filtering its output showed no remaining `src/server` or `type-tests` errors.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
