### PR TITLE
Sync Ask AI widget with dashboard dark mode

### DIFF
--- a/npm-packages/dashboard/src/elements/AskAI.tsx
+++ b/npm-packages/dashboard/src/elements/AskAI.tsx
@@ -14,6 +14,7 @@ export function AskAI() {
         data-project-name="Convex"
         data-project-color="#3F5295"
         data-project-logo="https://img.stackshare.io/service/41143/default_f1d33b63d360437ba28c8ac981dd68d7d2478b22.png"
+        data-color-scheme-selector=".dark"
         data-user-analytics-fingerprint-enabled="true"
         data-user-analytics-cookie-enabled="true"
         data-search-mode-enabled="true"


### PR DESCRIPTION
## Summary

Fixes #265.

Updates the Kapa AI widget configuration so the Ask AI modal follows the dashboard's dark mode state. The dashboard applies dark mode with a `.dark` class on the document, and Kapa supports `data-color-scheme-selector` for syncing its internal color scheme to a host-page selector.

## Changes

- Adds `data-color-scheme-selector=".dark"` to the Ask AI widget script.

## Testing

- Ran focused ESLint on `npm-packages/dashboard/src/elements/AskAI.tsx` with the repo eslint config.
- Verified the Kapa widget script in a local browser harness:
  - when `.dark` is present, Kapa's shadow root sets `data-mantine-color-scheme="dark"`.
  - when `.dark` is absent, Kapa sets `data-mantine-color-scheme="light"`.
  - toggling `.dark` updates Kapa back to dark.