### PR TITLE
Fix function-spec failing deployment-wide on deeply nested validators

### DIFF
--- a/npm-packages/system-udfs/convex/_system/cli/modules.ts
+++ b/npm-packages/system-udfs/convex/_system/cli/modules.ts
@@ -21,6 +21,49 @@ type FunctionSpecs = (FunctionSpec | HttpFunctionSpec)[];
 export const DEFAULT_ARGS_VALIDATOR = '{ "type": "any" }';
 export const DEFAULT_RETURN_VALIDATOR = '{ "type": "any" }';
 
+const MAX_VALIDATOR_NESTING = 64 - 2;
+const ANY_VALIDATOR = jsonToConvex(JSON.parse(DEFAULT_RETURN_VALIDATOR));
+
+function validatorNesting(value: Value): number {
+  if (Array.isArray(value)) {
+    let deepest = 0;
+    for (const item of value) {
+      deepest = Math.max(deepest, validatorNesting(item));
+    }
+    return 1 + deepest;
+  }
+  if (
+    typeof value === "object" &&
+    value !== null &&
+    !(value instanceof ArrayBuffer)
+  ) {
+    let deepest = 0;
+    for (const item of Object.values(value)) {
+      if (item !== undefined) {
+        deepest = Math.max(deepest, validatorNesting(item));
+      }
+    }
+    return 1 + deepest;
+  }
+  return 0;
+}
+
+function degradeIfTooNested(
+  value: Value,
+  identifier: string,
+  kind: "args" | "returns",
+): Value {
+  if (validatorNesting(value) <= MAX_VALIDATOR_NESTING) {
+    return value;
+  }
+  // eslint-disable-next-line no-console
+  console.warn(
+    `${identifier}: ${kind} validator is too deeply nested to include in the ` +
+      "function spec; reporting it as `v.any()`.",
+  );
+  return ANY_VALIDATOR;
+}
+
 export const apiSpec = queryPrivateSystem("ViewData")({
   args: {
     componentId: v.optional(v.union(v.string(), v.null())),
@@ -36,12 +79,21 @@ export const apiSpec = queryPrivateSystem("ViewData")({
       for (const fn of analyzeResult.functions || []) {
         const argsValidator = fn.args ?? DEFAULT_ARGS_VALIDATOR;
         const returnsValidator = fn.returns ?? DEFAULT_RETURN_VALIDATOR;
+        const identifier = module.path + ":" + fn.name;
         result.push({
-          identifier: module.path + ":" + fn.name,
+          identifier,
           functionType: fn.udfType,
           visibility: fn.visibility ?? { kind: "public" },
-          args: jsonToConvex(JSON.parse(argsValidator)),
-          returns: jsonToConvex(JSON.parse(returnsValidator)),
+          args: degradeIfTooNested(
+            jsonToConvex(JSON.parse(argsValidator)),
+            identifier,
+            "args",
+          ),
+          returns: degradeIfTooNested(
+            jsonToConvex(JSON.parse(returnsValidator)),
+            identifier,
+            "returns",
+          ),
         });
       }
 


### PR DESCRIPTION
## Problem

`npx convex function-spec` (and MCP `functionSpec`) fail for the **entire** deployment when any one functions validator spec nests deeper than ~62 levels:

```
Uncaught Error: Value is too nested (nested 65 levels deep >  maximum nesting 64)
```

`_system/cli/modules:apiSpec` serializes every function's spec as a single array, wrapping each validator in a per-function object. That adds two levels, so a validator whose parsed spec is ≥63 deep pushes the aggregate response past the 64-level `ConvexValue` ceiling (`MAX_NESTING` in `crates/value/src/size.rs`). Because validators are legal at runtime and stored as JSON strings, they pass push/analyze and only break when `apiSpec` re-inflates them with `jsonToConvex`. The check fails at the first level to cross the ceiling, so the message saturates at `65 > 64` and names no culprit — one deep-but-legal function silently takes down `function-spec`, MCP `functionSpec`, and any tooling built on them.

Fixes #512.

## Fix

Measure each validator's nesting (mirroring `Size::nesting`) and, if it wouldn't fit in the aggregate, report it as `v.any()`    and log a warning naming the function and which validator. Every function still appears in the spec; only the offending validator is degraded — implementing suggestion #3 from the issue.

## Verification

- **Repro / fix on a local backend:** a query with a 70-deep return validator makes `function-spec` fail with the error above; with the fix it succeeds and that function's `returns` is reported as `{ "type": "any" }`, with a warning naming it in the logs.
- **Boundary matches the reporter's calibration** (checked against the real `v` / `jsonToConvex`): spec depth 62 is kept (aggregate 64), depth 63 is degraded (aggregate 65).
- `tsc` typecheck, ESLint, and dprint all pass.
