### PR TITLE
fix(cli): add --names-only flag to env list to avoid printing secret values

### DIFF
--- a/npm-packages/convex/src/cli/env.ts
+++ b/npm-packages/convex/src/cli/env.ts
@@ -164,11 +164,11 @@ const envRemoveCmd = new Command("remove")
   });
 
 const envListCmd = new Command("list")
-  .summary("List all variables")
+  .summary("List all variables and their values")
   .description(
     [
-      "• List all variables: `npx convex env list`",
-      "• List only variable names: `npx convex env list --names-only`",
+      "• List all variables and their values: `npx convex env list`",
+      "• List only variable names (no values): `npx convex env list --names-only`",
       "• Save all variables to a file: `npx convex env list > .env.convex`",
       "• Append to a file: `npx convex env list >> .env.convex`",
     ].join("\n"),
@@ -207,7 +207,8 @@ export const env = new Command("env")
       "• Set interactively: `npx convex env set NAME`",
       "• Set multiple from file: `npx convex env set --from-file .env`",
       "• Unset a variable: `npx convex env remove NAME`",
-      "• List all variables: `npx convex env list`",
+      "• List all variables and their values: `npx convex env list`",
+      "• List only variable names (no values): `npx convex env list --names-only`",
       "• Print a variable's value: `npx convex env get NAME`",
       "",
       "By default, this sets and views variables on your dev deployment.",

--- a/npm-packages/convex/src/cli/env.ts
+++ b/npm-packages/convex/src/cli/env.ts
@@ -168,14 +168,21 @@ const envListCmd = new Command("list")
   .description(
     [
       "• List all variables: `npx convex env list`",
+      "• List only variable names: `npx convex env list --names-only`",
       "• Save all variables to a file: `npx convex env list > .env.convex`",
       "• Append to a file: `npx convex env list >> .env.convex`",
     ].join("\n"),
   )
+  .option(
+    "--names-only",
+    "List only the names of environment variables, without their values",
+  )
   .configureHelp({ showGlobalOptions: true })
   .allowExcessArguments(false)
-  .action(async (_options, cmd) => {
-    const options = cmd.optsWithGlobals();
+  .action(async (cmdOptions, cmd) => {
+    // Note: We use `as` here because optsWithGlobals() type inference doesn't
+    // include global options from the parent command (added via addDeploymentSelectionOptions)
+    const options = cmd.optsWithGlobals() as DeploymentSelectionOptions;
     const { ctx, deployment } = await selectEnvDeployment(options);
     await ensureHasConvexDependency(ctx, "env list");
     await withRunningBackend({
@@ -183,7 +190,9 @@ const envListCmd = new Command("list")
       deployment,
       action: async () => {
         const backend = deploymentEnvBackend(ctx, deployment);
-        await envList(ctx, backend);
+        await envList(ctx, backend, {
+          namesOnly: cmdOptions.namesOnly ?? false,
+        });
       },
     });
   });

--- a/npm-packages/convex/src/cli/lib/env.test.ts
+++ b/npm-packages/convex/src/cli/lib/env.test.ts
@@ -1,0 +1,60 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import type { Context } from "../../bundler/context.js";
+import { envList, type EnvVar, type EnvVarBackend } from "./env.js";
+
+const logMocks = vi.hoisted(() => ({
+  logFailure: vi.fn(),
+  logFinishedStep: vi.fn(),
+  logMessage: vi.fn(),
+  logOutput: vi.fn(),
+}));
+
+vi.mock("../../bundler/log.js", () => ({
+  logFailure: logMocks.logFailure,
+  logFinishedStep: logMocks.logFinishedStep,
+  logMessage: logMocks.logMessage,
+  logOutput: logMocks.logOutput,
+}));
+
+function fakeBackend(envs: EnvVar[]): EnvVarBackend {
+  return {
+    get() {
+      return Promise.resolve(null);
+    },
+    list() {
+      return Promise.resolve(envs);
+    },
+    update() {
+      return Promise.reject(new Error("Unexpected update"));
+    },
+    notice: "",
+  };
+}
+
+describe("envList", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test("prints only names without values or warnings when namesOnly is true", async () => {
+    await envList(
+      {} as Context,
+      fakeBackend([
+        { name: "PLAIN", value: "plain-value" },
+        { name: "DANGEROUS", value: "secret'value#fragment" },
+      ]),
+      { namesOnly: true },
+    );
+
+    expect(logMocks.logOutput.mock.calls).toEqual([["PLAIN"], ["DANGEROUS"]]);
+    expect(logMocks.logMessage).not.toHaveBeenCalled();
+
+    const emitted = [
+      ...logMocks.logOutput.mock.calls.flat(),
+      ...logMocks.logMessage.mock.calls.flat(),
+    ].join("\n");
+    expect(emitted).not.toContain("plain-value");
+    expect(emitted).not.toContain("secret'value#fragment");
+    expect(emitted).not.toContain("Warning (");
+  });
+});

--- a/npm-packages/convex/src/cli/lib/env.ts
+++ b/npm-packages/convex/src/cli/lib/env.ts
@@ -171,13 +171,21 @@ export async function envRemove(
   );
 }
 
-export async function envList(ctx: Context, backend: EnvVarBackend) {
+export async function envList(
+  ctx: Context,
+  backend: EnvVarBackend,
+  options?: { namesOnly?: boolean },
+) {
   const envs = await backend.list();
   if (envs.length === 0) {
     logMessage(`No environment variables set${backend.notice}`);
     return;
   }
   for (const { name, value } of envs) {
+    if (options?.namesOnly) {
+      logOutput(name);
+      continue;
+    }
     const { formatted, warning } = formatEnvValueForDotfile(value);
     if (warning) {
       logMessage(`Warning (${name}): ${warning}`);


### PR DESCRIPTION
## Summary
`npx convex env list` prints every variable as `NAME=value`, including plaintext secrets. This adds an opt-in `--names-only` flag that lists just the variable names, so you can check what's configured without the values landing in terminal scrollback, CI logs, or an agent's transcript. Default output is unchanged.

## Why this matters
The reporter (#481) hit this through coding agents: they run `convex env list` constantly to check config, and every run dumps secrets into the transcript and model context. One of their agents stopped and told them to rotate their tokens. `convex env get NAME` already exists for the intentional "I want this value" case, but there was no way to answer "which variables are set?" without printing all of them.

This is deliberately the smallest, non-breaking step:
- `--names-only` is opt-in. `convex env list` with no flag is byte-for-byte unchanged, so existing `convex env list > .env.convex` and pipe-to-command workflows behave exactly as before (the concern you raised on the issue).
- In names-only mode the value is never formatted, so the `Warning (NAME): ...` line (which is derived from the value) is suppressed too. No value-derived content reaches any output channel.

It does not change the default. #481 floats hardening the default (names-only by default, redact-by-default, or auto-redact when non-TTY). Since you flagged that none of those is a slam dunk and the non-TTY case is the pipe-to-file pattern you want to preserve, I left the default alone here. Happy to follow up with whichever default direction you prefer. And `--names-only` is just one option name; if you'd rather call it `--reveal`/`--show-values` (inverting the default), say the word and I'll rename before you spend review time on it.

## Testing
Added a unit test (`src/cli/lib/env.test.ts`) that runs `envList` with a fake backend and `{ namesOnly: true }`, including a value with `'` and `#` (which normally triggers a dotfile warning), and asserts the output is names-only with no values and no `Warning (` lines.

Refs #481



---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
