### PR TITLE
Expose mutation commit timestamps in Convex clients

### DIFF
--- a/npm-packages/convex/src/browser/index.ts
+++ b/npm-packages/convex/src/browser/index.ts
@@ -20,11 +20,12 @@ export { BaseConvexClient } from "./sync/client.js";
 export type {
   BaseConvexClientOptions,
   MutationOptions,
+  MutationOptionsWithCommitTimestamp,
+  MutationResult,
   SubscribeOptions,
   ConnectionState,
   AuthTokenFetcher,
 } from "./sync/client.js";
-/** @internal */
 export type { BaseConvexClientInterface } from "./sync/client.js";
 export type { PaginationStatus } from "./sync/pagination.js";
 export type { ConvexClientOptions } from "./simple_client.js";

--- a/npm-packages/convex/src/browser/simple_client.ts
+++ b/npm-packages/convex/src/browser/simple_client.ts
@@ -12,6 +12,8 @@ import {
   BaseConvexClientOptions,
   ConnectionState,
   MutationOptions,
+  MutationOptionsWithCommitTimestamp,
+  MutationResult,
 } from "./sync/client.js";
 import {
   ExtendedTransition,
@@ -487,13 +489,30 @@ export class ConvexClient {
    * @param options - A {@link MutationOptions} options object for the mutation.
    * @returns A promise of the mutation's result.
    */
-  async mutation<Mutation extends FunctionReference<"mutation">>(
+  mutation<Mutation extends FunctionReference<"mutation">>(
+    mutation: Mutation,
+    args: FunctionArgs<Mutation>,
+    options: MutationOptionsWithCommitTimestamp,
+  ): Promise<MutationResult<Awaited<FunctionReturnType<Mutation>>>>;
+  mutation<Mutation extends FunctionReference<"mutation">>(
     mutation: Mutation,
     args: FunctionArgs<Mutation>,
     options?: MutationOptions,
-  ): Promise<Awaited<FunctionReturnType<Mutation>>> {
+  ): Promise<Awaited<FunctionReturnType<Mutation>>>;
+  async mutation<Mutation extends FunctionReference<"mutation">>(
+    mutation: Mutation,
+    args: FunctionArgs<Mutation>,
+    options?: MutationOptions | MutationOptionsWithCommitTimestamp,
+  ): Promise<
+    | Awaited<FunctionReturnType<Mutation>>
+    | MutationResult<Awaited<FunctionReturnType<Mutation>>>
+  > {
     if (this.disabled) throw new Error("ConvexClient is disabled");
-    return await this.client.mutation(getFunctionName(mutation), args, options);
+    const name = getFunctionName(mutation);
+    if (options?.returnCommitTimestamp === true) {
+      return await this.client.mutation(name, args, options);
+    }
+    return await this.client.mutation(name, args, options);
   }
 
   /**

--- a/npm-packages/convex/src/browser/sync/client.ts
+++ b/npm-packages/convex/src/browser/sync/client.ts
@@ -224,7 +224,35 @@ export interface MutationOptions {
    * Once the mutation completes, the update will be rolled back.
    */
   optimisticUpdate?: OptimisticUpdate<any> | undefined;
+
+  /**
+   * Return the mutation's commit timestamp along with its value.
+   *
+   * The timestamp can be compared with {@link Transition.timestamp} to
+   * determine whether a transition includes this mutation's writes.
+   */
+  returnCommitTimestamp?: false | undefined;
 }
+
+/**
+ * Options for returning a mutation's commit timestamp.
+ *
+ * @public
+ */
+export interface MutationOptionsWithCommitTimestamp
+  extends Omit<MutationOptions, "returnCommitTimestamp"> {
+  returnCommitTimestamp: true;
+}
+
+/**
+ * A mutation's return value and the timestamp at which it committed.
+ *
+ * @public
+ */
+export type MutationResult<Value> = {
+  value: Value;
+  ts: TS;
+};
 
 /**
  * Type describing updates to a query within a `Transition`.
@@ -873,12 +901,26 @@ export class BaseConvexClient {
 
    * @returns - A promise of the mutation's result.
    */
-  async mutation(
+  mutation(
+    name: string,
+    args: Record<string, Value> | undefined,
+    options: MutationOptionsWithCommitTimestamp,
+  ): Promise<MutationResult<any>>;
+  mutation(
     name: string,
     args?: Record<string, Value>,
     options?: MutationOptions,
+  ): Promise<any>;
+  async mutation(
+    name: string,
+    args?: Record<string, Value>,
+    options?: MutationOptions | MutationOptionsWithCommitTimestamp,
   ): Promise<any> {
-    const result = await this.mutationInternal(name, args, options);
+    const { result, commitTimestamp } = await this.mutationInternal(
+      name,
+      args,
+      options,
+    );
     if (!result.success) {
       if (result.errorData !== undefined) {
         throw forwardData(
@@ -890,6 +932,12 @@ export class BaseConvexClient {
       }
       throw new Error(createHybridErrorStacktrace("mutation", name, result));
     }
+    if (options?.returnCommitTimestamp === true) {
+      if (commitTimestamp === undefined) {
+        throw new Error("Mutation succeeded without a commit timestamp");
+      }
+      return { value: result.value, ts: commitTimestamp };
+    }
     return result.value;
   }
 
@@ -899,9 +947,9 @@ export class BaseConvexClient {
   async mutationInternal(
     udfPath: string,
     args?: Record<string, Value>,
-    options?: MutationOptions,
+    options?: MutationOptions | MutationOptionsWithCommitTimestamp,
     componentPath?: string,
-  ): Promise<FunctionResult> {
+  ) {
     const { mutationPromise } = this.enqueueMutation(
       udfPath,
       args,
@@ -917,9 +965,9 @@ export class BaseConvexClient {
   enqueueMutation(
     udfPath: string,
     args?: Record<string, Value>,
-    options?: MutationOptions,
+    options?: MutationOptions | MutationOptionsWithCommitTimestamp,
     componentPath?: string,
-  ): { requestId: RequestId; mutationPromise: Promise<FunctionResult> } {
+  ) {
     const mutationArgs = parseArgs(args);
     this.tryReportLongDisconnect();
     const requestId = this.nextRequestId;
@@ -1030,7 +1078,8 @@ export class BaseConvexClient {
     };
 
     const mightBeSent = this.webSocketManager.sendMessage(message);
-    return this.requestManager.request(message, mightBeSent);
+    const { result } = await this.requestManager.request(message, mightBeSent);
+    return result;
   }
 
   /**
@@ -1130,7 +1179,7 @@ export class BaseConvexClient {
 /**
  * The public API of {@link BaseConvexClient}.
  *
- * @internal
+ * @public
  */
 export interface BaseConvexClientInterface {
   addOnTransitionHandler(fn: (transition: Transition) => void): () => void;
@@ -1176,6 +1225,12 @@ export interface BaseConvexClientInterface {
   subscribeToConnectionState(
     cb: (connectionState: ConnectionState) => void,
   ): () => void;
+
+  mutation(
+    name: string,
+    args: Record<string, Value> | undefined,
+    options: MutationOptionsWithCommitTimestamp,
+  ): Promise<MutationResult<any>>;
 
   mutation(
     name: string,

--- a/npm-packages/convex/src/browser/sync/client.ts
+++ b/npm-packages/convex/src/browser/sync/client.ts
@@ -18,7 +18,7 @@ import {
   Logger,
 } from "../logging.js";
 import { LocalSyncState } from "./local_state.js";
-import { RequestManager } from "./request_manager.js";
+import { RequestManager, type RequestResult } from "./request_manager.js";
 import {
   OptimisticLocalStore,
   OptimisticUpdate,
@@ -916,11 +916,8 @@ export class BaseConvexClient {
     args?: Record<string, Value>,
     options?: MutationOptions | MutationOptionsWithCommitTimestamp,
   ): Promise<any> {
-    const { result, commitTimestamp } = await this.mutationInternal(
-      name,
-      args,
-      options,
-    );
+    const { mutationResultPromise } = this.enqueueMutation(name, args, options);
+    const { result, commitTimestamp } = await mutationResultPromise;
     if (!result.success) {
       if (result.errorData !== undefined) {
         throw forwardData(
@@ -949,7 +946,7 @@ export class BaseConvexClient {
     args?: Record<string, Value>,
     options?: MutationOptions | MutationOptionsWithCommitTimestamp,
     componentPath?: string,
-  ) {
+  ): Promise<FunctionResult> {
     const { mutationPromise } = this.enqueueMutation(
       udfPath,
       args,
@@ -967,7 +964,11 @@ export class BaseConvexClient {
     args?: Record<string, Value>,
     options?: MutationOptions | MutationOptionsWithCommitTimestamp,
     componentPath?: string,
-  ) {
+  ): {
+    requestId: RequestId;
+    mutationPromise: Promise<FunctionResult>;
+    mutationResultPromise: Promise<RequestResult>;
+  } {
     const mutationArgs = parseArgs(args);
     this.tryReportLongDisconnect();
     const requestId = this.nextRequestId;
@@ -1027,10 +1028,15 @@ export class BaseConvexClient {
       args: [convexToJson(mutationArgs)],
     };
     const mightBeSent = this.webSocketManager.sendMessage(message);
-    const mutationPromise = this.requestManager.request(message, mightBeSent);
+    const mutationResultPromise = this.requestManager.request(
+      message,
+      mightBeSent,
+    );
+    const mutationPromise = mutationResultPromise.then(({ result }) => result);
     return {
       requestId,
       mutationPromise,
+      mutationResultPromise,
     };
   }
 

--- a/npm-packages/convex/src/browser/sync/client.ts
+++ b/npm-packages/convex/src/browser/sync/client.ts
@@ -228,8 +228,8 @@ export interface MutationOptions {
   /**
    * Return the mutation's commit timestamp along with its value.
    *
-   * The timestamp can be compared with {@link Transition.timestamp} to
-   * determine whether a transition includes this mutation's writes.
+   * Use `result.ts.lessThanOrEqual(transition.timestamp)` to determine whether
+   * a {@link Transition} includes this mutation's writes.
    */
   returnCommitTimestamp?: false | undefined;
 }
@@ -251,6 +251,12 @@ export interface MutationOptionsWithCommitTimestamp
  */
 export type MutationResult<Value> = {
   value: Value;
+  /**
+   * The mutation's commit timestamp.
+   *
+   * Use `ts.lessThanOrEqual(transition.timestamp)` to determine whether a
+   * {@link Transition} includes this mutation's writes.
+   */
   ts: TS;
 };
 
@@ -579,7 +585,13 @@ export class BaseConvexClient {
     }
   }
 
-  getMaxObservedTimestamp() {
+  /**
+   * Get the latest timestamp observed by this client.
+   *
+   * @returns The latest observed timestamp, or `undefined` before the first
+   * server message carrying a timestamp.
+   */
+  getMaxObservedTimestamp(): TS | undefined {
     return this.maxObservedTimestamp;
   }
 
@@ -1189,6 +1201,14 @@ export class BaseConvexClient {
  */
 export interface BaseConvexClientInterface {
   addOnTransitionHandler(fn: (transition: Transition) => void): () => void;
+
+  /**
+   * Get the latest timestamp observed by this client.
+   *
+   * @returns The latest observed timestamp, or `undefined` before the first
+   * server message carrying a timestamp.
+   */
+  getMaxObservedTimestamp(): TS | undefined;
 
   setAuth(
     fetchToken: AuthTokenFetcher,

--- a/npm-packages/convex/src/browser/sync/request_manager.ts
+++ b/npm-packages/convex/src/browser/sync/request_manager.ts
@@ -9,12 +9,18 @@ import {
   MutationRequest,
   MutationResponse,
   RequestId,
+  TS,
 } from "./protocol.js";
+
+export type RequestResult = {
+  result: FunctionResult;
+  commitTimestamp?: TS;
+};
 
 type RequestStatus =
   | {
       status: "Requested" | "NotSent";
-      onResult: (result: FunctionResult) => void;
+      onResult: (result: RequestResult) => void;
       requestedAt: Date;
     }
   | {
@@ -46,8 +52,8 @@ export class RequestManager {
   request(
     message: MutationRequest | ActionRequest,
     sent: boolean,
-  ): Promise<FunctionResult> {
-    const result = new Promise<FunctionResult>((resolve) => {
+  ): Promise<RequestResult> {
+    const result = new Promise<RequestResult>((resolve) => {
       const status = sent ? "Requested" : "NotSent";
       this.inflightRequests.set(message.requestId, {
         message,
@@ -119,7 +125,13 @@ export class RequestManager {
         logLines: response.logLines,
         value: jsonToConvex(response.result),
       };
-      onResolve = () => status.onResult(result);
+      onResolve = () =>
+        status.onResult({
+          result,
+          ...(response.type === "MutationResponse"
+            ? { commitTimestamp: response.ts }
+            : {}),
+        });
     } else {
       const errorMessage = response.result as string;
       const { errorData } = response;
@@ -131,7 +143,7 @@ export class RequestManager {
           errorData !== undefined ? jsonToConvex(errorData) : undefined,
         logLines: response.logLines,
       };
-      onResolve = () => status.onResult(result);
+      onResolve = () => status.onResult({ result });
     }
 
     // We can resolve Mutation failures immediately since they don't have any
@@ -219,9 +231,11 @@ export class RequestManager {
           throw new Error("Action should never be in 'Completed' state");
         }
         value.status.onResult({
-          success: false,
-          errorMessage: "Connection lost while action was in flight",
-          logLines: [],
+          result: {
+            success: false,
+            errorMessage: "Connection lost while action was in flight",
+            logLines: [],
+          },
         });
       }
     }

--- a/npm-packages/convex/src/react/client.ts
+++ b/npm-packages/convex/src/react/client.ts
@@ -286,8 +286,9 @@ export interface MutationOptions<Args extends Record<string, Value>> {
   /**
    * Return the mutation's commit timestamp along with its value.
    *
-   * The timestamp can be compared with transition timestamps from
-   * {@link ConvexReactClient.sync}.
+   * Use `result.ts.lessThanOrEqual(transition.timestamp)` to determine whether
+   * a transition from {@link ConvexReactClient.sync} includes this mutation's
+   * writes.
    */
   returnCommitTimestamp?: false | undefined;
 }

--- a/npm-packages/convex/src/react/client.ts
+++ b/npm-packages/convex/src/react/client.ts
@@ -13,6 +13,7 @@ import {
   BaseConvexClientOptions,
   ConnectionState,
   BaseConvexClientInterface,
+  MutationResult,
 } from "../browser/sync/client.js";
 import type { UserIdentityAttributes } from "../browser/sync/protocol.js";
 import { RequestForQueries, useQueries } from "./use_queries.js";
@@ -281,6 +282,25 @@ export interface MutationOptions<Args extends Record<string, Value>> {
    * Once the mutation completes, the update will be rolled back.
    */
   optimisticUpdate?: OptimisticUpdate<Args> | undefined;
+
+  /**
+   * Return the mutation's commit timestamp along with its value.
+   *
+   * The timestamp can be compared with transition timestamps from
+   * {@link ConvexReactClient.sync}.
+   */
+  returnCommitTimestamp?: false | undefined;
+}
+
+/**
+ * Options for returning a mutation's commit timestamp.
+ *
+ * @public
+ */
+export interface MutationOptionsWithCommitTimestamp<
+  Args extends Record<string, Value>,
+> extends Omit<MutationOptions<Args>, "returnCommitTimestamp"> {
+  returnCommitTimestamp: true;
 }
 
 /**
@@ -373,9 +393,9 @@ export class ConvexReactClient {
    * Lazily instantiate the `BaseConvexClient` so we don't create the WebSocket
    * when server-side rendering.
    *
-   * @internal
+   * @public
    */
-  get sync() {
+  get sync(): BaseConvexClientInterface {
     if (this.closed) {
       throw new Error("ConvexReactClient has already been closed.");
     }
@@ -636,13 +656,32 @@ export class ConvexReactClient {
    */
   mutation<Mutation extends FunctionReference<"mutation">>(
     mutation: Mutation,
+    args: FunctionArgs<Mutation>,
+    options: MutationOptionsWithCommitTimestamp<FunctionArgs<Mutation>>,
+  ): Promise<MutationResult<FunctionReturnType<Mutation>>>;
+  mutation<Mutation extends FunctionReference<"mutation">>(
+    mutation: Mutation,
     ...argsAndOptions: ArgsAndOptions<
       Mutation,
       MutationOptions<FunctionArgs<Mutation>>
     >
-  ): Promise<FunctionReturnType<Mutation>> {
+  ): Promise<FunctionReturnType<Mutation>>;
+  mutation<Mutation extends FunctionReference<"mutation">>(
+    mutation: Mutation,
+    ...argsAndOptions:
+      | ArgsAndOptions<Mutation, MutationOptions<FunctionArgs<Mutation>>>
+      | [
+          args: FunctionArgs<Mutation>,
+          options: MutationOptionsWithCommitTimestamp<FunctionArgs<Mutation>>,
+        ]
+  ):
+    | Promise<FunctionReturnType<Mutation>>
+    | Promise<MutationResult<FunctionReturnType<Mutation>>> {
     const [args, options] = argsAndOptions;
     const name = getFunctionName(mutation);
+    if (options?.returnCommitTimestamp === true) {
+      return this.sync.mutation(name, args, options);
+    }
     return this.sync.mutation(name, args, options);
   }
 

--- a/npm-packages/convex/src/react/index.ts
+++ b/npm-packages/convex/src/react/index.ts
@@ -75,6 +75,7 @@ export type { AuthTokenFetcher } from "../browser/sync/client.js";
 export * from "./auth_helpers.js";
 export * from "./ConvexAuthState.js";
 export * from "./hydration.js";
+export type { MutationResult } from "../browser/sync/client.js";
 /* @internal */
 export { useSubscription } from "./use_subscription.js";
 export {
@@ -83,6 +84,7 @@ export {
   type Watch,
   type WatchQueryOptions,
   type MutationOptions,
+  type MutationOptionsWithCommitTimestamp,
   type ConvexReactClientOptions,
   type OptionalRestArgsOrSkip,
   type UseQueryResult,


### PR DESCRIPTION
## Summary

- add an opt-in `returnCommitTimestamp: true` mutation option that resolves with `{ value, ts }`
- preserve the existing return value and types for every mutation call that does not opt in
- expose the option through `BaseConvexClient`, `ConvexClient`, and `ConvexReactClient`
- make `ConvexReactClient.sync` and `BaseConvexClientInterface` public, including transition handlers and `getMaxObservedTimestamp()`

The returned `ts` is the mutation commit timestamp already present on `MutationResponse`. It is preserved through the request manager and only exposed after the client has transitioned through that timestamp, retaining the existing read-your-writes guarantee. Callers can use `result.ts.lessThanOrEqual(transition.timestamp)` to prove that a materialized query result includes the mutation.

This is useful for durable local-first/state-library integrations: they can retire persisted optimistic overlays using platform timestamps instead of adding application-specific command IDs to every query and coverage payload.

Closes get-convex/convex-js#182.

## Verification

- `npm run typecheck`
- `npm run build` (all CJS/ESM runtime and declaration targets)
- `npm run test-esm`
- public TypeScript API compile test covering opted-in and unchanged mutation return types, typed `ConvexReactClient.sync`, and `getMaxObservedTimestamp()`
- protocol-level runtime test covering:
  - commit timestamp propagation
  - no mutation resolution before the read-your-writes transition
  - unchanged default mutation, internal mutation, and action-restart behavior
- dependent `local-store` and `dashboard-common` builds
- Prettier and ESLint on all changed files
