### PR TITLE
node-executor: ref-count process.env swap so concurrent invocations keep their env vars

### DIFF
--- a/npm-packages/node-executor/src/executor.test.ts
+++ b/npm-packages/node-executor/src/executor.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, test } from "vitest";
+import { runWithEnvironmentVariables } from "./executor";
+
+function deferred() {
+  let resolve!: () => void;
+  const promise = new Promise<void>((r) => {
+    resolve = r;
+  });
+  return { promise, resolve };
+}
+
+async function tick() {
+  await new Promise<void>((resolve) => setImmediate(resolve));
+}
+
+describe("runWithEnvironmentVariables", () => {
+  test("allows overlapping invocations with the same env hash", async () => {
+    const firstStarted = deferred();
+    const releaseFirst = deferred();
+    let secondStarted = false;
+
+    const envs = [{ name: "CONVEX_TEST_SHARED", value: "shared" }];
+    const first = runWithEnvironmentVariables([...envs], async () => {
+      expect(process.env.CONVEX_TEST_SHARED).toBe("shared");
+      firstStarted.resolve();
+      await releaseFirst.promise;
+      expect(process.env.CONVEX_TEST_SHARED).toBe("shared");
+    });
+
+    await firstStarted.promise;
+
+    const second = runWithEnvironmentVariables([...envs], async () => {
+      secondStarted = true;
+      expect(process.env.CONVEX_TEST_SHARED).toBe("shared");
+    });
+
+    await tick();
+
+    expect(secondStarted).toBe(true);
+    releaseFirst.resolve();
+    await Promise.all([first, second]);
+  });
+
+  test("waits for the active batch before using a different env hash", async () => {
+    const firstStarted = deferred();
+    const releaseFirst = deferred();
+    let secondStarted = false;
+
+    const first = runWithEnvironmentVariables(
+      [{ name: "CONVEX_TEST_STALE", value: "stale" }],
+      async () => {
+        expect(process.env.CONVEX_TEST_STALE).toBe("stale");
+        firstStarted.resolve();
+        await releaseFirst.promise;
+        expect(process.env.CONVEX_TEST_STALE).toBe("stale");
+      },
+    );
+
+    await firstStarted.promise;
+
+    const second = runWithEnvironmentVariables(
+      [{ name: "CONVEX_TEST_FRESH", value: "fresh" }],
+      async () => {
+        secondStarted = true;
+        expect(process.env.CONVEX_TEST_STALE).toBeUndefined();
+        expect(process.env.CONVEX_TEST_FRESH).toBe("fresh");
+      },
+    );
+
+    await tick();
+
+    expect(secondStarted).toBe(false);
+    releaseFirst.resolve();
+    await Promise.all([first, second]);
+    expect(secondStarted).toBe(true);
+  });
+});

--- a/npm-packages/node-executor/src/executor.ts
+++ b/npm-packages/node-executor/src/executor.ts
@@ -72,31 +72,50 @@ export function setupGlobals(modulePath: string) {
 
 let numInvocations = 0;
 
+// Number of invocations currently executing inside runWithEnvironmentVariables.
+// process.env is process-global, yet multiple invocations can run concurrently
+// in a single executor process. Only the first concurrent invocation swaps
+// process.env and only the last one restores it; otherwise an invocation that
+// finishes while another is still in flight would restore process.env and strip
+// the user-defined variables out from under the still-running invocation. That
+// surfaces as environment variables being intermittently `undefined` under
+// concurrent / batched Node actions.
+//
+// This assumes concurrent invocations in one process share the same environment
+// (true today: an executor process serves a single deployment). A fully isolated
+// alternative would resolve process.env per invocation via AsyncLocalStorage, as
+// is already done for syscalls and the console.
+let concurrentEnvInvocations = 0;
+let savedEnv: typeof process.env | undefined;
+
 async function runWithEnvironmentVariables<T>(
   envs: EnvironmentVariable[],
   fn: (envHash: string) => Promise<T>,
 ): Promise<T> {
-  const savedEnv = process.env;
+  if (concurrentEnvInvocations === 0) {
+    savedEnv = process.env;
 
-  // AWS Lambda populates a number of environment variables, like Lambda version,
-  // handler name, session, AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, etc. We
-  // don't want to expose any of that. Only expose variables that are common
-  // between local Node.js and AWS Lambda.
-  //
-  // Note: This sanitization is for consistency between environments, not for security.
-  // While user code can still access underlying environment variables through
-  // other means, sensitive variables (such as AWS credentials) are protected
-  // through restrictive IAM policies that limit what the Lambda function can do
-  // with those credentials.
-  const allowedEnvs = ["PATH", "PWD", "LANG", "NODE_PATH", "TZ", "UTC"];
-  const sanitized: { [name: string]: string } = {};
-  for (const name of allowedEnvs) {
-    const value = process.env[name];
-    if (value !== undefined) {
-      sanitized[name] = value;
+    // AWS Lambda populates a number of environment variables, like Lambda version,
+    // handler name, session, AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, etc. We
+    // don't want to expose any of that. Only expose variables that are common
+    // between local Node.js and AWS Lambda.
+    //
+    // Note: This sanitization is for consistency between environments, not for security.
+    // While user code can still access underlying environment variables through
+    // other means, sensitive variables (such as AWS credentials) are protected
+    // through restrictive IAM policies that limit what the Lambda function can do
+    // with those credentials.
+    const allowedEnvs = ["PATH", "PWD", "LANG", "NODE_PATH", "TZ", "UTC"];
+    const sanitized: { [name: string]: string } = {};
+    for (const name of allowedEnvs) {
+      const value = process.env[name];
+      if (value !== undefined) {
+        sanitized[name] = value;
+      }
     }
+    process.env = sanitized;
   }
-  process.env = sanitized;
+  concurrentEnvInvocations += 1;
 
   // Set the user defined environment variables
   envs.sort((a, b) => a.name.localeCompare(b.name));
@@ -110,10 +129,15 @@ async function runWithEnvironmentVariables<T>(
   try {
     return await fn(envHash);
   } finally {
-    // Restore the initial environment when we’re done.
-    // This is helpful to bypass a AWS Lambda bug affecting Node.js 24 where the lambda
-    // would crash when AWS’s own env vars are missing after a second function execution.
-    process.env = savedEnv;
+    concurrentEnvInvocations -= 1;
+    if (concurrentEnvInvocations === 0 && savedEnv !== undefined) {
+      // Restore the initial environment once the last concurrent invocation is
+      // done. This is helpful to bypass a AWS Lambda bug affecting Node.js 24
+      // where the lambda would crash when AWS's own env vars are missing after a
+      // second function execution.
+      process.env = savedEnv;
+      savedEnv = undefined;
+    }
   }
 }
 

--- a/npm-packages/node-executor/src/executor.ts
+++ b/npm-packages/node-executor/src/executor.ts
@@ -74,69 +74,90 @@ let numInvocations = 0;
 
 // Number of invocations currently executing inside runWithEnvironmentVariables.
 // process.env is process-global, yet multiple invocations can run concurrently
-// in a single executor process. Only the first concurrent invocation swaps
-// process.env and only the last one restores it; otherwise an invocation that
-// finishes while another is still in flight would restore process.env and strip
-// the user-defined variables out from under the still-running invocation. That
-// surfaces as environment variables being intermittently `undefined` under
-// concurrent / batched Node actions.
-//
-// This assumes concurrent invocations in one process share the same environment
-// (true today: an executor process serves a single deployment). A fully isolated
-// alternative would resolve process.env per invocation via AsyncLocalStorage, as
-// is already done for syscalls and the console.
+// in a single executor process. Invocations with the same env hash can safely
+// share one swapped process.env batch; invocations with different env hashes wait
+// until the active batch drains so deleted or renamed variables do not leak
+// between overlapping requests.
 let concurrentEnvInvocations = 0;
 let savedEnv: typeof process.env | undefined;
+let activeEnvHash: string | undefined;
+let activeEnvBatchDrained: Promise<void> | undefined;
+let resolveActiveEnvBatchDrained: (() => void) | undefined;
 
-async function runWithEnvironmentVariables<T>(
-  envs: EnvironmentVariable[],
-  fn: (envHash: string) => Promise<T>,
-): Promise<T> {
-  if (concurrentEnvInvocations === 0) {
-    savedEnv = process.env;
-
-    // AWS Lambda populates a number of environment variables, like Lambda version,
-    // handler name, session, AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, etc. We
-    // don't want to expose any of that. Only expose variables that are common
-    // between local Node.js and AWS Lambda.
-    //
-    // Note: This sanitization is for consistency between environments, not for security.
-    // While user code can still access underlying environment variables through
-    // other means, sensitive variables (such as AWS credentials) are protected
-    // through restrictive IAM policies that limit what the Lambda function can do
-    // with those credentials.
-    const allowedEnvs = ["PATH", "PWD", "LANG", "NODE_PATH", "TZ", "UTC"];
-    const sanitized: { [name: string]: string } = {};
-    for (const name of allowedEnvs) {
-      const value = process.env[name];
-      if (value !== undefined) {
-        sanitized[name] = value;
-      }
+function sanitizedEnvironment(): { [name: string]: string } {
+  // AWS Lambda populates a number of environment variables, like Lambda version,
+  // handler name, session, AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, etc. We
+  // don't want to expose any of that. Only expose variables that are common
+  // between local Node.js and AWS Lambda.
+  //
+  // Note: This sanitization is for consistency between environments, not for security.
+  // While user code can still access underlying environment variables through
+  // other means, sensitive variables (such as AWS credentials) are protected
+  // through restrictive IAM policies that limit what the Lambda function can do
+  // with those credentials.
+  const allowedEnvs = ["PATH", "PWD", "LANG", "NODE_PATH", "TZ", "UTC"];
+  const sanitized: { [name: string]: string } = {};
+  for (const name of allowedEnvs) {
+    const value = process.env[name];
+    if (value !== undefined) {
+      sanitized[name] = value;
     }
-    process.env = sanitized;
   }
-  concurrentEnvInvocations += 1;
+  return sanitized;
+}
 
-  // Set the user defined environment variables
-  envs.sort((a, b) => a.name.localeCompare(b.name));
+function applyUserEnvironmentVariables(envs: EnvironmentVariable[]) {
   for (const e of envs) {
     process.env[e.name] = e.value;
   }
+}
+
+export async function runWithEnvironmentVariables<T>(
+  envs: EnvironmentVariable[],
+  fn: (envHash: string) => Promise<T>,
+): Promise<T> {
+  // Set the user defined environment variables in a stable order.
+  envs.sort((a, b) => a.name.localeCompare(b.name));
 
   // Compute a hash based on the user defined environment variables.
   const envHash = createHash("md5").update(JSON.stringify(envs)).digest("hex");
+
+  while (concurrentEnvInvocations > 0 && activeEnvHash !== envHash) {
+    if (activeEnvBatchDrained === undefined) {
+      throw new Error("Missing active environment batch drain promise");
+    }
+    await activeEnvBatchDrained;
+  }
+
+  if (concurrentEnvInvocations === 0) {
+    savedEnv = process.env;
+    process.env = sanitizedEnvironment();
+    activeEnvHash = envHash;
+    activeEnvBatchDrained = new Promise((resolve) => {
+      resolveActiveEnvBatchDrained = resolve;
+    });
+  }
+  concurrentEnvInvocations += 1;
+
+  applyUserEnvironmentVariables(envs);
 
   try {
     return await fn(envHash);
   } finally {
     concurrentEnvInvocations -= 1;
     if (concurrentEnvInvocations === 0 && savedEnv !== undefined) {
+      const resolveDrained = resolveActiveEnvBatchDrained;
+
       // Restore the initial environment once the last concurrent invocation is
       // done. This is helpful to bypass a AWS Lambda bug affecting Node.js 24
       // where the lambda would crash when AWS's own env vars are missing after a
       // second function execution.
       process.env = savedEnv;
       savedEnv = undefined;
+      activeEnvHash = undefined;
+      activeEnvBatchDrained = undefined;
+      resolveActiveEnvBatchDrained = undefined;
+      resolveDrained?.();
     }
   }
 }


### PR DESCRIPTION
Addresses #492.

## Problem

`runWithEnvironmentVariables` swaps the **process-global** `process.env` per invocation and restores it in a `finally`. Node action invocations run **concurrently in one executor process** (only console/syscalls are isolated via `AsyncLocalStorage`, not `process.env`), so when one invocation's `finally` runs while another is still in flight, it restores `process.env` and strips the user-defined env vars out from under the still-running invocation. The result is deployment env vars being intermittently `undefined` under concurrent / batched Node actions (full analysis and a repro in #492).

A simple ref-counted swap fixes that original restore race, but it can leave stale keys behind if an overlapping invocation starts with a different environment variable set. For example, a deleted or renamed env var from the first active invocation could still be visible to the second invocation if both share the same process-global `process.env` object.

## Change

Batch `process.env` swaps by the sorted user-env `envHash`:

- Sort the invocation's user-defined env vars and compute `envHash` before mutating `process.env`.
- Invocations with the same `envHash` share one ref-counted environment batch. The first invocation saves and replaces `process.env`; the last invocation restores the original environment.
- Invocations with a different `envHash` wait for the active batch to drain, then install a fresh sanitized environment and apply their own user env vars.

This preserves concurrency for the normal same-env case while avoiding both failure modes:

- a finishing invocation no longer restores `process.env` out from under same-env siblings;
- deleted or renamed env vars no longer leak into overlapping different-env invocations.

The Node.js 24 AWS-env restore behavior is preserved; restore happens when the active env batch drains.

## Why not delete absent keys during overlap?

Deleting absent keys before every overlapping invocation would fix the stale-key case for the later invocation, but it would mutate `process.env` out from under the still-running earlier invocation. Waiting for a different-env batch avoids that cross-invocation mutation without requiring a full `process.env` Proxy / `AsyncLocalStorage` implementation.

## Testing

Added focused `node-executor` tests covering:

- overlapping invocations with the same env hash can run concurrently and keep their env vars;
- an overlapping invocation with a different env hash waits for the active batch and does not see stale keys.

Ran locally:

```sh
./node_modules/.bin/vitest run src/executor.test.ts
npm run build
scripts/rush_from_npm-packages.sh build -t node-executor
git diff --check
```

---

By submitting this pull request, I confirm that Convex can use, modify, copy, and redistribute the contribution, under the terms of its choice.
