### PR TITLE
fix(mcp): don't require Convex Cloud auth for self-hosted deployments

### DIFF
--- a/npm-packages/convex/src/cli/mcp.ts
+++ b/npm-packages/convex/src/cli/mcp.ts
@@ -16,7 +16,10 @@ import {
 } from "./lib/mcp/requestContext.js";
 import { mcpTool, convexTools, ConvexTool } from "./lib/mcp/tools/index.js";
 import { Mutex } from "./lib/utils/mutex.js";
-import { initializeBigBrainAuth } from "./lib/deploymentSelection.js";
+import {
+  getDeploymentSelection,
+  initializeBigBrainAuth,
+} from "./lib/deploymentSelection.js";
 
 const allToolNames = convexTools.map((t) => t.name).sort();
 
@@ -115,14 +118,26 @@ function makeServer(options: McpOptions) {
       const ctx = new RequestContext(options);
       await initializeBigBrainAuth(ctx, options);
       try {
-        const authorized = await checkAuthorization(ctx, false);
-        if (!authorized) {
-          await ctx.crash({
-            exitCode: 1,
-            errorType: "fatal",
-            printedMessage:
-              "Not Authorized: Run `npx convex dev` to login to your Convex project.",
-          });
+        // Deployments reached directly via `--url`/`--admin-key` or the
+        // `CONVEX_SELF_HOSTED_URL`/`CONVEX_SELF_HOSTED_ADMIN_KEY` env vars are
+        // authenticated by their admin key alone; they have no Convex Cloud
+        // account to check authorization against, so only require the Big
+        // Brain authorization check for deployment selections that actually
+        // depend on it.
+        const deploymentSelection = await getDeploymentSelection(ctx, options);
+        const needsBigBrainAuthorization =
+          deploymentSelection.kind !== "existingDeployment" ||
+          deploymentSelection.deploymentToActOn.source === "deployKey";
+        if (needsBigBrainAuthorization) {
+          const authorized = await checkAuthorization(ctx, false);
+          if (!authorized) {
+            await ctx.crash({
+              exitCode: 1,
+              errorType: "fatal",
+              printedMessage:
+                "Not Authorized: Run `npx convex dev` to login to your Convex project.",
+            });
+          }
         }
         if (!request.params.arguments) {
           await ctx.crash({


### PR DESCRIPTION
## Summary

The MCP server's tool-call handler (`npm-packages/convex/src/cli/mcp.ts`) unconditionally calls `checkAuthorization()` on every single tool call, which requires a Convex Cloud "Big Brain" auth header (from a global `npx convex login` session, or `CONVEX_DEPLOY_KEY`).

Deployments selected via `CONVEX_SELF_HOSTED_URL`/`CONVEX_SELF_HOSTED_ADMIN_KEY` (or `--url`/`--admin-key`) have no Convex Cloud account to authorize against at all — but the gate runs before deployment selection is even consulted, so every tool call for a self-hosted-only setup fails with:

```
Not Authorized: Run `npx convex dev` to login to your Convex project.
```

...regardless of how correct the self-hosted admin key/URL are. This effectively makes the MCP server unusable for self-hosted Convex deployments that don't also have (or want) a Convex Cloud account.

## Fix

Resolve the deployment selection first via the existing `getDeploymentSelection()`, and only require the Big Brain authorization check when the resolved selection actually depends on it — i.e. everything except the `selfHosted`/`cliArgs` `existingDeployment` sources, which are already fully authenticated by their own admin key.

## Testing

Verified live against a real self-hosted deployment with only `CONVEX_SELF_HOSTED_URL`/`CONVEX_SELF_HOSTED_ADMIN_KEY` set (no cloud login):
- `status` tool call now succeeds and returns the deployment's `deploymentSelector`/`url` (previously failed with "Not Authorized").
- `tables` tool call using that selector now succeeds and returns real schema data.
- Non-self-hosted auth paths (deploy keys) are unaffected — the check still runs for `source: "deployKey"`.

## Test plan

- [x] Ran the patched MCP server from source (`tsx src/cli/index.ts mcp start`) against a live self-hosted backend with `CONVEX_SELF_HOSTED_URL`/`CONVEX_SELF_HOSTED_ADMIN_KEY` set, confirmed `status` and `tables` tool calls succeed end-to-end.
- [ ] Would appreciate a maintainer sanity-check on the `deployKey`-only gating condition against the various `CONVEX_DEPLOY_KEY` / preview / project-key flows, since I don't have those set up locally to test.