### PR TITLE
Fix InvalidCursor loop on the deployment History page

### DIFF
--- a/npm-packages/dashboard-common/src/features/history/components/HistoryView.tsx
+++ b/npm-packages/dashboard-common/src/features/history/components/HistoryView.tsx
@@ -1,7 +1,7 @@
 import { endOfDay, endOfToday, startOfDay } from "date-fns";
 import { Link } from "@ui/Link";
 import { useRouter } from "next/router";
-import { useCallback, useContext, useEffect, useState } from "react";
+import { useCallback, useContext, useEffect, useRef, useState } from "react";
 import { DeploymentEventContent } from "@common/elements/DeploymentEventContent";
 import {
   DateRangePicker,
@@ -28,6 +28,7 @@ import { LocalDevCallout } from "@common/elements/LocalDevCallout";
 const INITIAL_EVENTS_TO_LOAD = 10;
 const PAGE_SIZE = 10;
 const DISTANCE_FROM_BOTTOM_THRESHOLD_PX = 300;
+const MAX_PAGINATION_RESTARTS = 3;
 
 export function HistoryView() {
   const { useIsOperationAllowed } = useContext(PermissionsContext);
@@ -145,6 +146,23 @@ function HistoryList({ filters }: { filters: DeploymentAuditLogFilters }) {
     INITIAL_EVENTS_TO_LOAD,
   );
 
+  // Stop loading more if pagination keeps restarting without making progress.
+  const furthestResultCount = useRef(0);
+  const restartCount = useRef(0);
+  const filtersKey = `${filters.minDate}|${filters.maxDate}`;
+  useEffect(() => {
+    furthestResultCount.current = 0;
+    restartCount.current = 0;
+  }, [filtersKey]);
+  useEffect(() => {
+    if (results.length > furthestResultCount.current) {
+      furthestResultCount.current = results.length;
+      restartCount.current = 0;
+    } else if (results.length === 0 && furthestResultCount.current > 0) {
+      restartCount.current += 1;
+    }
+  }, [results.length]);
+
   // Keep track of scroll position.
   useEffect(() => {
     function onScroll() {
@@ -154,7 +172,8 @@ function HistoryList({ filters }: { filters: DeploymentAuditLogFilters }) {
           (parentElement.scrollTop + parentElement.clientHeight);
         if (
           distanceFromBottom < DISTANCE_FROM_BOTTOM_THRESHOLD_PX &&
-          status === "CanLoadMore"
+          status === "CanLoadMore" &&
+          restartCount.current < MAX_PAGINATION_RESTARTS
         ) {
           loadMore(PAGE_SIZE);
         }

--- a/npm-packages/system-udfs/convex/_system/frontend/paginatedDeploymentEvents.test.ts
+++ b/npm-packages/system-udfs/convex/_system/frontend/paginatedDeploymentEvents.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, test } from "vitest";
+import { minDateForAuditLogRetention } from "./paginatedDeploymentEvents";
+
+describe("minDateForAuditLogRetention", () => {
+  test("does not move over the course of a day", () => {
+    const startOfDay = Date.UTC(2026, 1, 11, 0, 0, 0, 0);
+    const endOfDay = Date.UTC(2026, 1, 11, 23, 59, 59, 999);
+    expect(minDateForAuditLogRetention(30, startOfDay)).toEqual(
+      minDateForAuditLogRetention(30, endOfDay),
+    );
+  });
+
+  test("does not reach back further than the retention window", () => {
+    const now = Date.UTC(2026, 1, 11, 12, 0, 0, 0);
+    expect(now - minDateForAuditLogRetention(30, now)).toBeLessThanOrEqual(
+      31 * 24 * 60 * 60 * 1000,
+    );
+  });
+});

--- a/npm-packages/system-udfs/convex/_system/frontend/paginatedDeploymentEvents.ts
+++ b/npm-packages/system-udfs/convex/_system/frontend/paginatedDeploymentEvents.ts
@@ -65,20 +65,35 @@ export default queryPrivateSystem("ViewAuditLog")({
   },
 });
 
+const MILLIS_PER_DAY = 24 * 60 * 60 * 1000;
+
+// rounded to a whole day so pagination cursors stay valid across executions
+export function minDateForAuditLogRetention(
+  auditLogRetentionDays: number,
+  now: number,
+) {
+  return (
+    Math.floor(now / MILLIS_PER_DAY) * MILLIS_PER_DAY -
+    auditLogRetentionDays * MILLIS_PER_DAY
+  );
+}
+
 export async function clampForAuditLogRetention(
   db: DatabaseReader,
   minDate: number,
 ) {
   const backendInfo = await db.query("_backend_info").first();
-  const auditLogRetentionDays = Number(backendInfo?.auditLogRetentionDays || 0);
+  // no _backend_info row means self-hosted, which has no retention limit
+  if (backendInfo === null) {
+    return minDate;
+  }
+  const auditLogRetentionDays = Number(backendInfo.auditLogRetentionDays || 0);
   // no limit if auditLogRetentionDays is -1
   if (auditLogRetentionDays === -1) {
     return minDate;
   }
-  const minAllowable =
-    Date.now() - (auditLogRetentionDays + 1) * 24 * 60 * 60 * 1000;
-  if (minDate < minAllowable) {
-    return minAllowable;
-  }
-  return minDate;
+  return Math.max(
+    minDate,
+    minDateForAuditLogRetention(auditLogRetentionDays, Date.now()),
+  );
 }


### PR DESCRIPTION
Fixes #352

On self-hosted deployments, `/history` loops forever spamming `InvalidCursor` errors: `clampForAuditLogRetention` derives the audit log query's index range from `Date.now()`, so every execution has a different pagination fingerprint and every cursor is rejected. `usePaginatedQuery` resets to the first page, the History page immediately loads more, and the cycle repeats. Self-hosted always hits this because it has no `_backend_info` row, which clamps the window to 1 day while the page's default range is 7 days.

- Round the retention cutoff down to a whole day so cursors stay valid across executions. The cutoff is never earlier than the previous `now − (N+1) days` bound, so this never widens access.
- Treat a missing `_backend_info` row (self-hosted) as no retention limit, matching the entitlements the self-hosted dashboard already assumes.
- Stop the History page from auto-loading after repeated pagination restarts that make no progress, so a future cursor rejection degrades gracefully instead of looping.

Reproduced against the self-hosted Docker image by calling `_system/frontend/paginatedDeploymentEvents` directly: with the default 7-day range, reusing page 1's cursor fails with `InvalidCursor`; with a range inside the retention window the same flow succeeds. Added unit tests pinning the cutoff's stability within a day; the stability test fails against the old implementation.
