### PR TITLE
docs(self-hosted): document clearing and resetting data

### DIFF
--- a/self-hosted/README.md
+++ b/self-hosted/README.md
@@ -119,6 +119,7 @@ e.g., instead of setting `CONVEX_DEPLOY_KEY`, you'll need to set
 - [Hosting on your own servers](./advanced/hosting_on_own_infra.md)
 - [Running the database on Postgres or MySQL](./advanced/postgres_or_mysql.md)
 - [Storing files in S3 instead of local filesystem](./advanced/s3_storage.md)
+- [Clearing or resetting data](./advanced/clearing_data.md)
 - [Running the dashboard locally](./advanced/dashboard.md)
 - [Disabling logging features](./advanced/disabling_logging.md)
 - [Upgrading Convex self-hosted version](./advanced/upgrading.md)

--- a/self-hosted/advanced/clearing_data.md
+++ b/self-hosted/advanced/clearing_data.md
@@ -1,0 +1,38 @@
+# Clearing or resetting data
+
+There is no single destructive "reset database" command, by design. Instead, you
+clear data by replacing tables with an empty snapshot import. This lets you wipe
+data without deleting your Docker volume or re-provisioning the deployment, and
+it leaves your schema and functions in place.
+
+> Back up first: run `npx convex export --path backup.zip` before clearing.
+> `--replace -y` is irreversible.
+
+Before running an all-tables clear, make sure `CONVEX_SELF_HOSTED_URL` points at
+the deployment you intend to wipe. The same one-liner run against a production
+deployment destroys all of its data.
+
+## Clear a single table
+
+```
+npx convex import --table $tableName --replace --format jsonLines /dev/null -y
+```
+
+## Clear all tables in the app
+
+```
+for tableName in `npx convex data`; do npx convex import --table $tableName --replace -y --format jsonLines /dev/null; done
+```
+
+## Clear all tables in a component
+
+```
+for tableName in `npx convex data --component $component`; do npx convex import --component $component --table $tableName --replace -y --format jsonLines /dev/null; done
+```
+
+These commands use `/dev/null` as an empty import file, which works on Linux and
+macOS. On Windows (PowerShell), `/dev/null` does not exist, so use an empty file
+you create instead.
+
+Commands verified with `convex@latest` as of 2026-06. Run
+`npx convex import --help` for current flag behavior.


### PR DESCRIPTION
## Summary
Adds a self-hosted docs page explaining how to clear or reset data without deleting the Docker volume, by replacing tables with an empty snapshot import. Linked from the Advanced Configuration list.

## Why this matters
The reporter (#476) couldn't find any documentation for resetting a self-hosted database and assumed there was no supported way short of deleting the Docker volume. The capability already exists via `npx convex import --replace`, and @ianmacartney posted the exact one-liners in the thread (one table, all tables, all tables in a component), but a GitHub comment isn't discoverable later. This moves that answer into the docs so the next person searching "reset self-hosted convex database" finds it. No new command, no behavior change.

It follows the existing self-hosted docs convention: the page leads the destructive commands with an `npx convex export` backup step, matching upgrading.md and s3_storage.md, and warns to confirm `CONVEX_SELF_HOSTED_URL` before an all-tables clear.

## Testing
Docs-only, prettier-checked. The commands are the ones from the issue thread (`npx convex data` lists bare table names to stdout, and `npx convex import --replace --format jsonLines /dev/null` clears a table).

Refs #476
