### PR TITLE
docs: document stable TypeScript 7 setup

### DIFF
--- a/npm-packages/docs/docs/production/project-configuration.mdx
+++ b/npm-packages/docs/docs/production/project-configuration.mdx
@@ -183,24 +183,42 @@ Let us know if you run into any issues or have any feedback!
 
 ### Configuring the TypeScript compiler
 
-By default, Convex will use the `tsc` binary installed in your project for
-typechecking. If you would like to use the TypeScript 7 native preview instead,
-you can set the `typescriptCompiler` option to `tsgo`. Note that
-`@typescript/native-preview` must be installed in your project to use `tsgo`.
+By default, Convex uses the `tsc` binary installed in your project for
+typechecking. This works with TypeScript 6 and TypeScript 7 without any
+additional `convex.json` configuration.
 
-<Admonition type="info" title="Convex version requirement">
+To use TypeScript 7, install it as your project's TypeScript version:
 
-To use the TypeScript 7 native preview, you must use the `convex` NPM package
-version 1.31.1 or later.
+```sh
+npm install --save-dev typescript@^7
+```
 
-</Admonition>
+TypeScript 7.0 does not include a JavaScript API. If other tools in your project
+still import the TypeScript API, use the
+[side-by-side installation](https://devblogs.microsoft.com/typescript/announcing-typescript-7-0/#running-side-by-side-with-typescript-60)
+recommended by the TypeScript team:
 
-```json title="convex.json"
+```json title="package.json"
 {
-  "$schema": "./node_modules/convex/schemas/convex.schema.json",
-  "typescriptCompiler": "tsgo"
+  "devDependencies": {
+    "@typescript/native": "npm:typescript@^7.0.2",
+    "typescript": "npm:@typescript/typescript6@^6.0.2"
+  }
 }
 ```
+
+This exposes TypeScript 7 as `tsc` while keeping the TypeScript 6 API available
+to other tools through the `typescript` package. The TypeScript 6 compatibility
+compiler remains available as `tsc6`.
+
+<Admonition type="info" title="Migrating from the TypeScript 7 preview">
+
+If you previously installed `@typescript/native-preview` and set
+`"typescriptCompiler": "tsgo"`, replace the preview package with stable
+TypeScript 7 and remove the `typescriptCompiler` setting. Stable TypeScript 7
+uses Convex's default `tsc` selection.
+
+</Admonition>
 
 ### Configuring bundler options
 


### PR DESCRIPTION
## Summary

- Replace the TypeScript 7 native-preview instructions with the stable TypeScript 7 installation.
- Document the TypeScript team's TS6 API + TS7 compiler side-by-side layout.
- Explain how existing `@typescript/native-preview` / `"tsgo"` users migrate to the default `tsc` selection.

Companion to get-convex/convex-js#178 and related to get-convex/convex-js#177.

## Why

TypeScript 7 is now stable under the standard `typescript` package. The existing docs still direct users to the former `@typescript/native-preview` package and make `typescriptCompiler` look necessary for TypeScript 7.

The companion CLI change also supports the official side-by-side package aliases for projects whose tooling still imports the TypeScript 6 JavaScript API.

## Validation

- Preserves the existing project-configuration page structure and MDX components.
- Limits the change to the TypeScript compiler section.
- Code snippets match the stable TypeScript team's documented installation layouts.

By submitting pull requests, you confirm that Convex can use, modify, copy, and redistribute the contribution, under the terms of its choice.
