### PR TITLE
Fix SQLite persistence materializing entire ranges in index_scan and load_documents (#495)

### DIFF
--- a/crates/sqlite/src/lib.rs
+++ b/crates/sqlite/src/lib.rs
@@ -43,7 +43,6 @@ use common::{
     },
     query::Order,
     runtime::CoopStreamExt as _,
-    try_anyhow,
     types::{
         IndexId,
         PersistenceVersion,
@@ -55,10 +54,7 @@ use common::{
         TabletId,
     },
 };
-use futures::{
-    stream,
-    StreamExt,
-};
+use futures::StreamExt;
 use futures_async_stream::try_stream;
 use parking_lot::Mutex;
 use rusqlite::{
@@ -98,14 +94,99 @@ impl SqlitePersistence {
         })
     }
 
-    #[allow(clippy::needless_lifetimes)]
-    #[try_stream(ok = T, error = anyhow::Error)]
-    async fn validate_document_snapshot<T: 'static>(
+    /// Read one page of the documents log, at most `page_size` rows, resuming
+    /// strictly after `cursor` — the `(ts, table_id, id)` primary key of the
+    /// last row the previous page read, in scan order.
+    fn _load_documents_page(
         &self,
-        ts: Timestamp,
+        range: TimestampRange,
+        order: Order,
+        page_size: usize,
+        cursor: Option<&(u64, Vec<u8>, Vec<u8>)>,
+    ) -> anyhow::Result<Vec<DocumentLogEntry>> {
+        let mut params: Vec<&dyn ToSql> = vec![];
+        let cursor_bound = match cursor {
+            Some((ts, table_id, id)) => {
+                params.push(ts);
+                params.push(table_id);
+                params.push(id);
+                match order {
+                    Order::Asc => {
+                        " AND (ts > $1 OR (ts = $1 AND (table_id > $2 OR (table_id = $2 AND id > \
+                         $3))))"
+                    },
+                    Order::Desc => {
+                        " AND (ts < $1 OR (ts = $1 AND (table_id < $2 OR (table_id = $2 AND id < \
+                         $3))))"
+                    },
+                }
+            },
+            None => "",
+        };
+        let order_str = match order {
+            Order::Asc => "ASC",
+            Order::Desc => "DESC",
+        };
+        let query = format!(
+            r#"
+SELECT id, ts, table_id, json_value, deleted, prev_ts
+FROM documents
+WHERE ts >= {min} AND ts < {max}{cursor_bound}
+ORDER BY ts {order_str}, table_id {order_str}, id {order_str}
+LIMIT {page_size}
+"#,
+            min = range.min_timestamp_inclusive(),
+            max = range.max_timestamp_exclusive(),
+        );
+        let connection = &self.inner.lock().connection;
+        let mut stmt = connection.prepare(&query)?;
+        let mut page = vec![];
+        for row in stmt.query_map(&params[..], load_document_row)? {
+            let (document_id, ts, document, prev_ts) = row_to_document(row)?;
+            page.push(DocumentLogEntry {
+                ts,
+                id: document_id,
+                value: document,
+                prev_ts,
+            });
+        }
+        Ok(page)
+    }
+
+    /// Stream the documents log one page at a time. As in the Postgres
+    /// reader, the snapshot is validated against retention after each page is
+    /// read and before any of its rows are yielded: pages are read at
+    /// different times, and each read is only valid while the range's minimum
+    /// timestamp is still within retention. Unlike `_index_scan_paginated`,
+    /// nothing is filtered out — deletes are part of the log — so a short
+    /// page always means the range is exhausted.
+    #[try_stream(ok = DocumentLogEntry, error = anyhow::Error)]
+    async fn _load_documents_paginated(
+        &self,
+        range: TimestampRange,
+        order: Order,
+        page_size: usize,
         retention_validator: Arc<dyn RetentionValidator>,
     ) {
-        retention_validator.validate_document_snapshot(ts).await?;
+        let mut cursor: Option<(u64, Vec<u8>, Vec<u8>)> = None;
+        loop {
+            let page = self._load_documents_page(range, order, page_size, cursor.as_ref())?;
+            let page_len = page.len();
+            retention_validator
+                .validate_document_snapshot(range.min_timestamp_inclusive())
+                .await?;
+            for entry in page {
+                cursor = Some((
+                    u64::from(entry.ts),
+                    entry.id.table().0[..].to_vec(),
+                    entry.id.internal_id()[..].to_vec(),
+                ));
+                yield entry;
+            }
+            if page_len < page_size {
+                break;
+            }
+        }
     }
 
     /// Read one page of an index scan, at most `batch_size` keys, resuming
@@ -516,34 +597,16 @@ impl PersistenceReader for SqlitePersistence {
         &self,
         range: TimestampRange,
         order: Order,
-        _page_size: u32,
+        page_size: u32,
         retention_validator: Arc<dyn RetentionValidator>,
     ) -> DocumentStream<'_> {
-        let triples = try_anyhow!({
-            let connection = &self.inner.lock().connection;
-            let load_docs_query = load_docs(range, order);
-            let mut stmt = connection.prepare(load_docs_query.as_str())?;
-
-            let mut entries = vec![];
-            for row in stmt.query_map([], load_document_row)? {
-                let (document_id, ts, document, prev_ts) = row_to_document(row)?;
-                entries.push(Ok(DocumentLogEntry {
-                    ts,
-                    id: document_id,
-                    value: document,
-                    prev_ts,
-                }));
-            }
-            entries
-        });
-        // load_documents isn't async so we have to validate snapshot as part of the
-        // stream.
-        let validate =
-            self.validate_document_snapshot(range.min_timestamp_inclusive(), retention_validator);
-        match triples {
-            Ok(s) => validate.chain(stream::iter(s).cooperative()).boxed(),
-            Err(e) => stream::once(async { Err(e) }).boxed(),
-        }
+        // Mirror the Postgres reader: one bounded query per page instead of
+        // materializing the entire log range into memory. `page_size` comes
+        // from the caller; guard against 0, which would never terminate.
+        let page_size = page_size.max(1) as usize;
+        self._load_documents_paginated(range, order, page_size, retention_validator)
+            .cooperative()
+            .boxed()
     }
 
     async fn previous_revisions(
@@ -729,24 +792,6 @@ fn row_to_document(
     Ok((document_id, prev_ts, document, prev_prev_ts))
 }
 
-fn load_docs(range: TimestampRange, order: Order) -> String {
-    let order_str = match order {
-        Order::Asc => " ORDER BY ts ASC, table_id ASC, id ASC ",
-        Order::Desc => " ORDER BY ts DESC, table_id DESC, id DESC ",
-    };
-    format!(
-        r#"
-SELECT id, ts, table_id, json_value, deleted, prev_ts
-FROM documents
-WHERE ts >= {} AND ts < {}
-{}
-"#,
-        range.min_timestamp_inclusive(),
-        range.max_timestamp_exclusive(),
-        order_str,
-    )
-}
-
 fn load_document_row(
     row: &Row<'_>,
 ) -> rusqlite::Result<(Vec<u8>, u64, Vec<u8>, Option<String>, bool, Option<u64>)> {
@@ -825,6 +870,7 @@ mod tests {
             Persistence,
             PersistenceIndexEntry,
             PersistenceReader,
+            TimestampRange,
         },
         query::Order,
         types::{
@@ -1089,6 +1135,197 @@ mod tests {
         let fixture = make_fixture(&specs).await?;
         let out_of_range = make_interval(vec![200], Some(vec![201]));
         assert!(run_scan(&fixture, 100, &out_of_range, Order::Asc, 3)
+            .await?
+            .is_empty());
+        Ok(())
+    }
+
+    /// One row of the documents log for the `load_documents` tests:
+    /// `value: None` is a delete entry, which the log emits as-is.
+    struct LogEntrySpec {
+        ts: u64,
+        tablet_n: u8,
+        doc_n: u8,
+        value: Option<i64>,
+    }
+
+    async fn make_log_fixture(
+        specs: &[LogEntrySpec],
+    ) -> anyhow::Result<(SqlitePersistence, tempfile::TempDir)> {
+        let dir = tempfile::tempdir()?;
+        let path = dir.path().join("test.sqlite3");
+        let persistence = SqlitePersistence::new(path.to_str().unwrap())?;
+        let documents = specs
+            .iter()
+            .map(log_entry)
+            .collect::<anyhow::Result<Vec<_>>>()?;
+        persistence
+            .write(&documents, &[], ConflictStrategy::Error)
+            .await?;
+        Ok((persistence, dir))
+    }
+
+    fn log_entry(spec: &LogEntrySpec) -> anyhow::Result<DocumentLogEntry> {
+        let tablet_id = TabletId(internal_id(spec.tablet_n));
+        let table_number = TableNumber::try_from(1)?;
+        let value = spec
+            .value
+            .map(|v| make_doc(tablet_id, table_number, spec.doc_n, v))
+            .transpose()?;
+        Ok(DocumentLogEntry {
+            ts: Timestamp::try_from(spec.ts)?,
+            id: InternalDocumentId::new(tablet_id, internal_id(spec.doc_n)),
+            value,
+            prev_ts: None,
+        })
+    }
+
+    /// The reference implementation: every log row in the timestamp range,
+    /// deletes included, in `(ts, table_id, id)` scan order.
+    fn expected_log(
+        specs: &[LogEntrySpec],
+        range: &TimestampRange,
+        order: Order,
+    ) -> anyhow::Result<Vec<DocumentLogEntry>> {
+        let mut rows = vec![];
+        for spec in specs {
+            let ts = Timestamp::try_from(spec.ts)?;
+            if ts < range.min_timestamp_inclusive() || ts >= range.max_timestamp_exclusive() {
+                continue;
+            }
+            let entry = log_entry(spec)?;
+            let key = (
+                spec.ts,
+                entry.id.table().0[..].to_vec(),
+                entry.id.internal_id()[..].to_vec(),
+            );
+            rows.push((key, entry));
+        }
+        rows.sort_by(|(a, _), (b, _)| a.cmp(b));
+        if order == Order::Desc {
+            rows.reverse();
+        }
+        Ok(rows.into_iter().map(|(_, entry)| entry).collect())
+    }
+
+    async fn run_load(
+        persistence: &SqlitePersistence,
+        range: TimestampRange,
+        order: Order,
+        page_size: u32,
+    ) -> anyhow::Result<Vec<DocumentLogEntry>> {
+        persistence
+            .load_documents(range, order, page_size, Arc::new(NoopRetentionValidator))
+            .try_collect()
+            .await
+    }
+
+    /// Two tablets writing interleaved updates and deletes, with several rows
+    /// sharing the same timestamp: the compound cursor's `(table_id, id)`
+    /// tiebreak is what keeps pagination correct when a page boundary lands
+    /// in the middle of a same-`ts` run.
+    #[tokio::test]
+    async fn paginated_load_matches_reference() -> anyhow::Result<()> {
+        let mut specs = vec![];
+        for tablet_n in [1u8, 2] {
+            for doc_n in 0u8..6 {
+                specs.push(LogEntrySpec {
+                    ts: 10,
+                    tablet_n,
+                    doc_n,
+                    value: Some(1),
+                });
+                if doc_n % 2 == 0 {
+                    specs.push(LogEntrySpec {
+                        ts: 20,
+                        tablet_n,
+                        doc_n,
+                        value: Some(2),
+                    });
+                }
+                if doc_n % 3 == 0 {
+                    specs.push(LogEntrySpec {
+                        ts: 30,
+                        tablet_n,
+                        doc_n,
+                        value: None,
+                    });
+                }
+                if doc_n % 2 == 1 {
+                    specs.push(LogEntrySpec {
+                        ts: 40,
+                        tablet_n,
+                        doc_n,
+                        value: Some(3),
+                    });
+                }
+            }
+        }
+        let (persistence, _dir) = make_log_fixture(&specs).await?;
+
+        let ranges = [
+            TimestampRange::all(),
+            TimestampRange::new(Timestamp::try_from(15u64)?..Timestamp::try_from(35u64)?),
+        ];
+        for range in &ranges {
+            for order in [Order::Asc, Order::Desc] {
+                let expected = expected_log(&specs, range, order)?;
+                for page_size in [1, 2, 3, 10_000] {
+                    let got = run_load(&persistence, *range, order, page_size).await?;
+                    assert_eq!(
+                        got, expected,
+                        "load mismatch at range={range:?} order={order:?} page_size={page_size}"
+                    );
+                }
+            }
+        }
+        Ok(())
+    }
+
+    /// Ten documents written at one single timestamp: every page boundary
+    /// falls inside the same-`ts` run, so only the `(table_id, id)` tiebreak
+    /// of the cursor separates the pages.
+    #[tokio::test]
+    async fn same_ts_run_spans_pages() -> anyhow::Result<()> {
+        let specs: Vec<LogEntrySpec> = (0u8..10)
+            .map(|doc_n| LogEntrySpec {
+                ts: 17,
+                tablet_n: 1,
+                doc_n,
+                value: Some(i64::from(doc_n)),
+            })
+            .collect();
+        let (persistence, _dir) = make_log_fixture(&specs).await?;
+
+        let range = TimestampRange::all();
+        for order in [Order::Asc, Order::Desc] {
+            let expected = expected_log(&specs, &range, order)?;
+            assert_eq!(expected.len(), 10);
+            let got = run_load(&persistence, range, order, 3).await?;
+            assert_eq!(got, expected, "same-ts run must paginate by (table_id, id)");
+        }
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn load_empty_and_out_of_range() -> anyhow::Result<()> {
+        let (empty, _dir) = make_log_fixture(&[]).await?;
+        assert!(run_load(&empty, TimestampRange::all(), Order::Asc, 2)
+            .await?
+            .is_empty());
+
+        let specs: Vec<LogEntrySpec> = (0u8..5)
+            .map(|doc_n| LogEntrySpec {
+                ts: 10,
+                tablet_n: 1,
+                doc_n,
+                value: Some(1),
+            })
+            .collect();
+        let (persistence, _dir) = make_log_fixture(&specs).await?;
+        let out_of_range =
+            TimestampRange::new(Timestamp::try_from(100u64)?..Timestamp::try_from(200u64)?);
+        assert!(run_load(&persistence, out_of_range, Order::Asc, 2)
             .await?
             .is_empty());
         Ok(())

--- a/crates/sqlite/src/lib.rs
+++ b/crates/sqlite/src/lib.rs
@@ -100,16 +100,6 @@ impl SqlitePersistence {
 
     #[allow(clippy::needless_lifetimes)]
     #[try_stream(ok = T, error = anyhow::Error)]
-    async fn validate_snapshot<T: 'static>(
-        &self,
-        ts: Timestamp,
-        retention_validator: Arc<dyn RetentionValidator>,
-    ) {
-        retention_validator.validate_snapshot(ts).await?;
-    }
-
-    #[allow(clippy::needless_lifetimes)]
-    #[try_stream(ok = T, error = anyhow::Error)]
     async fn validate_document_snapshot<T: 'static>(
         &self,
         ts: Timestamp,
@@ -118,14 +108,20 @@ impl SqlitePersistence {
         retention_validator.validate_document_snapshot(ts).await?;
     }
 
-    fn _index_scan_inner(
+    /// Read one page of an index scan, at most `batch_size` keys, resuming
+    /// after `cursor` (the last key the previous page scanned, in scan
+    /// order). Tombstoned keys are returned as `(key, None)`: they must
+    /// still advance the cursor, but must not be emitted to the caller.
+    fn _index_scan_page(
         &self,
         index_id: IndexId,
         tablet_id: TabletId,
         read_timestamp: Timestamp,
         interval: &Interval,
         order: Order,
-    ) -> anyhow::Result<Vec<anyhow::Result<(IndexKeyBytes, LatestDocument)>>> {
+        batch_size: usize,
+        cursor: Option<&IndexKeyBytes>,
+    ) -> anyhow::Result<Vec<(IndexKeyBytes, Option<LatestDocument>)>> {
         let interval = interval.clone();
         let index_id = &index_id.0[..];
         let read_timestamp: u64 = read_timestamp.into();
@@ -150,22 +146,42 @@ impl SqlitePersistence {
             None => "".to_owned(),
         };
 
+        let cursor_bytes = cursor.map(|key| &key.0[..]);
+        let cursor_bound = match cursor_bytes {
+            Some(ref t) => {
+                params.push(t);
+                match order {
+                    Order::Asc => format!(" AND key > ${}", params.len()),
+                    Order::Desc => format!(" AND key < ${}", params.len()),
+                }
+            },
+            None => "".to_owned(),
+        };
+
         let order = match order {
             Order::Asc => "ASC",
             Order::Desc => "DESC",
         };
+        // The inner subquery is bounded by `LIMIT`: `GROUP BY` over a prefix
+        // of the `(index_id, key, ts)` primary key streams groups in key
+        // order, so SQLite stops scanning after `batch_size` keys instead of
+        // materializing the entire interval. `B.deleted` is selected (not
+        // filtered in the join) so that tombstoned keys count toward the
+        // page: otherwise a page full of tombstones would be
+        // indistinguishable from the end of the interval.
         let query = format!(
             r#"
-SELECT B.key, B.ts, B.document_id, C.table_id, C.json_value, C.prev_ts
+SELECT B.key, B.ts, B.document_id, C.table_id, C.json_value, C.prev_ts, B.deleted
 FROM (
     SELECT index_id, key, MAX(ts) as max_ts
     FROM indexes
-    WHERE index_id = $1 AND ts <= $2{lower}{upper}
+    WHERE index_id = $1 AND ts <= $2{lower}{upper}{cursor_bound}
     GROUP BY index_id, key
+    ORDER BY key {order}
+    LIMIT {batch_size}
 ) A
 JOIN indexes B
-ON B.deleted is FALSE
-AND A.index_id = B.index_id
+ON A.index_id = B.index_id
 AND A.key = B.key
 AND A.max_ts = B.ts
 LEFT JOIN documents C
@@ -181,22 +197,30 @@ ORDER BY B.key {order}
         let row_iter = stmt.query_map(&params[..], |row| {
             let key = IndexKeyBytes(row.get::<_, Vec<u8>>(0)?);
             let ts = Timestamp::try_from(row.get::<_, u64>(1)?).expect("timestamp out of bounds");
-            let document_id = row.get::<_, Vec<u8>>(2)?;
+            let document_id: Option<Vec<u8>> = row.get(2)?;
             let table: Option<Vec<u8>> = row.get(3)?;
             let json_value: Option<String> = row.get(4)?;
             let prev_ts: Option<Timestamp> = row
                 .get::<_, Option<u64>>(5)?
                 .map(|ts| Timestamp::try_from(ts).expect("prev_ts out of bounds"));
+            let deleted = row.get::<_, u32>(6)? != 0;
 
-            Ok((key, ts, document_id, table, json_value, prev_ts))
+            Ok((key, ts, document_id, table, json_value, prev_ts, deleted))
         })?;
-        let mut triples = vec![];
+        let mut page = vec![];
         for row in row_iter {
-            let (key, ts, document_id, table, json_value, prev_ts) = row?;
+            let (key, ts, document_id, table, json_value, prev_ts, deleted) = row?;
+            if deleted {
+                page.push((key, None));
+                continue;
+            }
             let table = table.ok_or_else(|| {
                 anyhow::anyhow!("Dangling index reference for {:?} {:?}", key, ts)
             })?;
             let table = TabletId(table.try_into()?);
+            let document_id = document_id.ok_or_else(|| {
+                anyhow::anyhow!("Dangling index reference for {:?} {:?}", key, ts)
+            })?;
             let _document_id = InternalDocumentId::new(table, InternalId::try_from(document_id)?);
             let json_value = json_value.ok_or_else(|| {
                 anyhow::anyhow!("Index reference to deleted document {:?} {:?}", key, ts)
@@ -204,16 +228,59 @@ ORDER BY B.key {order}
             let json_value: serde_json::Value = serde_json::from_str(&json_value)?;
             let value: ConvexValue = json_value.try_into()?;
             let document = ResolvedDocument::from_database(tablet_id, value)?;
-            triples.push(Ok((
+            page.push((
                 key,
-                LatestDocument {
+                Some(LatestDocument {
                     ts,
                     value: document,
                     prev_ts,
-                },
-            )));
+                }),
+            ));
         }
-        Ok(triples)
+        Ok(page)
+    }
+
+    /// Stream an index scan one page at a time. The snapshot is validated
+    /// against retention after each page is read and before any of its rows
+    /// are yielded, mirroring the Postgres reader: pages are read at
+    /// different times, and each read is only valid if the snapshot is still
+    /// within retention.
+    #[try_stream(ok = (IndexKeyBytes, LatestDocument), error = anyhow::Error)]
+    async fn _index_scan_paginated(
+        &self,
+        index_id: IndexId,
+        tablet_id: TabletId,
+        read_timestamp: Timestamp,
+        interval: Interval,
+        order: Order,
+        batch_size: usize,
+        retention_validator: Arc<dyn RetentionValidator>,
+    ) {
+        let mut cursor: Option<IndexKeyBytes> = None;
+        loop {
+            let page = self._index_scan_page(
+                index_id,
+                tablet_id,
+                read_timestamp,
+                &interval,
+                order,
+                batch_size,
+                cursor.as_ref(),
+            )?;
+            let page_len = page.len();
+            retention_validator
+                .validate_snapshot(read_timestamp)
+                .await?;
+            for (key, doc) in page {
+                cursor = Some(key.clone());
+                if let Some(doc) = doc {
+                    yield (key, doc);
+                }
+            }
+            if page_len < batch_size {
+                break;
+            }
+        }
     }
 
     fn _get_persistence_global(
@@ -563,16 +630,23 @@ impl PersistenceReader for SqlitePersistence {
         read_timestamp: Timestamp,
         interval: &Interval,
         order: Order,
-        _size_hint: usize,
+        size_hint: usize,
         retention_validator: Arc<dyn RetentionValidator>,
     ) -> IndexStream<'_> {
-        let triples = self._index_scan_inner(index_id, tablet_id, read_timestamp, interval, order);
-        // index_scan isn't async so we have to validate snapshot as part of the stream.
-        let validate = self.validate_snapshot(read_timestamp, retention_validator);
-        match triples {
-            Ok(s) => (validate.chain(stream::iter(s))).boxed(),
-            Err(e) => stream::once(async { Err(e) }).boxed(),
-        }
+        // Mirror the Postgres reader: use the caller's size_hint to bound how
+        // much of the interval each query materializes, so a small take()
+        // over a large table no longer loads the entire range into memory.
+        let batch_size = size_hint.clamp(1, 5000);
+        self._index_scan_paginated(
+            index_id,
+            tablet_id,
+            read_timestamp,
+            interval.clone(),
+            order,
+            batch_size,
+            retention_validator,
+        )
+        .boxed()
     }
 
     async fn get_persistence_global(
@@ -725,3 +799,298 @@ WHERE
     ts = $3
 ORDER BY ts ASC, table_id ASC, id ASC
 "#;
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use common::{
+        document::{
+            CreationTime,
+            ResolvedDocument,
+        },
+        index::IndexKeyBytes,
+        interval::{
+            BinaryKey,
+            End,
+            Interval,
+            StartIncluded,
+        },
+        obj,
+        persistence::{
+            ConflictStrategy,
+            DocumentLogEntry,
+            LatestDocument,
+            NoopRetentionValidator,
+            Persistence,
+            PersistenceIndexEntry,
+            PersistenceReader,
+        },
+        query::Order,
+        types::{
+            IndexId,
+            Timestamp,
+        },
+        value::{
+            DeveloperDocumentId,
+            InternalDocumentId,
+            InternalId,
+            ResolvedDocumentId,
+            TableNumber,
+            TabletId,
+        },
+    };
+    use futures::TryStreamExt;
+
+    use super::SqlitePersistence;
+
+    /// One indexed key and its history: `(ts, Some(v))` is a live write of
+    /// value `v`, `(ts, None)` is a tombstone.
+    struct KeySpec {
+        key: Vec<u8>,
+        doc_n: u8,
+        versions: Vec<(u64, Option<i64>)>,
+    }
+
+    struct Fixture {
+        persistence: SqlitePersistence,
+        index_id: IndexId,
+        tablet_id: TabletId,
+        table_number: TableNumber,
+        // Kept alive so the database file outlives the test body.
+        _dir: tempfile::TempDir,
+    }
+
+    fn internal_id(n: u8) -> InternalId {
+        InternalId::from([n; 16])
+    }
+
+    fn make_doc(
+        tablet_id: TabletId,
+        table_number: TableNumber,
+        doc_n: u8,
+        v: i64,
+    ) -> anyhow::Result<ResolvedDocument> {
+        let id = ResolvedDocumentId::new(
+            tablet_id,
+            DeveloperDocumentId::new(table_number, internal_id(doc_n)),
+        );
+        ResolvedDocument::new(id, CreationTime::try_from(1234.5)?, obj!("v" => v)?)
+    }
+
+    async fn make_fixture(specs: &[KeySpec]) -> anyhow::Result<Fixture> {
+        let dir = tempfile::tempdir()?;
+        let path = dir.path().join("test.sqlite3");
+        let persistence = SqlitePersistence::new(path.to_str().unwrap())?;
+        let index_id = IndexId(internal_id(255));
+        let tablet_id = TabletId(internal_id(254));
+        let table_number = TableNumber::try_from(1)?;
+
+        let mut documents = vec![];
+        let mut indexes = vec![];
+        for spec in specs {
+            let doc_id = InternalDocumentId::new(tablet_id, internal_id(spec.doc_n));
+            for &(ts, v) in &spec.versions {
+                let ts = Timestamp::try_from(ts)?;
+                let value = v
+                    .map(|v| make_doc(tablet_id, table_number, spec.doc_n, v))
+                    .transpose()?;
+                documents.push(DocumentLogEntry {
+                    ts,
+                    id: doc_id,
+                    value,
+                    prev_ts: None,
+                });
+                indexes.push(PersistenceIndexEntry {
+                    ts,
+                    index_id,
+                    key: IndexKeyBytes(spec.key.clone()),
+                    value: v.map(|_| doc_id),
+                });
+            }
+        }
+        persistence
+            .write(&documents, &indexes, ConflictStrategy::Error)
+            .await?;
+        Ok(Fixture {
+            persistence,
+            index_id,
+            tablet_id,
+            table_number,
+            _dir: dir,
+        })
+    }
+
+    fn make_interval(start: Vec<u8>, end: Option<Vec<u8>>) -> Interval {
+        Interval {
+            start: StartIncluded(BinaryKey::from(start)),
+            end: match end {
+                Some(end) => End::Excluded(BinaryKey::from(end)),
+                None => End::Unbounded,
+            },
+        }
+    }
+
+    /// The reference implementation: latest visible version per key at
+    /// `read_ts`, tombstones dropped, interval applied, in scan order.
+    fn expected_scan(
+        fixture: &Fixture,
+        specs: &[KeySpec],
+        read_ts: u64,
+        interval: &Interval,
+        order: Order,
+    ) -> anyhow::Result<Vec<(IndexKeyBytes, LatestDocument)>> {
+        let mut rows = vec![];
+        for spec in specs {
+            if !interval.contains(&spec.key) {
+                continue;
+            }
+            let visible = spec
+                .versions
+                .iter()
+                .filter(|(ts, _)| *ts <= read_ts)
+                .max_by_key(|(ts, _)| *ts);
+            let Some(&(ts, Some(v))) = visible else {
+                continue;
+            };
+            rows.push((
+                IndexKeyBytes(spec.key.clone()),
+                LatestDocument {
+                    ts: Timestamp::try_from(ts)?,
+                    value: make_doc(fixture.tablet_id, fixture.table_number, spec.doc_n, v)?,
+                    prev_ts: None,
+                },
+            ));
+        }
+        rows.sort_by(|(a, _), (b, _)| a.cmp(b));
+        if order == Order::Desc {
+            rows.reverse();
+        }
+        Ok(rows)
+    }
+
+    async fn run_scan(
+        fixture: &Fixture,
+        read_ts: u64,
+        interval: &Interval,
+        order: Order,
+        size_hint: usize,
+    ) -> anyhow::Result<Vec<(IndexKeyBytes, LatestDocument)>> {
+        fixture
+            .persistence
+            .index_scan(
+                fixture.index_id,
+                fixture.tablet_id,
+                Timestamp::try_from(read_ts)?,
+                interval,
+                order,
+                size_hint,
+                Arc::new(NoopRetentionValidator),
+            )
+            .try_collect()
+            .await
+    }
+
+    /// 25 keys with updates, tombstones on page boundaries, and writes past
+    /// the read snapshot, scanned under every pagination regime: the
+    /// paginated scan must be indistinguishable from the one-shot scan it
+    /// replaced.
+    #[tokio::test]
+    async fn paginated_scan_matches_reference() -> anyhow::Result<()> {
+        let specs: Vec<KeySpec> = (0u8..25)
+            .map(|k| {
+                let mut versions = vec![(10, Some(1))];
+                if k % 3 == 0 {
+                    versions.push((20, Some(2)));
+                }
+                if k % 5 == 0 {
+                    versions.push((30, None));
+                }
+                if k % 2 == 0 {
+                    versions.push((40, Some(3)));
+                }
+                KeySpec {
+                    key: vec![k],
+                    doc_n: k,
+                    versions,
+                }
+            })
+            .collect();
+        let fixture = make_fixture(&specs).await?;
+
+        let intervals = [
+            make_interval(vec![], None),
+            make_interval(vec![3], Some(vec![20])),
+        ];
+        // At ts 35 the tombstones (ts 30) are the latest visible versions;
+        // at ts 45 the ts-40 writes resurrect the even keys among them.
+        for read_ts in [35, 45] {
+            for interval in &intervals {
+                for order in [Order::Asc, Order::Desc] {
+                    let expected = expected_scan(&fixture, &specs, read_ts, interval, order)?;
+                    for size_hint in [1, 2, 3, 10_000] {
+                        let got = run_scan(&fixture, read_ts, interval, order, size_hint).await?;
+                        assert_eq!(
+                            got, expected,
+                            "scan mismatch at read_ts={read_ts} order={order:?} \
+                             size_hint={size_hint}"
+                        );
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+
+    /// Ten consecutive tombstoned keys form entire pages with no live rows.
+    /// A scan that terminates on "page yielded fewer live rows than
+    /// requested" would stop in the middle of the interval and silently drop
+    /// every key after the tombstone run.
+    #[tokio::test]
+    async fn page_of_tombstones_does_not_terminate_scan() -> anyhow::Result<()> {
+        let specs: Vec<KeySpec> = (0u8..30)
+            .map(|k| {
+                let mut versions = vec![(10, Some(1))];
+                if (10..20).contains(&k) {
+                    versions.push((20, None));
+                }
+                KeySpec {
+                    key: vec![k],
+                    doc_n: k,
+                    versions,
+                }
+            })
+            .collect();
+        let fixture = make_fixture(&specs).await?;
+
+        let interval = make_interval(vec![], None);
+        for order in [Order::Asc, Order::Desc] {
+            let expected = expected_scan(&fixture, &specs, 25, &interval, order)?;
+            assert_eq!(expected.len(), 20);
+            let got = run_scan(&fixture, 25, &interval, order, 5).await?;
+            assert_eq!(got, expected, "tombstone run must not end the scan early");
+        }
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn empty_table_and_empty_range() -> anyhow::Result<()> {
+        let empty = make_fixture(&[]).await?;
+        let all = make_interval(vec![], None);
+        assert!(run_scan(&empty, 100, &all, Order::Asc, 3).await?.is_empty());
+
+        let specs: Vec<KeySpec> = (0u8..5)
+            .map(|k| KeySpec {
+                key: vec![k],
+                doc_n: k,
+                versions: vec![(10, Some(1))],
+            })
+            .collect();
+        let fixture = make_fixture(&specs).await?;
+        let out_of_range = make_interval(vec![200], Some(vec![201]));
+        assert!(run_scan(&fixture, 100, &out_of_range, Order::Asc, 3)
+            .await?
+            .is_empty());
+        Ok(())
+    }
+}

--- a/crates/sqlite/src/lib.rs
+++ b/crates/sqlite/src/lib.rs
@@ -43,7 +43,6 @@ use common::{
     },
     query::Order,
     runtime::CoopStreamExt as _,
-    try_anyhow,
     types::{
         IndexId,
         PersistenceVersion,
@@ -55,10 +54,7 @@ use common::{
         TabletId,
     },
 };
-use futures::{
-    stream,
-    StreamExt,
-};
+use futures::StreamExt;
 use futures_async_stream::try_stream;
 use parking_lot::Mutex;
 use rusqlite::{
@@ -98,14 +94,120 @@ impl SqlitePersistence {
         })
     }
 
-    #[allow(clippy::needless_lifetimes)]
-    #[try_stream(ok = T, error = anyhow::Error)]
-    async fn validate_document_snapshot<T: 'static>(
+    /// Read one page of the documents log, at most `page_size` rows, resuming
+    /// strictly after `cursor` — the `(ts, table_id, id)` primary key of the
+    /// last row the previous page read, in scan order.
+    fn _load_documents_page(
         &self,
-        ts: Timestamp,
+        tablet_id: Option<TabletId>,
+        range: TimestampRange,
+        order: Order,
+        page_size: usize,
+        cursor: Option<&(u64, Vec<u8>, Vec<u8>)>,
+    ) -> anyhow::Result<Vec<DocumentLogEntry>> {
+        // Outlives `params`, which borrows from it.
+        let tablet_id_bytes = tablet_id.map(|tablet_id| tablet_id.0);
+        let tablet_id_slice = tablet_id_bytes.as_ref().map(|bytes| &bytes[..]);
+        let mut params: Vec<&dyn ToSql> = vec![];
+        // Placeholder numbers are derived from `params` as each one is bound,
+        // so adding a parameter can never silently renumber the ones after it.
+        let tablet_bound = match tablet_id_slice {
+            Some(ref tablet_id) => {
+                params.push(tablet_id);
+                format!(" AND table_id = ${}", params.len())
+            },
+            None => String::new(),
+        };
+        let cursor_bound = match cursor {
+            // `table_id` here is the middle component of the primary key, used
+            // to break ties within a timestamp. It is unrelated to
+            // `tablet_bound` above, which restricts the rows considered at all.
+            Some((ts, table_id, id)) => {
+                let cmp = match order {
+                    Order::Asc => ">",
+                    Order::Desc => "<",
+                };
+                params.push(ts);
+                let ts_param = params.len();
+                params.push(table_id);
+                let table_param = params.len();
+                params.push(id);
+                let id_param = params.len();
+                format!(
+                    " AND (ts {cmp} ${ts_param} OR (ts = ${ts_param} AND (table_id {cmp} \
+                     ${table_param} OR (table_id = ${table_param} AND id {cmp} ${id_param}))))"
+                )
+            },
+            None => String::new(),
+        };
+        let order_str = match order {
+            Order::Asc => "ASC",
+            Order::Desc => "DESC",
+        };
+        let query = format!(
+            r#"
+SELECT id, ts, table_id, json_value, deleted, prev_ts
+FROM documents
+WHERE ts >= {min} AND ts < {max}{tablet_bound}{cursor_bound}
+ORDER BY ts {order_str}, table_id {order_str}, id {order_str}
+LIMIT {page_size}
+"#,
+            min = range.min_timestamp_inclusive(),
+            max = range.max_timestamp_exclusive(),
+        );
+        let connection = &self.inner.lock().connection;
+        let mut stmt = connection.prepare(&query)?;
+        let mut page = vec![];
+        for row in stmt.query_map(&params[..], load_document_row)? {
+            let (document_id, ts, document, prev_ts) = row_to_document(row)?;
+            page.push(DocumentLogEntry {
+                ts,
+                id: document_id,
+                value: document,
+                prev_ts,
+            });
+        }
+        Ok(page)
+    }
+
+    /// Stream the documents log one page at a time. As in the Postgres
+    /// reader, the snapshot is validated against retention after each page is
+    /// read and before any of its rows are yielded: pages are read at
+    /// different times, and each read is only valid while the range's minimum
+    /// timestamp is still within retention. Unlike `_index_scan_paginated`,
+    /// nothing is dropped after the query runs — deletes are part of the log,
+    /// and `tablet_id` restricts the rows the query considers at all, so
+    /// `LIMIT` counts exactly the rows that get yielded — and a short page
+    /// therefore always means the range is exhausted.
+    #[try_stream(ok = DocumentLogEntry, error = anyhow::Error)]
+    async fn _load_documents_paginated(
+        &self,
+        tablet_id: Option<TabletId>,
+        range: TimestampRange,
+        order: Order,
+        page_size: usize,
         retention_validator: Arc<dyn RetentionValidator>,
     ) {
-        retention_validator.validate_document_snapshot(ts).await?;
+        let mut cursor: Option<(u64, Vec<u8>, Vec<u8>)> = None;
+        loop {
+            let page =
+                self._load_documents_page(tablet_id, range, order, page_size, cursor.as_ref())?;
+            let page_len = page.len();
+            retention_validator
+                .validate_document_snapshot(range.min_timestamp_inclusive())
+                .await?;
+            for entry in page {
+                cursor = Some((
+                    u64::from(entry.ts),
+                    entry.id.table().0[..].to_vec(),
+                    entry.id.internal_id()[..].to_vec(),
+                ));
+                yield entry;
+            }
+            if page_len < page_size {
+                break;
+            }
+        }
     }
 
     /// Read one page of an index scan, at most `batch_size` keys, resuming
@@ -513,47 +615,23 @@ impl Persistence for SqlitePersistence {
 impl SqlitePersistence {
     /// Read the document log in `range`, restricted to `tablet_id` if given.
     ///
-    /// Rows are collected eagerly, so restricting in SQL keeps the untargeted
-    /// ones out of memory entirely.
+    /// Restricting in SQL keeps the untargeted rows out of memory entirely,
+    /// and reading one bounded page per query keeps the targeted ones from
+    /// being materialized all at once.
     fn stream_document_log(
         &self,
         tablet_id: Option<TabletId>,
         range: TimestampRange,
         order: Order,
+        page_size: u32,
         retention_validator: Arc<dyn RetentionValidator>,
     ) -> DocumentStream<'_> {
-        let entries = try_anyhow!({
-            let connection = &self.inner.lock().connection;
-            let load_docs_query = load_docs(range, order, tablet_id.is_some());
-            let mut stmt = connection.prepare(load_docs_query.as_str())?;
-
-            let tablet_id_bytes = tablet_id.map(|tablet_id| tablet_id.0);
-            let tablet_id_slice = tablet_id_bytes.as_ref().map(|tablet_id| &tablet_id[..]);
-            let params: Vec<&dyn ToSql> = match tablet_id_slice {
-                Some(ref tablet_id) => vec![tablet_id],
-                None => vec![],
-            };
-
-            let mut entries = vec![];
-            for row in stmt.query_map(params.as_slice(), load_document_row)? {
-                let (document_id, ts, document, prev_ts) = row_to_document(row)?;
-                entries.push(Ok(DocumentLogEntry {
-                    ts,
-                    id: document_id,
-                    value: document,
-                    prev_ts,
-                }));
-            }
-            entries
-        });
-        // The caller isn't async so we have to validate snapshot as part of the
-        // stream.
-        let validate =
-            self.validate_document_snapshot(range.min_timestamp_inclusive(), retention_validator);
-        match entries {
-            Ok(s) => validate.chain(stream::iter(s).cooperative()).boxed(),
-            Err(e) => stream::once(async { Err(e) }).boxed(),
-        }
+        // `page_size` comes from the caller; guard against 0, which would never
+        // terminate.
+        let page_size = page_size.max(1) as usize;
+        self._load_documents_paginated(tablet_id, range, order, page_size, retention_validator)
+            .cooperative()
+            .boxed()
     }
 }
 
@@ -563,10 +641,10 @@ impl PersistenceReader for SqlitePersistence {
         &self,
         range: TimestampRange,
         order: Order,
-        _page_size: u32,
+        page_size: u32,
         retention_validator: Arc<dyn RetentionValidator>,
     ) -> DocumentStream<'_> {
-        self.stream_document_log(None, range, order, retention_validator)
+        self.stream_document_log(None, range, order, page_size, retention_validator)
     }
 
     fn load_documents_from_table(
@@ -574,10 +652,16 @@ impl PersistenceReader for SqlitePersistence {
         tablet_id: TabletId,
         range: TimestampRange,
         order: Order,
-        _page_size: u32,
+        page_size: u32,
         retention_validator: Arc<dyn RetentionValidator>,
     ) -> DocumentStream<'_> {
-        self.stream_document_log(Some(tablet_id), range, order, retention_validator)
+        self.stream_document_log(
+            Some(tablet_id),
+            range,
+            order,
+            page_size,
+            retention_validator,
+        )
     }
 
     async fn previous_revisions(
@@ -763,30 +847,6 @@ fn row_to_document(
     Ok((document_id, prev_ts, document, prev_prev_ts))
 }
 
-fn load_docs(range: TimestampRange, order: Order, tablet_filter: bool) -> String {
-    let order_str = match order {
-        Order::Asc => " ORDER BY ts ASC, table_id ASC, id ASC ",
-        Order::Desc => " ORDER BY ts DESC, table_id DESC, id DESC ",
-    };
-    format!(
-        r#"
-SELECT id, ts, table_id, json_value, deleted, prev_ts
-FROM documents
-WHERE ts >= {} AND ts < {}
-{}
-{}
-"#,
-        range.min_timestamp_inclusive(),
-        range.max_timestamp_exclusive(),
-        if tablet_filter {
-            "AND table_id = $1"
-        } else {
-            ""
-        },
-        order_str,
-    )
-}
-
 fn load_document_row(
     row: &Row<'_>,
 ) -> rusqlite::Result<(Vec<u8>, u64, Vec<u8>, Option<String>, bool, Option<u64>)> {
@@ -865,6 +925,7 @@ mod tests {
             Persistence,
             PersistenceIndexEntry,
             PersistenceReader,
+            TimestampRange,
         },
         query::Order,
         types::{
@@ -1129,6 +1190,289 @@ mod tests {
         let fixture = make_fixture(&specs).await?;
         let out_of_range = make_interval(vec![200], Some(vec![201]));
         assert!(run_scan(&fixture, 100, &out_of_range, Order::Asc, 3)
+            .await?
+            .is_empty());
+        Ok(())
+    }
+
+    /// One row of the documents log for the `load_documents` tests:
+    /// `value: None` is a delete entry, which the log emits as-is.
+    #[derive(Clone)]
+    struct LogEntrySpec {
+        ts: u64,
+        tablet_n: u8,
+        doc_n: u8,
+        value: Option<i64>,
+    }
+
+    async fn make_log_fixture(
+        specs: &[LogEntrySpec],
+    ) -> anyhow::Result<(SqlitePersistence, tempfile::TempDir)> {
+        let dir = tempfile::tempdir()?;
+        let path = dir.path().join("test.sqlite3");
+        let persistence = SqlitePersistence::new(path.to_str().unwrap())?;
+        let documents = specs
+            .iter()
+            .map(log_entry)
+            .collect::<anyhow::Result<Vec<_>>>()?;
+        persistence
+            .write(&documents, &[], ConflictStrategy::Error)
+            .await?;
+        Ok((persistence, dir))
+    }
+
+    fn log_entry(spec: &LogEntrySpec) -> anyhow::Result<DocumentLogEntry> {
+        let tablet_id = TabletId(internal_id(spec.tablet_n));
+        let table_number = TableNumber::try_from(1)?;
+        let value = spec
+            .value
+            .map(|v| make_doc(tablet_id, table_number, spec.doc_n, v))
+            .transpose()?;
+        Ok(DocumentLogEntry {
+            ts: Timestamp::try_from(spec.ts)?,
+            id: InternalDocumentId::new(tablet_id, internal_id(spec.doc_n)),
+            value,
+            prev_ts: None,
+        })
+    }
+
+    /// The reference implementation: every log row in the timestamp range,
+    /// deletes included, in `(ts, table_id, id)` scan order.
+    fn expected_log(
+        specs: &[LogEntrySpec],
+        range: &TimestampRange,
+        order: Order,
+    ) -> anyhow::Result<Vec<DocumentLogEntry>> {
+        let mut rows = vec![];
+        for spec in specs {
+            let ts = Timestamp::try_from(spec.ts)?;
+            if ts < range.min_timestamp_inclusive() || ts >= range.max_timestamp_exclusive() {
+                continue;
+            }
+            let entry = log_entry(spec)?;
+            let key = (
+                spec.ts,
+                entry.id.table().0[..].to_vec(),
+                entry.id.internal_id()[..].to_vec(),
+            );
+            rows.push((key, entry));
+        }
+        rows.sort_by(|(a, _), (b, _)| a.cmp(b));
+        if order == Order::Desc {
+            rows.reverse();
+        }
+        Ok(rows.into_iter().map(|(_, entry)| entry).collect())
+    }
+
+    async fn run_load(
+        persistence: &SqlitePersistence,
+        range: TimestampRange,
+        order: Order,
+        page_size: u32,
+    ) -> anyhow::Result<Vec<DocumentLogEntry>> {
+        persistence
+            .load_documents(range, order, page_size, Arc::new(NoopRetentionValidator))
+            .try_collect()
+            .await
+    }
+
+    async fn run_load_from_table(
+        persistence: &SqlitePersistence,
+        tablet_id: TabletId,
+        range: TimestampRange,
+        order: Order,
+        page_size: u32,
+    ) -> anyhow::Result<Vec<DocumentLogEntry>> {
+        persistence
+            .load_documents_from_table(
+                tablet_id,
+                range,
+                order,
+                page_size,
+                Arc::new(NoopRetentionValidator),
+            )
+            .try_collect()
+            .await
+    }
+
+    /// `load_documents_from_table` restricts the scan in SQL, so `LIMIT`
+    /// counts only rows that will be yielded. Two tablets are interleaved at
+    /// every timestamp, so a filter applied *after* the limit would hand back
+    /// short pages and terminate the stream early, losing most of the log.
+    /// Page sizes below the number of rows per timestamp also put a page
+    /// boundary inside a same-`ts` run, where the cursor's `(table_id, id)`
+    /// tiebreak has to hold even though `table_id` is now pinned by the
+    /// filter.
+    #[tokio::test]
+    async fn paginated_load_from_table_matches_reference() -> anyhow::Result<()> {
+        let mut specs = vec![];
+        for ts in [10u64, 20, 30] {
+            for tablet_n in [1u8, 2] {
+                for doc_n in 0u8..4 {
+                    specs.push(LogEntrySpec {
+                        ts,
+                        tablet_n,
+                        doc_n,
+                        value: Some(ts as i64),
+                    });
+                }
+            }
+        }
+        // A delete in the targeted tablet, and a whole timestamp belonging to
+        // the other one: neither may terminate the targeted stream.
+        specs.push(LogEntrySpec {
+            ts: 40,
+            tablet_n: 1,
+            doc_n: 0,
+            value: None,
+        });
+        specs.push(LogEntrySpec {
+            ts: 50,
+            tablet_n: 2,
+            doc_n: 0,
+            value: None,
+        });
+        let (persistence, _dir) = make_log_fixture(&specs).await?;
+
+        let target_n = 2u8;
+        let target = TabletId(internal_id(target_n));
+        let targeted: Vec<LogEntrySpec> = specs
+            .iter()
+            .filter(|spec| spec.tablet_n == target_n)
+            .cloned()
+            .collect();
+
+        let ranges = [
+            TimestampRange::all(),
+            TimestampRange::new(Timestamp::try_from(15u64)?..Timestamp::try_from(45u64)?),
+        ];
+        for range in &ranges {
+            for order in [Order::Asc, Order::Desc] {
+                let expected = expected_log(&targeted, range, order)?;
+                for page_size in [1, 3, 5, 10_000] {
+                    let got =
+                        run_load_from_table(&persistence, target, *range, order, page_size).await?;
+                    assert_eq!(
+                        got, expected,
+                        "load_from_table mismatch at range={range:?} order={order:?} \
+                         page_size={page_size}"
+                    );
+                    assert!(
+                        got.iter().all(|entry| entry.id.table() == target),
+                        "load_from_table returned a row from another tablet"
+                    );
+                }
+            }
+        }
+        Ok(())
+    }
+
+    /// Two tablets writing interleaved updates and deletes, with several rows
+    /// sharing the same timestamp: the compound cursor's `(table_id, id)`
+    /// tiebreak is what keeps pagination correct when a page boundary lands
+    /// in the middle of a same-`ts` run.
+    #[tokio::test]
+    async fn paginated_load_matches_reference() -> anyhow::Result<()> {
+        let mut specs = vec![];
+        for tablet_n in [1u8, 2] {
+            for doc_n in 0u8..6 {
+                specs.push(LogEntrySpec {
+                    ts: 10,
+                    tablet_n,
+                    doc_n,
+                    value: Some(1),
+                });
+                if doc_n % 2 == 0 {
+                    specs.push(LogEntrySpec {
+                        ts: 20,
+                        tablet_n,
+                        doc_n,
+                        value: Some(2),
+                    });
+                }
+                if doc_n % 3 == 0 {
+                    specs.push(LogEntrySpec {
+                        ts: 30,
+                        tablet_n,
+                        doc_n,
+                        value: None,
+                    });
+                }
+                if doc_n % 2 == 1 {
+                    specs.push(LogEntrySpec {
+                        ts: 40,
+                        tablet_n,
+                        doc_n,
+                        value: Some(3),
+                    });
+                }
+            }
+        }
+        let (persistence, _dir) = make_log_fixture(&specs).await?;
+
+        let ranges = [
+            TimestampRange::all(),
+            TimestampRange::new(Timestamp::try_from(15u64)?..Timestamp::try_from(35u64)?),
+        ];
+        for range in &ranges {
+            for order in [Order::Asc, Order::Desc] {
+                let expected = expected_log(&specs, range, order)?;
+                for page_size in [1, 2, 3, 10_000] {
+                    let got = run_load(&persistence, *range, order, page_size).await?;
+                    assert_eq!(
+                        got, expected,
+                        "load mismatch at range={range:?} order={order:?} page_size={page_size}"
+                    );
+                }
+            }
+        }
+        Ok(())
+    }
+
+    /// Ten documents written at one single timestamp: every page boundary
+    /// falls inside the same-`ts` run, so only the `(table_id, id)` tiebreak
+    /// of the cursor separates the pages.
+    #[tokio::test]
+    async fn same_ts_run_spans_pages() -> anyhow::Result<()> {
+        let specs: Vec<LogEntrySpec> = (0u8..10)
+            .map(|doc_n| LogEntrySpec {
+                ts: 17,
+                tablet_n: 1,
+                doc_n,
+                value: Some(i64::from(doc_n)),
+            })
+            .collect();
+        let (persistence, _dir) = make_log_fixture(&specs).await?;
+
+        let range = TimestampRange::all();
+        for order in [Order::Asc, Order::Desc] {
+            let expected = expected_log(&specs, &range, order)?;
+            assert_eq!(expected.len(), 10);
+            let got = run_load(&persistence, range, order, 3).await?;
+            assert_eq!(got, expected, "same-ts run must paginate by (table_id, id)");
+        }
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn load_empty_and_out_of_range() -> anyhow::Result<()> {
+        let (empty, _dir) = make_log_fixture(&[]).await?;
+        assert!(run_load(&empty, TimestampRange::all(), Order::Asc, 2)
+            .await?
+            .is_empty());
+
+        let specs: Vec<LogEntrySpec> = (0u8..5)
+            .map(|doc_n| LogEntrySpec {
+                ts: 10,
+                tablet_n: 1,
+                doc_n,
+                value: Some(1),
+            })
+            .collect();
+        let (persistence, _dir) = make_log_fixture(&specs).await?;
+        let out_of_range =
+            TimestampRange::new(Timestamp::try_from(100u64)?..Timestamp::try_from(200u64)?);
+        assert!(run_load(&persistence, out_of_range, Order::Asc, 2)
             .await?
             .is_empty());
         Ok(())

--- a/crates/sqlite/src/lib.rs
+++ b/crates/sqlite/src/lib.rs
@@ -100,16 +100,6 @@ impl SqlitePersistence {
 
     #[allow(clippy::needless_lifetimes)]
     #[try_stream(ok = T, error = anyhow::Error)]
-    async fn validate_snapshot<T: 'static>(
-        &self,
-        ts: Timestamp,
-        retention_validator: Arc<dyn RetentionValidator>,
-    ) {
-        retention_validator.validate_snapshot(ts).await?;
-    }
-
-    #[allow(clippy::needless_lifetimes)]
-    #[try_stream(ok = T, error = anyhow::Error)]
     async fn validate_document_snapshot<T: 'static>(
         &self,
         ts: Timestamp,
@@ -118,14 +108,20 @@ impl SqlitePersistence {
         retention_validator.validate_document_snapshot(ts).await?;
     }
 
-    fn _index_scan_inner(
+    /// Read one page of an index scan, at most `batch_size` keys, resuming
+    /// after `cursor` (the last key the previous page scanned, in scan
+    /// order). Tombstoned keys are returned as `(key, None)`: they must
+    /// still advance the cursor, but must not be emitted to the caller.
+    fn _index_scan_page(
         &self,
         index_id: IndexId,
         tablet_id: TabletId,
         read_timestamp: Timestamp,
         interval: &Interval,
         order: Order,
-    ) -> anyhow::Result<Vec<anyhow::Result<(IndexKeyBytes, LatestDocument)>>> {
+        batch_size: usize,
+        cursor: Option<&IndexKeyBytes>,
+    ) -> anyhow::Result<Vec<(IndexKeyBytes, Option<LatestDocument>)>> {
         let interval = interval.clone();
         let index_id = &index_id.0[..];
         let read_timestamp: u64 = read_timestamp.into();
@@ -150,22 +146,42 @@ impl SqlitePersistence {
             None => "".to_owned(),
         };
 
+        let cursor_bytes = cursor.map(|key| &key.0[..]);
+        let cursor_bound = match cursor_bytes {
+            Some(ref t) => {
+                params.push(t);
+                match order {
+                    Order::Asc => format!(" AND key > ${}", params.len()),
+                    Order::Desc => format!(" AND key < ${}", params.len()),
+                }
+            },
+            None => "".to_owned(),
+        };
+
         let order = match order {
             Order::Asc => "ASC",
             Order::Desc => "DESC",
         };
+        // The inner subquery is bounded by `LIMIT`: `GROUP BY` over a prefix
+        // of the `(index_id, key, ts)` primary key streams groups in key
+        // order, so SQLite stops scanning after `batch_size` keys instead of
+        // materializing the entire interval. `B.deleted` is selected (not
+        // filtered in the join) so that tombstoned keys count toward the
+        // page: otherwise a page full of tombstones would be
+        // indistinguishable from the end of the interval.
         let query = format!(
             r#"
-SELECT B.key, B.ts, B.document_id, C.table_id, C.json_value, C.prev_ts
+SELECT B.key, B.ts, B.document_id, C.table_id, C.json_value, C.prev_ts, B.deleted
 FROM (
     SELECT index_id, key, MAX(ts) as max_ts
     FROM indexes
-    WHERE index_id = $1 AND ts <= $2{lower}{upper}
+    WHERE index_id = $1 AND ts <= $2{lower}{upper}{cursor_bound}
     GROUP BY index_id, key
+    ORDER BY key {order}
+    LIMIT {batch_size}
 ) A
 JOIN indexes B
-ON B.deleted is FALSE
-AND A.index_id = B.index_id
+ON A.index_id = B.index_id
 AND A.key = B.key
 AND A.max_ts = B.ts
 LEFT JOIN documents C
@@ -181,22 +197,30 @@ ORDER BY B.key {order}
         let row_iter = stmt.query_map(&params[..], |row| {
             let key = IndexKeyBytes(row.get::<_, Vec<u8>>(0)?);
             let ts = Timestamp::try_from(row.get::<_, u64>(1)?).expect("timestamp out of bounds");
-            let document_id = row.get::<_, Vec<u8>>(2)?;
+            let document_id: Option<Vec<u8>> = row.get(2)?;
             let table: Option<Vec<u8>> = row.get(3)?;
             let json_value: Option<String> = row.get(4)?;
             let prev_ts: Option<Timestamp> = row
                 .get::<_, Option<u64>>(5)?
                 .map(|ts| Timestamp::try_from(ts).expect("prev_ts out of bounds"));
+            let deleted = row.get::<_, u32>(6)? != 0;
 
-            Ok((key, ts, document_id, table, json_value, prev_ts))
+            Ok((key, ts, document_id, table, json_value, prev_ts, deleted))
         })?;
-        let mut triples = vec![];
+        let mut page = vec![];
         for row in row_iter {
-            let (key, ts, document_id, table, json_value, prev_ts) = row?;
+            let (key, ts, document_id, table, json_value, prev_ts, deleted) = row?;
+            if deleted {
+                page.push((key, None));
+                continue;
+            }
             let table = table.ok_or_else(|| {
                 anyhow::anyhow!("Dangling index reference for {:?} {:?}", key, ts)
             })?;
             let table = TabletId(table.try_into()?);
+            let document_id = document_id.ok_or_else(|| {
+                anyhow::anyhow!("Dangling index reference for {:?} {:?}", key, ts)
+            })?;
             let _document_id = InternalDocumentId::new(table, InternalId::try_from(document_id)?);
             let json_value = json_value.ok_or_else(|| {
                 anyhow::anyhow!("Index reference to deleted document {:?} {:?}", key, ts)
@@ -204,16 +228,59 @@ ORDER BY B.key {order}
             let json_value: serde_json::Value = serde_json::from_str(&json_value)?;
             let value: ConvexValue = json_value.try_into()?;
             let document = ResolvedDocument::from_database(tablet_id, value)?;
-            triples.push(Ok((
+            page.push((
                 key,
-                LatestDocument {
+                Some(LatestDocument {
                     ts,
                     value: document,
                     prev_ts,
-                },
-            )));
+                }),
+            ));
         }
-        Ok(triples)
+        Ok(page)
+    }
+
+    /// Stream an index scan one page at a time. The snapshot is validated
+    /// against retention after each page is read and before any of its rows
+    /// are yielded, mirroring the Postgres reader: pages are read at
+    /// different times, and each read is only valid if the snapshot is still
+    /// within retention.
+    #[try_stream(ok = (IndexKeyBytes, LatestDocument), error = anyhow::Error)]
+    async fn _index_scan_paginated(
+        &self,
+        index_id: IndexId,
+        tablet_id: TabletId,
+        read_timestamp: Timestamp,
+        interval: Interval,
+        order: Order,
+        batch_size: usize,
+        retention_validator: Arc<dyn RetentionValidator>,
+    ) {
+        let mut cursor: Option<IndexKeyBytes> = None;
+        loop {
+            let page = self._index_scan_page(
+                index_id,
+                tablet_id,
+                read_timestamp,
+                &interval,
+                order,
+                batch_size,
+                cursor.as_ref(),
+            )?;
+            let page_len = page.len();
+            retention_validator
+                .validate_snapshot(read_timestamp)
+                .await?;
+            for (key, doc) in page {
+                cursor = Some(key.clone());
+                if let Some(doc) = doc {
+                    yield (key, doc);
+                }
+            }
+            if page_len < batch_size {
+                break;
+            }
+        }
     }
 
     fn _get_persistence_global(
@@ -597,16 +664,23 @@ impl PersistenceReader for SqlitePersistence {
         read_timestamp: Timestamp,
         interval: &Interval,
         order: Order,
-        _size_hint: usize,
+        size_hint: usize,
         retention_validator: Arc<dyn RetentionValidator>,
     ) -> IndexStream<'_> {
-        let triples = self._index_scan_inner(index_id, tablet_id, read_timestamp, interval, order);
-        // index_scan isn't async so we have to validate snapshot as part of the stream.
-        let validate = self.validate_snapshot(read_timestamp, retention_validator);
-        match triples {
-            Ok(s) => (validate.chain(stream::iter(s))).boxed(),
-            Err(e) => stream::once(async { Err(e) }).boxed(),
-        }
+        // Mirror the Postgres reader: use the caller's size_hint to bound how
+        // much of the interval each query materializes, so a small take()
+        // over a large table no longer loads the entire range into memory.
+        let batch_size = size_hint.clamp(1, 5000);
+        self._index_scan_paginated(
+            index_id,
+            tablet_id,
+            read_timestamp,
+            interval.clone(),
+            order,
+            batch_size,
+            retention_validator,
+        )
+        .boxed()
     }
 
     async fn get_persistence_global(
@@ -765,3 +839,298 @@ WHERE
     ts = $3
 ORDER BY ts ASC, table_id ASC, id ASC
 "#;
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use common::{
+        document::{
+            CreationTime,
+            ResolvedDocument,
+        },
+        index::IndexKeyBytes,
+        interval::{
+            BinaryKey,
+            End,
+            Interval,
+            StartIncluded,
+        },
+        obj,
+        persistence::{
+            ConflictStrategy,
+            DocumentLogEntry,
+            LatestDocument,
+            NoopRetentionValidator,
+            Persistence,
+            PersistenceIndexEntry,
+            PersistenceReader,
+        },
+        query::Order,
+        types::{
+            IndexId,
+            Timestamp,
+        },
+        value::{
+            DeveloperDocumentId,
+            InternalDocumentId,
+            InternalId,
+            ResolvedDocumentId,
+            TableNumber,
+            TabletId,
+        },
+    };
+    use futures::TryStreamExt;
+
+    use super::SqlitePersistence;
+
+    /// One indexed key and its history: `(ts, Some(v))` is a live write of
+    /// value `v`, `(ts, None)` is a tombstone.
+    struct KeySpec {
+        key: Vec<u8>,
+        doc_n: u8,
+        versions: Vec<(u64, Option<i64>)>,
+    }
+
+    struct Fixture {
+        persistence: SqlitePersistence,
+        index_id: IndexId,
+        tablet_id: TabletId,
+        table_number: TableNumber,
+        // Kept alive so the database file outlives the test body.
+        _dir: tempfile::TempDir,
+    }
+
+    fn internal_id(n: u8) -> InternalId {
+        InternalId::from([n; 16])
+    }
+
+    fn make_doc(
+        tablet_id: TabletId,
+        table_number: TableNumber,
+        doc_n: u8,
+        v: i64,
+    ) -> anyhow::Result<ResolvedDocument> {
+        let id = ResolvedDocumentId::new(
+            tablet_id,
+            DeveloperDocumentId::new(table_number, internal_id(doc_n)),
+        );
+        ResolvedDocument::new(id, CreationTime::try_from(1234.5)?, obj!("v" => v)?)
+    }
+
+    async fn make_fixture(specs: &[KeySpec]) -> anyhow::Result<Fixture> {
+        let dir = tempfile::tempdir()?;
+        let path = dir.path().join("test.sqlite3");
+        let persistence = SqlitePersistence::new(path.to_str().unwrap())?;
+        let index_id = IndexId(internal_id(255));
+        let tablet_id = TabletId(internal_id(254));
+        let table_number = TableNumber::try_from(1)?;
+
+        let mut documents = vec![];
+        let mut indexes = vec![];
+        for spec in specs {
+            let doc_id = InternalDocumentId::new(tablet_id, internal_id(spec.doc_n));
+            for &(ts, v) in &spec.versions {
+                let ts = Timestamp::try_from(ts)?;
+                let value = v
+                    .map(|v| make_doc(tablet_id, table_number, spec.doc_n, v))
+                    .transpose()?;
+                documents.push(DocumentLogEntry {
+                    ts,
+                    id: doc_id,
+                    value,
+                    prev_ts: None,
+                });
+                indexes.push(PersistenceIndexEntry {
+                    ts,
+                    index_id,
+                    key: IndexKeyBytes(spec.key.clone()),
+                    value: v.map(|_| doc_id),
+                });
+            }
+        }
+        persistence
+            .write(&documents, &indexes, ConflictStrategy::Error)
+            .await?;
+        Ok(Fixture {
+            persistence,
+            index_id,
+            tablet_id,
+            table_number,
+            _dir: dir,
+        })
+    }
+
+    fn make_interval(start: Vec<u8>, end: Option<Vec<u8>>) -> Interval {
+        Interval {
+            start: StartIncluded(BinaryKey::from(start)),
+            end: match end {
+                Some(end) => End::Excluded(BinaryKey::from(end)),
+                None => End::Unbounded,
+            },
+        }
+    }
+
+    /// The reference implementation: latest visible version per key at
+    /// `read_ts`, tombstones dropped, interval applied, in scan order.
+    fn expected_scan(
+        fixture: &Fixture,
+        specs: &[KeySpec],
+        read_ts: u64,
+        interval: &Interval,
+        order: Order,
+    ) -> anyhow::Result<Vec<(IndexKeyBytes, LatestDocument)>> {
+        let mut rows = vec![];
+        for spec in specs {
+            if !interval.contains(&spec.key) {
+                continue;
+            }
+            let visible = spec
+                .versions
+                .iter()
+                .filter(|(ts, _)| *ts <= read_ts)
+                .max_by_key(|(ts, _)| *ts);
+            let Some(&(ts, Some(v))) = visible else {
+                continue;
+            };
+            rows.push((
+                IndexKeyBytes(spec.key.clone()),
+                LatestDocument {
+                    ts: Timestamp::try_from(ts)?,
+                    value: make_doc(fixture.tablet_id, fixture.table_number, spec.doc_n, v)?,
+                    prev_ts: None,
+                },
+            ));
+        }
+        rows.sort_by(|(a, _), (b, _)| a.cmp(b));
+        if order == Order::Desc {
+            rows.reverse();
+        }
+        Ok(rows)
+    }
+
+    async fn run_scan(
+        fixture: &Fixture,
+        read_ts: u64,
+        interval: &Interval,
+        order: Order,
+        size_hint: usize,
+    ) -> anyhow::Result<Vec<(IndexKeyBytes, LatestDocument)>> {
+        fixture
+            .persistence
+            .index_scan(
+                fixture.index_id,
+                fixture.tablet_id,
+                Timestamp::try_from(read_ts)?,
+                interval,
+                order,
+                size_hint,
+                Arc::new(NoopRetentionValidator),
+            )
+            .try_collect()
+            .await
+    }
+
+    /// 25 keys with updates, tombstones on page boundaries, and writes past
+    /// the read snapshot, scanned under every pagination regime: the
+    /// paginated scan must be indistinguishable from the one-shot scan it
+    /// replaced.
+    #[tokio::test]
+    async fn paginated_scan_matches_reference() -> anyhow::Result<()> {
+        let specs: Vec<KeySpec> = (0u8..25)
+            .map(|k| {
+                let mut versions = vec![(10, Some(1))];
+                if k % 3 == 0 {
+                    versions.push((20, Some(2)));
+                }
+                if k % 5 == 0 {
+                    versions.push((30, None));
+                }
+                if k % 2 == 0 {
+                    versions.push((40, Some(3)));
+                }
+                KeySpec {
+                    key: vec![k],
+                    doc_n: k,
+                    versions,
+                }
+            })
+            .collect();
+        let fixture = make_fixture(&specs).await?;
+
+        let intervals = [
+            make_interval(vec![], None),
+            make_interval(vec![3], Some(vec![20])),
+        ];
+        // At ts 35 the tombstones (ts 30) are the latest visible versions;
+        // at ts 45 the ts-40 writes resurrect the even keys among them.
+        for read_ts in [35, 45] {
+            for interval in &intervals {
+                for order in [Order::Asc, Order::Desc] {
+                    let expected = expected_scan(&fixture, &specs, read_ts, interval, order)?;
+                    for size_hint in [1, 2, 3, 10_000] {
+                        let got = run_scan(&fixture, read_ts, interval, order, size_hint).await?;
+                        assert_eq!(
+                            got, expected,
+                            "scan mismatch at read_ts={read_ts} order={order:?} \
+                             size_hint={size_hint}"
+                        );
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+
+    /// Ten consecutive tombstoned keys form entire pages with no live rows.
+    /// A scan that terminates on "page yielded fewer live rows than
+    /// requested" would stop in the middle of the interval and silently drop
+    /// every key after the tombstone run.
+    #[tokio::test]
+    async fn page_of_tombstones_does_not_terminate_scan() -> anyhow::Result<()> {
+        let specs: Vec<KeySpec> = (0u8..30)
+            .map(|k| {
+                let mut versions = vec![(10, Some(1))];
+                if (10..20).contains(&k) {
+                    versions.push((20, None));
+                }
+                KeySpec {
+                    key: vec![k],
+                    doc_n: k,
+                    versions,
+                }
+            })
+            .collect();
+        let fixture = make_fixture(&specs).await?;
+
+        let interval = make_interval(vec![], None);
+        for order in [Order::Asc, Order::Desc] {
+            let expected = expected_scan(&fixture, &specs, 25, &interval, order)?;
+            assert_eq!(expected.len(), 20);
+            let got = run_scan(&fixture, 25, &interval, order, 5).await?;
+            assert_eq!(got, expected, "tombstone run must not end the scan early");
+        }
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn empty_table_and_empty_range() -> anyhow::Result<()> {
+        let empty = make_fixture(&[]).await?;
+        let all = make_interval(vec![], None);
+        assert!(run_scan(&empty, 100, &all, Order::Asc, 3).await?.is_empty());
+
+        let specs: Vec<KeySpec> = (0u8..5)
+            .map(|k| KeySpec {
+                key: vec![k],
+                doc_n: k,
+                versions: vec![(10, Some(1))],
+            })
+            .collect();
+        let fixture = make_fixture(&specs).await?;
+        let out_of_range = make_interval(vec![200], Some(vec![201]));
+        assert!(run_scan(&fixture, 100, &out_of_range, Order::Asc, 3)
+            .await?
+            .is_empty());
+        Ok(())
+    }
+}


### PR DESCRIPTION
## Problem

On the self-hosted **SQLite** backend, both persistence read paths materialize entire ranges into memory instead of honoring their pagination parameters:

- `PersistenceReader::index_scan` ignores its `size_hint` argument (bound as `_size_hint`) and runs a query with **no `LIMIT`**, collecting every row in the interval into a `Vec` before the query layer's `.take(N)` is ever applied. An indexed read that should touch a handful of documents reads the whole range: on moderately large tables it fails with `SystemTimeoutError: Your request timed out performing too many system operations`, and on memory-constrained hosts it drives the backend into memory pressure / OOM (each row is also fully deserialized into a `ResolvedDocument` before anything is returned).
- `PersistenceReader::load_documents` ignores its `page_size` argument the same way and collects the entire documents-log range into a `Vec`. The boot-time search index bootstrap walks the whole log through this path, so the backend's startup working set scales with total log size.

Since #56013 the same is true of `load_documents_from_table`, which shares that code path and is now the one `DataSyncIterator` takes when it targets a single table.

This is the failure described in #495 and it reproduces on current `main`.

## Fix (two commits, one per read path)

Both fixes mirror the Postgres reader's design (`crates/postgres` already uses these parameters for batched cursor pagination):

**Commit 1 — `index_scan`:**
- `size_hint.clamp(1, 5000)` is the page size; each page is one query.
- The grouped subquery gains `ORDER BY key {order}` + `LIMIT {batch_size}`: since `GROUP BY index_id, key` runs over a prefix of the `(index_id, key, ts)` primary key, SQLite streams groups in key order and stops after one page.
- Each page resumes strictly after the last **scanned** key (`key > cursor` asc / `key < cursor` desc); pages re-query with `ts <= read_timestamp`, so pagination reads the same logical snapshot from the append-only log.
- **Tombstones count toward the page but are not emitted.** `B.deleted` moved from the join filter into the projection: with the old join filter, a page consisting entirely of tombstoned keys would be indistinguishable from the end of the interval and a "fewer rows than requested ⇒ done" termination would silently drop the rest of the range.
- The retention snapshot is validated after each page is read and before any of its rows are yielded — the same contract as the Postgres reader.
- Also fixes a latent row-mapper failure path: tombstoned index rows carry `document_id = NULL`, which the old `row.get::<_, Vec<u8>>(2)` would have failed on (it never saw them only because the join filtered tombstones out).

**Commit 2 — `load_documents` and `load_documents_from_table`:**
- `page_size` is now honored (guarded with `.max(1)`); each page is one query with `LIMIT`, resuming strictly after the `(ts, table_id, id)` primary key of the last row read (composite strict bound, mirrored for `Desc`).
- Deletes are legitimate log entries here, so nothing is filtered after the query runs and short-page termination is safe.
- Retention is validated per page via `validate_document_snapshot`, and the stream keeps the existing `.cooperative()` wrapping.
- `load_documents_from_table` shares the paginated path, taking the tablet restriction as one more bound on the same query. Restricting in SQL — rather than filtering rows out after they are read — is what keeps short-page termination correct: `LIMIT` counts only rows that will be yielded. A filter applied after the limit would hand back short pages on an interleaved log and end the stream early.
- Placeholder numbers are derived from the parameter vector as each one is bound, so adding the tablet parameter cannot silently renumber the cursor's.

Error surfacing is now lazy (first poll of the stream) rather than eager at call time, matching the Postgres reader.

## Rebased onto current `main`

#56013 landed after this PR was opened: it made `PersistenceReader::load_documents_from_table` a required trait method (dropping the default body that the SQLite reader relied on) and pushed the tablet filter down into SQL for it. That optimization is preserved here — the filter stays in the query — and pagination is added underneath it, so the single-table `DataSyncIterator` path gets both. The free `load_docs` helper is gone; the query is built inline where the cursor and tablet bounds are assembled.

## Measurements

We hit this in production self-hosting and measured the fix against a **snapshot of a real production database** (2.3 GB SQLite, ~1.5 M documents-log rows, ~3.2 M index rows): same machine, same base commit, network-isolated boot, RSS sampled every 5 s. These numbers were taken before the rebase; the pagination design is unchanged.

| Backend | Boot RSS behavior |
|---|---|
| Unpatched | Climbs without bound: **6.8 GB at 7 min 25 s**, killed by a safety cap while still climbing (in production this plateaued at 14–16 GB and pushed the host into reclaim thrashing) |
| Commit 1 only | Climbs to ~5.1 GB in 95 s, then holds a stable plateau at **~5.3 GB** (the remaining climb is `load_documents` during search index bootstrap) |
| Commits 1 + 2 | **~355 MB**, flat for the entire observation window |

## Tests

`crates/sqlite` had no test module; this PR adds one (most of the diff — the production change is small):

- `paginated_scan_matches_reference` — 25 keys with updates, tombstones landing on page boundaries, and writes newer than the read snapshot, checked against an in-memory reference model across 2 read timestamps × 2 intervals × `Asc`/`Desc` × size hints `{1, 2, 3, 10_000}`.
- `page_of_tombstones_does_not_terminate_scan` — 10 consecutive tombstoned keys forming whole pages with no live rows, the case a naive termination check breaks on.
- `load_documents` equivalents: full-log reference comparison across page sizes/orders/partial ts ranges, plus a run of many documents written at a **single timestamp** with pages breaking inside it (the `(table_id, id)` cursor tiebreak is the fragile spot), and empty-table/empty-range cases.
- `paginated_load_from_table_matches_reference` — two tablets interleaved at every timestamp, compared against a filtered reference across both orders and page sizes `{1, 3, 5, 10_000}`. This is the test that fails if the tablet restriction moves out of SQL, or if a placeholder number is hardcoded once a second parameter exists.

Validation: `cargo test -p sqlite` green (7 tests), `cargo fmt` clean, `cargo clippy -p sqlite --lib --tests` introduces no new warnings. Each commit builds and passes on its own.

Fixes #495
