### PR TITLE
Upgrade runtime libc packages for CVE-2026-5450

### DIFF
--- a/self-hosted/docker-build/Dockerfile.backend
+++ b/self-hosted/docker-build/Dockerfile.backend
@@ -114,7 +114,9 @@ WORKDIR /convex
 
 # Install libraries needed for running the backend
 RUN --mount=type=cache,target=/var/cache/apt --mount=type=cache,target=/var/lib/apt,sharing=locked <<EOF
+set -e
 apt-get update
+apt-get install -y --no-install-recommends --only-upgrade libc6 libc-bin
 apt-get install -y --no-install-recommends libclang1 curl ca-certificates
 EOF
 


### PR DESCRIPTION
## Note

closing, AI went rogue and created the PR without checking


## Summary

Updates Ubuntu Noble runtime `libc6` and `libc-bin` during the backend image build to pick up the CVE-2026-5450 fix (version `2.39-0ubuntu8.8`).

`--only-upgrade` limits this step to upgrading packages already present in the Noble base image, avoiding installation of new packages while ensuring both libc packages update together.

## Validation

- `git diff --check HEAD^ HEAD`
- `docker buildx build --check --file self-hosted/docker-build/Dockerfile.backend .`

No runtime or full image build testing was performed.