### PR TITLE
Fix cursor when splitting later paginated query pages

### DIFF
--- a/npm-packages/convex/src/browser/sync/paginated_query_client.test.ts
+++ b/npm-packages/convex/src/browser/sync/paginated_query_client.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, test } from "vitest";
+import { Value } from "../../values/index.js";
+import { BaseConvexClientInterface, Transition } from "./client.js";
+import { PaginatedQueryClient } from "./paginated_query_client.js";
+import { QueryToken } from "./udf_path_utils.js";
+import { Long } from "../../vendor/long.js";
+
+class TestBaseClient {
+  private transitionHandler: ((transition: Transition) => void) | undefined;
+  private nextToken = 0;
+  readonly subscriptions: Array<{
+    queryToken: QueryToken;
+    args: Record<string, Value>;
+  }> = [];
+  readonly results = new Map<QueryToken, Value>();
+
+  addOnTransitionHandler(handler: (transition: Transition) => void) {
+    this.transitionHandler = handler;
+    return () => {
+      this.transitionHandler = undefined;
+    };
+  }
+
+  subscribe(_name: string, args: Record<string, Value> = {}) {
+    const queryToken = `query-${this.nextToken++}` as QueryToken;
+    this.subscriptions.push({ queryToken, args });
+    return { queryToken, unsubscribe: () => {} };
+  }
+
+  localQueryResultByToken(queryToken: QueryToken) {
+    return this.results.get(queryToken);
+  }
+
+  emitTransition(queryToken: QueryToken) {
+    this.transitionHandler?.({
+      queries: [
+        {
+          token: queryToken,
+          modification: { kind: "Updated", result: undefined },
+        },
+      ],
+      reflectedMutations: [],
+      timestamp: Long.fromNumber(0),
+    });
+  }
+}
+
+describe("PaginatedQueryClient", () => {
+  test("splitting a later page preserves its start cursor", () => {
+    const baseClient = new TestBaseClient();
+    const paginatedClient = new PaginatedQueryClient(
+      baseClient as unknown as BaseConvexClientInterface,
+      () => {},
+    );
+    const { paginatedQueryToken } = paginatedClient.subscribe(
+      "messages:list",
+      {},
+      { initialNumItems: 2, id: 1 },
+    );
+
+    const firstPage = baseClient.subscriptions[0];
+    baseClient.results.set(firstPage.queryToken, {
+      page: [1, 2],
+      isDone: false,
+      continueCursor: "page-1-end",
+    });
+    baseClient.emitTransition(firstPage.queryToken);
+
+    const result = paginatedClient.localQueryResultByToken(paginatedQueryToken);
+    expect(result?.status).toBe("CanLoadMore");
+    expect(result?.loadMore(2)).toBe(true);
+
+    const secondPage = baseClient.subscriptions[1];
+    expect(secondPage.args.paginationOpts).toMatchObject({
+      cursor: "page-1-end",
+    });
+    baseClient.results.set(secondPage.queryToken, {
+      page: [3, 4],
+      isDone: false,
+      continueCursor: "page-2-end",
+      splitCursor: "page-2-middle",
+      pageStatus: "SplitRequired",
+    });
+    baseClient.emitTransition(secondPage.queryToken);
+
+    expect(baseClient.subscriptions[2].args.paginationOpts).toMatchObject({
+      cursor: "page-1-end",
+      endCursor: "page-2-middle",
+    });
+    expect(baseClient.subscriptions[3].args.paginationOpts).toMatchObject({
+      cursor: "page-2-middle",
+      endCursor: "page-2-end",
+    });
+  });
+});

--- a/npm-packages/convex/src/browser/sync/paginated_query_client.ts
+++ b/npm-packages/convex/src/browser/sync/paginated_query_client.ts
@@ -28,6 +28,12 @@ import { Long } from "../../vendor/long.js";
 
 type QueryPageKey = number;
 
+type PageSubscription = {
+  queryToken: QueryToken;
+  unsubscribe: () => void;
+  startCursor: string | null;
+};
+
 /**
  * Represents a paginated query subscription with multiple pages.
  *
@@ -44,10 +50,7 @@ type LocalPaginatedQuery = {
   nextPageKey: QueryPageKey;
   pageKeys: QueryPageKey[]; // These pages make up the active page queries.
   // Map page keys to their query subscriptions
-  pageKeyToQuery: Map<
-    QueryPageKey,
-    { queryToken: QueryToken; unsubscribe: () => void }
-  >;
+  pageKeyToQuery: Map<QueryPageKey, PageSubscription>;
   ongoingSplits: Map<QueryPageKey, [QueryPageKey, QueryPageKey]>;
   skip: boolean;
 
@@ -423,6 +426,8 @@ export class PaginatedQueryClient {
   ): void {
     const splitKey1 = paginatedQuery.nextPageKey++;
     const splitKey2 = paginatedQuery.nextPageKey++;
+    const originalStartCursor =
+      paginatedQuery.pageKeyToQuery.get(pageKey)!.startCursor;
 
     const paginationOpts: Value = {
       cursor: continueCursor,
@@ -437,12 +442,15 @@ export class PaginatedQueryClient {
         ...paginatedQuery.args,
         paginationOpts: {
           ...paginationOpts,
-          cursor: null, // Start from beginning for first split
+          cursor: originalStartCursor,
           endCursor: splitCursor,
         },
       },
     );
-    paginatedQuery.pageKeyToQuery.set(splitKey1, firstSubscription);
+    paginatedQuery.pageKeyToQuery.set(splitKey1, {
+      ...firstSubscription,
+      startCursor: originalStartCursor,
+    });
 
     // Second split page: cursor starts at splitCursor, endCursor is the original continueCursor
     const secondSubscription = this.client.subscribe(
@@ -456,7 +464,10 @@ export class PaginatedQueryClient {
         },
       },
     );
-    paginatedQuery.pageKeyToQuery.set(splitKey2, secondSubscription);
+    paginatedQuery.pageKeyToQuery.set(splitKey2, {
+      ...secondSubscription,
+      startCursor: splitCursor,
+    });
 
     paginatedQuery.ongoingSplits.set(pageKey, [splitKey1, splitKey2]);
   }
@@ -489,7 +500,10 @@ export class PaginatedQueryClient {
     );
 
     paginatedQuery.pageKeys.push(pageKey);
-    paginatedQuery.pageKeyToQuery.set(pageKey, subscription);
+    paginatedQuery.pageKeyToQuery.set(pageKey, {
+      ...subscription,
+      startCursor: continueCursor,
+    });
     return subscription;
   }
 


### PR DESCRIPTION
## Summary

- retain the start cursor for each paginated query page
- reuse that cursor when splitting a later page
- preserve split cursors so recursively split pages keep correct boundaries
- add a regression test covering a split on page 2

Fixes #508

## Validation

- targeted Vitest regression test
- targeted ESLint and Prettier checks
- Rush build for the convex package