### PR TITLE
fix(cli): use self-hosted dashboard URL in auth config error

### DIFF
--- a/npm-packages/convex/src/cli/lib/config.ts
+++ b/npm-packages/convex/src/cli/lib/config.ts
@@ -22,7 +22,10 @@ import {
   entryPointsByEnvironment,
 } from "../../bundler/index.js";
 import { version } from "../version.js";
-import { deploymentDashboardUrlPage } from "./dashboard.js";
+import {
+  deploymentDashboardUrlPage,
+  selfHostedDashboardUrl,
+} from "./dashboard.js";
 import {
   functionsDir,
   ErrorData,
@@ -975,6 +978,15 @@ export async function handlePushConfigError(
       const dashboardUrl = deploymentDashboardUrlPage(
         deploymentName,
         `/settings/environment-variables${variableQuery}`,
+      );
+      setEnvVarInstructions = `Go to:\n\n    ${chalkStderr.bold(
+        dashboardUrl,
+      )}\n\n  to set it up. `;
+    } else if (deployment) {
+      // Self-hosted deployments have no deploymentName but do have a deployment URL.
+      const dashboardUrl = selfHostedDashboardUrl(
+        deployment.deploymentUrl,
+        `/settings/environment-variables`,
       );
       setEnvVarInstructions = `Go to:\n\n    ${chalkStderr.bold(
         dashboardUrl,

--- a/npm-packages/convex/src/cli/lib/dashboard.ts
+++ b/npm-packages/convex/src/cli/lib/dashboard.ts
@@ -62,3 +62,22 @@ export function projectDashboardUrl(team: string, project: string) {
 export function teamDashboardUrl(team: string) {
   return `${DASHBOARD_HOST}/t/${team}`;
 }
+
+/**
+ * Derive the self-hosted dashboard URL from the backend deployment URL.
+ * The self-hosted dashboard runs on port 6791 by default (same host as the
+ * backend which is typically on port 3210).
+ */
+export function selfHostedDashboardUrl(
+  deploymentUrl: string,
+  page: string,
+): string {
+  try {
+    const url = new URL(deploymentUrl);
+    url.port = "6791";
+    return `${url.origin}${page}`;
+  } catch {
+    // If URL parsing fails, fall back to a reasonable guess
+    return `http://localhost:6791${page}`;
+  }
+}


### PR DESCRIPTION
## Summary

When running a self-hosted Convex deployment, the CLI error for missing auth config environment variables showed a `dashboard.convex.dev` URL with `null` as the deployment name:

```
✖ Environment variable CLERK_JWT_ISSUER_DOMAIN is used in auth config file but its value was not set. Go to:

    https://dashboard.convex.dev/d/null/settings/environment-variables?var=CLERK_JWT_ISSUER_DOMAIN

  to set it up. 
```

This PR fixes the error message to derive the dashboard URL from the deployment URL when the deployment is self-hosted (i.e., `deploymentName` is null but `deployment` is available). The self-hosted dashboard URL is constructed by replacing the port with `6791` (the default self-hosted dashboard port from `docker-compose.yml`).

## Changes

- Added `selfHostedDashboardUrl()` to `dashboard.ts` — derives the dashboard URL from the backend deployment URL by swapping to port 6791
- Updated `handlePushConfigError()` in `config.ts` — added an `else if (deployment)` branch for the self-hosted case

## Testing

- TypeScript compiles without errors (`npx tsc --noEmit`)
- No existing tests cover this code path; manual testing with a self-hosted deployment recommended

Fixes #56