### PR TITLE
Add URL.canParse() static method to thefunction runtime

### DIFF
--- a/npm-packages/udf-runtime/src/00_url.ts
+++ b/npm-packages/udf-runtime/src/00_url.ts
@@ -189,6 +189,15 @@ class URL {
   #urlInfo: UrlInfo;
   #searchParams: URLSearchParams;
 
+  static canParse(url: string | URL, base?: string | URL): boolean {
+    try {
+      new URL(url, base);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
   constructor(url: string | URL, base?: string | URL) {
     let baseHref: string | null = null;
     if (base !== undefined) {


### PR DESCRIPTION
## What

Adds the standard [`URL.canParse(url, base)`](https://developer.mozilla.org/en-US/docs/Web/API/URL/canParse_static) static method to the function runtime's `URL` class in `npm-packages/udf-runtime/src/00_url.ts`. The class previously implemented no statci methods so this Web API was missing.

## Why

Fixes #510. Libraries such as Effect 4 call `URL.canParse()` internally (e.g. its `urlFromString` schema transform) and break in Convex functions because the method is absent.

## How

`canParse` returns `true`/`false` without throwing implemented as the standard polyfill over the exisintng constructor:


static canParse(url: string | URL, base?: string | URL): boolean {
  try {
    new URL(url, base);
    return true;
  } catch {
    return false;
  }
}


This relies on the constructors existing behavior of throwing a TypeError on invalid input, which matches the WHATWG spec.

## Notes

- Additive only — no existing behavior changed, no new deps, no Rust changes.
- Formatted with \`dprint\` (no changes) and \`tsc --noEmit\` passes for \`udf-runtime\`.
- I couldnt find an existing runtimetest harness for \`URL\` (the code depends on \`performOp\`, which only runs inside the isolate). Ill be  like Happy to add an integration test wherever youd prefer.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.