### PR TITLE
Name local Node action executors

### DIFF
--- a/npm-packages/node-executor/src/local.ts
+++ b/npm-packages/node-executor/src/local.ts
@@ -5,8 +5,14 @@ import { log, setDebugLogging } from "./log";
 import os from "node:os";
 import http from "node:http";
 import express, { Request, Response } from "express";
+import { setNodeExecutorProcessTitle } from "./processTitle";
 
 const DEFAULT_PORT = 3002;
+
+setNodeExecutorProcessTitle(
+  process,
+  process.env.CONVEX_NODE_EXECUTOR_PROCESS_TITLE,
+);
 
 async function startServer(
   listenTarget: number | { path: string },

--- a/npm-packages/node-executor/src/processTitle.test.ts
+++ b/npm-packages/node-executor/src/processTitle.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import {
+  nodeExecutorProcessTitle,
+  setNodeExecutorProcessTitle,
+} from "./processTitle";
+
+describe("nodeExecutorProcessTitle", () => {
+  it("uses the default title without an override", () => {
+    expect(nodeExecutorProcessTitle()).toBe("convex-node-executor");
+  });
+
+  it("normalizes an inherited override", () => {
+    expect(nodeExecutorProcessTitle("  local\tworker\n1  ")).toBe(
+      "local worker 1",
+    );
+  });
+
+  it("falls back to the default for an empty normalized override", () => {
+    expect(nodeExecutorProcessTitle("\u0000 \n\t")).toBe(
+      "convex-node-executor",
+    );
+  });
+
+  it("caps overrides without splitting UTF-8 characters", () => {
+    const title = nodeExecutorProcessTitle("\u{1F642}".repeat(25));
+    expect(Buffer.byteLength(title)).toBe(96);
+    expect(title).toBe("\u{1F642}".repeat(24));
+  });
+
+  it("sets the title on the provided process target", () => {
+    const target = { title: "" };
+    setNodeExecutorProcessTitle(target, "local executor");
+    expect(target.title).toBe("local executor");
+  });
+});

--- a/npm-packages/node-executor/src/processTitle.ts
+++ b/npm-packages/node-executor/src/processTitle.ts
@@ -1,0 +1,26 @@
+const DEFAULT_PROCESS_TITLE = "convex-node-executor";
+// Keep process titles readable in Activity Monitor and below platform truncation limits.
+const MAX_PROCESS_TITLE_BYTES = 96;
+
+export function nodeExecutorProcessTitle(override?: string): string {
+  const normalized = override?.replace(/[\s\p{C}]+/gu, " ").trim();
+  const title = normalized || DEFAULT_PROCESS_TITLE;
+  let byteLength = 0;
+  let truncated = "";
+  for (const character of title) {
+    const characterByteLength = Buffer.byteLength(character);
+    if (byteLength + characterByteLength > MAX_PROCESS_TITLE_BYTES) {
+      break;
+    }
+    truncated += character;
+    byteLength += characterByteLength;
+  }
+  return truncated;
+}
+
+export function setNodeExecutorProcessTitle(
+  target: { title: string },
+  override?: string,
+): void {
+  target.title = nodeExecutorProcessTitle(override);
+}


### PR DESCRIPTION
## Summary
- set a descriptive process title for local Node action executors so macOS Activity Monitor no longer shows a bare `node` process
- default to `convex-node-executor` and support an optional `CONVEX_NODE_EXECUTOR_PROCESS_TITLE` override
- normalize overrides and safely limit the displayed UTF-8 title

## Testing
- `pnpm --filter node-executor exec vitest run src/processTitle.test.ts`