### PR TITLE
feat(cli): syntax-highlight JSON output of convex run/data in a TTY

### DIFF
--- a/npm-packages/convex/src/cli/lib/run.test.ts
+++ b/npm-packages/convex/src/cli/lib/run.test.ts
@@ -1,0 +1,43 @@
+import chalk from "chalk";
+import { afterEach, describe, expect, test } from "vitest";
+import { highlightJson } from "./run.js";
+
+const stripAnsi = (value: string) => value.replace(/\x1b\[[0-9;]*m/g, "");
+const originalChalkLevel = chalk.level;
+
+describe("highlightJson", () => {
+  afterEach(() => {
+    chalk.level = originalChalkLevel;
+  });
+
+  test("preserves valid JSON after ANSI codes are stripped", () => {
+    chalk.level = 1;
+    const value = {
+      key: "value",
+      count: 3,
+      negative: -2.5e3,
+      active: true,
+      missing: null,
+      nested: ["item", false],
+      escaped: 'a"b',
+    };
+
+    const highlighted = highlightJson(JSON.stringify(value, null, 2));
+
+    expect(JSON.parse(stripAnsi(highlighted))).toEqual(value);
+  });
+
+  test("adds ANSI color codes for JSON tokens", () => {
+    chalk.level = 1;
+    const value = {
+      key: "value",
+      count: 3,
+      active: true,
+      missing: null,
+    };
+
+    const highlighted = highlightJson(JSON.stringify(value, null, 2));
+
+    expect(highlighted).toContain("\x1b[");
+  });
+});

--- a/npm-packages/convex/src/cli/lib/run.ts
+++ b/npm-packages/convex/src/cli/lib/run.ts
@@ -1,5 +1,5 @@
-import { chalkStderr } from "chalk";
-import util from "util";
+// eslint-disable-next-line no-restricted-imports -- default chalk formats stdout output (logOutput)
+import chalk, { chalkStderr } from "chalk";
 import ws from "ws";
 import { ConvexHttpClient } from "../../browser/http_client.js";
 import { BaseConvexClient } from "../../browser/index.js";
@@ -322,12 +322,32 @@ export async function runSystemQuery(
 export function formatValue(value: Value) {
   const json = convexToJson(value);
   if (process.stdout.isTTY) {
-    // TODO (Tom) add JSON syntax highlighting like https://stackoverflow.com/a/51319962/398212
-    // until then, just spit out something that isn't quite JSON because it's easy
-    return util.inspect(value, { colors: true, depth: null });
+    return highlightJson(JSON.stringify(json, null, 2));
   } else {
     return JSON.stringify(json, null, 2);
   }
+}
+
+// Syntax-highlight a pretty-printed JSON string for TTY output. Only ANSI
+// color codes are added; the underlying JSON is unchanged, so stripping the
+// codes yields the exact `JSON.stringify(value, null, 2)` output.
+export function highlightJson(jsonString: string): string {
+  return jsonString.replace(
+    /("(\\u[a-zA-Z0-9]{4}|\\[^u]|[^\\"])*"(\s*:)?|\b(true|false|null)\b|-?\d+(?:\.\d*)?(?:[eE][+\-]?\d+)?)/g,
+    (match) => {
+      if (match.startsWith('"')) {
+        const keyMatch = /^(.*?)(\s*:)$/.exec(match);
+        if (keyMatch !== null) {
+          return `${chalk.cyan(keyMatch[1])}${keyMatch[2]}`;
+        }
+        return chalk.green(match);
+      }
+      if (match === "null") {
+        return chalk.gray(match);
+      }
+      return chalk.yellow(match);
+    },
+  );
 }
 
 export async function subscribeAndLog(


### PR DESCRIPTION
## Summary

`convex run` and `convex data` now print real, syntax-highlighted JSON when writing to a terminal. The TTY branch of `formatValue` previously fell back to `util.inspect`, whose output uses single quotes and unquoted keys (so it isn't valid JSON). It is now colorized `JSON.stringify` output. Piped/redirected output is unchanged, so anything parsing `convex run` keeps working.

## Why this matters

`formatValue` in `npm-packages/convex/src/cli/lib/run.ts` carried a standing TODO:

```ts
// TODO (Tom) add JSON syntax highlighting like https://stackoverflow.com/a/51319962/398212
// until then, just spit out something that isn't quite JSON because it's easy
return util.inspect(value, { colors: true, depth: null });
```

`util.inspect` renders `_id: 'k17abc'` (unquoted key, single-quoted string). Reading a query result in the terminal and copying it into something that expects JSON requires fixing the quotes by hand. Colorizing the real `JSON.stringify` output keeps the terminal view valid JSON while making keys and values easy to scan, matching what most modern CLIs do.

## Demo

Before (`util.inspect`) vs after (highlighted, valid JSON):

![demo](https://raw.githubusercontent.com/mvanhorn/convex-backend/6795acf5bd07b80b020109e569aca2fc263a925e/convex-run-json-highlight.gif)

## Changes

- Added `highlightJson(jsonString)`, a small regex tokenizer that wraps JSON keys, strings, numbers, booleans, and `null` in chalk colors without changing any characters, and switched the TTY branch of `formatValue` to use it. The non-TTY branch stays exactly `JSON.stringify(json, null, 2)` so scripts and agents that pipe `convex run` are unaffected. The default `chalk` import (for stdout) carries the eslint-disable the project's own rule documents for `logOutput` formatting.

## Testing

Added `run.test.ts`: stripping the ANSI codes from `highlightJson` output parses back to JSON deeply equal to the input (covering keys, strings, numbers, booleans, null, nested arrays, escaped quotes, and scientific notation), and the highlighted output contains ANSI codes. `prettier --check` passes on both files.
