### PR TITLE
fix(dashboard): bypass WorkOS redirect after account deletion to prev…

### DIFF
--- a/npm-packages/dashboard/src/pages/api/auth/logout.ts
+++ b/npm-packages/dashboard/src/pages/api/auth/logout.ts
@@ -17,7 +17,7 @@ export default async function handler(
 
     res.setHeader("Set-Cookie", deleteSessionCookie());
 
-    if (!session) {
+    if (!session || req.query.local === "true") {
       return res.redirect("/login");
     }
 

--- a/npm-packages/dashboard/src/pages/profile.tsx
+++ b/npm-packages/dashboard/src/pages/profile.tsx
@@ -92,8 +92,7 @@ export function Profile() {
                         document.cookie = "";
                         window.localStorage.clear();
                         await deleteAccount();
-                        window.location.href =
-                          "/api/auth/logout?returnTo=/api/auth/login";
+                        window.location.href = "/api/auth/logout?local=true";
                       } catch (e: any) {
                         setDeleteAccountError(e.message);
                         throw e;


### PR DESCRIPTION
Description
This PR addresses issue #418, where deleting a user account leads to a blank page on the WorkOS domain.

Root Cause
When a user requests account deletion, the backend deletes the user profile and invalidates all active sessions within WorkOS.
After the deletion call completes, the dashboard attempts to clear local state and redirects the browser to the Next.js API logout handler (/api/auth/logout) to erase the HttpOnly session cookie (wos-session).
The API logout handler loads the session and attempts to fetch a WorkOS-managed logout URL using session.getLogoutUrl({ returnTo: ... }).
Because the session has already been deleted in WorkOS (via the user deletion flow), redirecting to the WorkOS logout URL with that session ID causes WorkOS to fail/hang on a blank page instead of redirecting back to the login page.
Solution
Added a local=true query parameter to the /api/auth/logout Next.js API route. When specified, it deletes the wos-session cookie and immediately redirects back to /login without invoking the external WorkOS logout URL.
Updated the confirmation action in profile.tsx to redirect the user to /api/auth/logout?local=true once the deleteAccount API request succeeds.
Changes
npm-packages/dashboard/src/pages/api/auth/logout.ts
Added check for req.query.local === "true" in the session-validation conditional to redirect to /login early.
npm-packages/dashboard/src/pages/profile.tsx
Updated redirection in the confirmation callback from /api/auth/logout?returnTo=/api/auth/login to /api/auth/logout?local=true.