### PR TITLE
Clean up local Node executor processes

### DIFF
--- a/crates/application/src/application_function_runner/mod.rs
+++ b/crates/application/src/application_function_runner/mod.rs
@@ -741,7 +741,7 @@ impl<RT: Runtime> ApplicationFunctionRunner<RT> {
     }
 
     pub(crate) async fn shutdown(&self) -> anyhow::Result<()> {
-        self.node_actions.shutdown();
+        self.node_actions.shutdown().await?;
         Ok(())
     }
 

--- a/crates/node_executor/src/executor.rs
+++ b/crates/node_executor/src/executor.rs
@@ -148,7 +148,7 @@ pub trait NodeExecutor: Sync + Send {
         request: ExecutorRequest,
         log_line_sender: mpsc::UnboundedSender<LogLine>,
     ) -> anyhow::Result<InvokeResponse>;
-    fn shutdown(&self);
+    async fn shutdown(&self) -> anyhow::Result<()>;
 }
 
 pub struct InvokeResponse {
@@ -229,8 +229,8 @@ impl<RT: Runtime> NodeActions<RT> {
         self.executor.enable()
     }
 
-    pub fn shutdown(&self) {
-        self.executor.shutdown()
+    pub async fn shutdown(&self) -> anyhow::Result<()> {
+        self.executor.shutdown().await
     }
 
     #[rustfmt::skip]

--- a/crates/node_executor/src/local.rs
+++ b/crates/node_executor/src/local.rs
@@ -1,7 +1,10 @@
 use std::{
     fs,
     path::PathBuf,
-    sync::Arc,
+    sync::{
+        Arc,
+        Mutex as StdMutex,
+    },
     time::Duration,
 };
 
@@ -26,7 +29,8 @@ use tokio::{
     },
     sync::{
         mpsc,
-        Mutex,
+        Mutex as AsyncMutex,
+        Notify,
     },
 };
 
@@ -47,8 +51,38 @@ const HEALTH_CHECK_INTERVAL: Duration = Duration::from_millis(100);
 const MAX_HEALTH_CHECK_ATTEMPTS: u32 = 50;
 
 pub struct LocalNodeExecutor {
-    inner: Arc<Mutex<Option<InnerLocalNodeExecutor>>>,
+    inner: AsyncMutex<Option<InnerLocalNodeExecutor>>,
+    lifecycle: Arc<ExecutorLifecycle>,
     config: LocalNodeExecutorConfig,
+}
+
+struct ExecutorLifecycle {
+    state: StdMutex<ExecutorLifecycleState>,
+    state_changed: Notify,
+}
+
+struct ExecutorLifecycleState {
+    active_invocations: usize,
+    startup_in_progress: bool,
+    shutdown: ExecutorShutdownState,
+}
+
+enum ExecutorShutdownState {
+    Running,
+    ShuttingDown { shutdown_claimed: bool },
+    ShutDown,
+}
+
+struct InvocationLease {
+    lifecycle: Arc<ExecutorLifecycle>,
+}
+
+struct StartupLease {
+    lifecycle: Arc<ExecutorLifecycle>,
+}
+
+struct ShutdownLease {
+    lifecycle: Arc<ExecutorLifecycle>,
 }
 
 struct LocalNodeExecutorConfig {
@@ -61,9 +95,120 @@ struct LocalNodeExecutorConfig {
 }
 
 struct InnerLocalNodeExecutor {
-    _source_dir: TempDir,
+    source_dir: TempDir,
     client: reqwest::Client,
-    _server_handle: Child,
+    server_handle: Child,
+}
+
+impl ExecutorLifecycle {
+    fn new() -> Self {
+        Self {
+            state: StdMutex::new(ExecutorLifecycleState {
+                active_invocations: 0,
+                startup_in_progress: false,
+                shutdown: ExecutorShutdownState::Running,
+            }),
+            state_changed: Notify::new(),
+        }
+    }
+
+    fn begin_invocation(self: &Arc<Self>) -> anyhow::Result<InvocationLease> {
+        let mut state = self.state.lock().expect("Executor lifecycle lock poisoned");
+        if !matches!(state.shutdown, ExecutorShutdownState::Running) {
+            anyhow::bail!("Node executor is shutting down");
+        }
+        state.active_invocations += 1;
+        Ok(InvocationLease {
+            lifecycle: self.clone(),
+        })
+    }
+
+    async fn begin_startup(self: &Arc<Self>) -> anyhow::Result<StartupLease> {
+        loop {
+            let state_changed = self.state_changed.notified();
+            {
+                let mut state = self.state.lock().expect("Executor lifecycle lock poisoned");
+                if !matches!(state.shutdown, ExecutorShutdownState::Running) {
+                    anyhow::bail!("Node executor is shutting down");
+                }
+                if !state.startup_in_progress {
+                    state.startup_in_progress = true;
+                    return Ok(StartupLease {
+                        lifecycle: self.clone(),
+                    });
+                }
+            }
+            state_changed.await;
+        }
+    }
+
+    async fn begin_shutdown(self: &Arc<Self>) -> Option<ShutdownLease> {
+        loop {
+            let state_changed = self.state_changed.notified();
+            {
+                let mut state = self.state.lock().expect("Executor lifecycle lock poisoned");
+                let active_invocations = state.active_invocations;
+                match &mut state.shutdown {
+                    ExecutorShutdownState::Running => {
+                        state.shutdown = ExecutorShutdownState::ShuttingDown {
+                            shutdown_claimed: false,
+                        };
+                    },
+                    ExecutorShutdownState::ShutDown => return None,
+                    ExecutorShutdownState::ShuttingDown { .. } => {},
+                }
+                if let ExecutorShutdownState::ShuttingDown { shutdown_claimed } =
+                    &mut state.shutdown
+                    && active_invocations == 0
+                    && !*shutdown_claimed
+                {
+                    *shutdown_claimed = true;
+                    return Some(ShutdownLease {
+                        lifecycle: self.clone(),
+                    });
+                }
+            }
+            state_changed.await;
+        }
+    }
+
+    fn finish_invocation(&self) {
+        let mut state = self.state.lock().expect("Executor lifecycle lock poisoned");
+        state.active_invocations -= 1;
+        if state.active_invocations == 0 {
+            self.state_changed.notify_waiters();
+        }
+    }
+
+    fn finish_startup(&self) {
+        let mut state = self.state.lock().expect("Executor lifecycle lock poisoned");
+        state.startup_in_progress = false;
+        self.state_changed.notify_waiters();
+    }
+
+    fn finish_shutdown(&self) {
+        let mut state = self.state.lock().expect("Executor lifecycle lock poisoned");
+        state.shutdown = ExecutorShutdownState::ShutDown;
+        self.state_changed.notify_waiters();
+    }
+}
+
+impl Drop for InvocationLease {
+    fn drop(&mut self) {
+        self.lifecycle.finish_invocation();
+    }
+}
+
+impl Drop for StartupLease {
+    fn drop(&mut self) {
+        self.lifecycle.finish_startup();
+    }
+}
+
+impl Drop for ShutdownLease {
+    fn drop(&mut self) {
+        self.lifecycle.finish_shutdown();
+    }
 }
 
 impl InnerLocalNodeExecutor {
@@ -93,8 +238,6 @@ impl InnerLocalNodeExecutor {
         } else {
             panic!("not supported");
         };
-        let server_handle =
-            Self::start_node_with_listener(config, &source_path, &source_dir, &socket_path).await?;
         // Don't keep idle connections in the pool. The Node HTTP server closes
         // idle keep-alive connections after its (default 5s) `keepAliveTimeout`,
         // but hyper's pool would hold one much longer and reuse it right as the
@@ -103,26 +246,37 @@ impl InnerLocalNodeExecutor {
         let mut client_builder = Client::builder().pool_max_idle_per_host(0);
         #[cfg(unix)]
         {
-            client_builder = client_builder.unix_socket(socket_path);
+            client_builder = client_builder.unix_socket(socket_path.clone());
         }
         #[cfg(windows)]
         {
-            client_builder = client_builder.windows_named_pipe(socket_path);
+            client_builder = client_builder.windows_named_pipe(socket_path.clone());
         }
         let client = client_builder.build()?;
+        let server_handle =
+            Self::start_node_with_listener(config, &source_path, &source_dir, &socket_path).await?;
 
-        // Wait for the Node process to be ready to handle HTTP requests.
-        for _ in 0..MAX_HEALTH_CHECK_ATTEMPTS {
-            if Self::check_server_health(&client).await? {
-                return Ok(Self {
-                    _source_dir: source_dir,
-                    client,
-                    _server_handle: server_handle,
-                });
+        let executor = Self {
+            source_dir,
+            client,
+            server_handle,
+        };
+        let health_error = 'health: {
+            // Wait for the Node process to be ready to handle HTTP requests.
+            for _ in 0..MAX_HEALTH_CHECK_ATTEMPTS {
+                match Self::check_server_health(&executor.client).await {
+                    Ok(true) => return Ok(executor),
+                    Ok(false) => {},
+                    Err(error) => break 'health error,
+                }
+                tokio::time::sleep(HEALTH_CHECK_INTERVAL).await;
             }
-            tokio::time::sleep(HEALTH_CHECK_INTERVAL).await;
+            anyhow::anyhow!("Node executor server failed to start and become healthy")
+        };
+        if let Err(cleanup_error) = executor.shutdown().await {
+            tracing::warn!("Failed to stop unhealthy Node executor server: {cleanup_error:#}");
         }
-        anyhow::bail!("Node executor server failed to start and become healthy")
+        Err(health_error)
     }
 
     async fn check_node_version(node_path: &str) -> anyhow::Result<()> {
@@ -185,6 +339,8 @@ impl InnerLocalNodeExecutor {
             .arg(socket_path)
             .arg("--tempdir")
             .arg(temp_dir.path())
+            .arg("--parent-pid")
+            .arg(std::process::id().to_string())
             .kill_on_drop(true);
         if let Some(backoff) = config.callback_initial_backoff {
             cmd.env(
@@ -197,12 +353,27 @@ impl InnerLocalNodeExecutor {
 
         Ok(child)
     }
+
+    async fn shutdown(mut self) -> anyhow::Result<()> {
+        match self.server_handle.start_kill() {
+            Ok(()) => {},
+            Err(error) if error.kind() == std::io::ErrorKind::InvalidInput => {},
+            Err(error) => return Err(error).context("Failed to terminate Node executor server"),
+        }
+        self.server_handle
+            .wait()
+            .await
+            .context("Failed to wait for Node executor server to exit")?;
+        drop(self.source_dir);
+        Ok(())
+    }
 }
 
 impl LocalNodeExecutor {
     pub async fn new(node_process_timeout: Duration) -> anyhow::Result<Self> {
         let executor = Self {
-            inner: Arc::new(Mutex::new(None)),
+            inner: AsyncMutex::new(None),
+            lifecycle: Arc::new(ExecutorLifecycle::new()),
             config: LocalNodeExecutorConfig {
                 node_process_timeout,
                 callback_initial_backoff: None,
@@ -247,31 +418,54 @@ impl LocalNodeExecutor {
             }
         }
     }
-}
 
-#[async_trait]
-impl NodeExecutor for LocalNodeExecutor {
-    fn enable(&self) -> anyhow::Result<()> {
-        Ok(())
+    async fn client(&self) -> anyhow::Result<Client> {
+        loop {
+            if let Some(client) = self
+                .inner
+                .lock()
+                .await
+                .as_ref()
+                .map(|inner| inner.client.clone())
+            {
+                return Ok(client);
+            }
+
+            let _startup = self.lifecycle.begin_startup().await?;
+            if let Some(client) = self
+                .inner
+                .lock()
+                .await
+                .as_ref()
+                .map(|inner| inner.client.clone())
+            {
+                return Ok(client);
+            }
+
+            let inner = InnerLocalNodeExecutor::new(&self.config)
+                .await
+                .context("Failed to create inner local node executor")?;
+            let client = inner.client.clone();
+            *self.inner.lock().await = Some(inner);
+            return Ok(client);
+        }
     }
 
-    async fn invoke(
+    async fn discard_inner(&self) {
+        let inner = self.inner.lock().await.take();
+        if let Some(inner) = inner
+            && let Err(cleanup_error) = inner.shutdown().await
+        {
+            tracing::warn!("Failed to stop Node executor server: {cleanup_error:#}");
+        }
+    }
+
+    async fn invoke_with_client(
         &self,
+        client: reqwest::Client,
         request: ExecutorRequest,
         log_line_sender: mpsc::UnboundedSender<LogLine>,
     ) -> anyhow::Result<InvokeResponse> {
-        let client = {
-            let mut inner = self.inner.lock().await;
-            if inner.is_none() {
-                *inner = Some(
-                    InnerLocalNodeExecutor::new(&self.config)
-                        .await
-                        .context("Failed to create inner local node executor")?,
-                )
-            }
-            let inner = inner.as_ref().unwrap();
-            inner.client.clone()
-        };
         let request_json = JsonValue::try_from(request)?;
 
         let response_result = client
@@ -292,7 +486,7 @@ impl NodeExecutor for LocalNodeExecutor {
                     // Connection error likely means the Node server crashed (e.g., OOM).
                     // Drop the dead server so it will be restarted on next invoke.
                     tracing::warn!("Node server connection failed, dropping server: {e}");
-                    self.inner.lock().await.take();
+                    self.discard_inner().await;
                     return Err(anyhow::anyhow!(e).context("Node server request failed"));
                 } else {
                     return Err(anyhow::anyhow!(e).context("Node server request failed"));
@@ -323,7 +517,7 @@ impl NodeExecutor for LocalNodeExecutor {
                     .unwrap_or(false)
                 {
                     // Drop the server if it claims to be exiting.
-                    self.inner.lock().await.take();
+                    self.discard_inner().await;
                 }
                 Ok(InvokeResponse {
                     response: payload,
@@ -333,6 +527,106 @@ impl NodeExecutor for LocalNodeExecutor {
             Err(e) => Ok(e),
         }
     }
+}
 
-    fn shutdown(&self) {}
+#[async_trait]
+impl NodeExecutor for LocalNodeExecutor {
+    fn enable(&self) -> anyhow::Result<()> {
+        Ok(())
+    }
+
+    async fn invoke(
+        &self,
+        request: ExecutorRequest,
+        log_line_sender: mpsc::UnboundedSender<LogLine>,
+    ) -> anyhow::Result<InvokeResponse> {
+        let _invocation = self.lifecycle.begin_invocation()?;
+        let client = self.client().await?;
+        self.invoke_with_client(client, request, log_line_sender)
+            .await
+    }
+
+    async fn shutdown(&self) -> anyhow::Result<()> {
+        let Some(_shutdown) = self.lifecycle.begin_shutdown().await else {
+            return Ok(());
+        };
+        let inner = self.inner.lock().await.take();
+        if let Some(inner) = inner {
+            inner.shutdown().await?;
+        }
+        Ok(())
+    }
+}
+
+#[cfg(all(test, unix))]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn shutdown_stops_server_and_cleans_socket() -> anyhow::Result<()> {
+        let executor = InnerLocalNodeExecutor::new(&LocalNodeExecutorConfig {
+            node_process_timeout: Duration::from_secs(1),
+            callback_initial_backoff: None,
+        })
+        .await?;
+        let socket_path = executor.source_dir.path().join(".executor.sock");
+        assert!(socket_path.exists());
+
+        executor.shutdown().await?;
+
+        assert!(!socket_path.exists());
+        Ok(())
+    }
+
+    async fn wait_for_shutdown_to_start(lifecycle: &ExecutorLifecycle) {
+        for _ in 0..100 {
+            if !matches!(
+                lifecycle
+                    .state
+                    .lock()
+                    .expect("Executor lifecycle lock poisoned")
+                    .shutdown,
+                ExecutorShutdownState::Running
+            ) {
+                return;
+            }
+            tokio::task::yield_now().await;
+        }
+        panic!("shutdown did not start");
+    }
+
+    #[tokio::test]
+    async fn shutdown_rejects_invocation_that_could_start_replacement() {
+        let lifecycle = Arc::new(ExecutorLifecycle::new());
+        let invocation = lifecycle.begin_invocation().unwrap();
+        let shutdown_lifecycle = lifecycle.clone();
+        let shutdown = tokio::spawn(async move {
+            let shutdown = shutdown_lifecycle.begin_shutdown().await.unwrap();
+            drop(shutdown);
+        });
+
+        wait_for_shutdown_to_start(&lifecycle).await;
+        assert!(lifecycle.begin_invocation().is_err());
+
+        drop(invocation);
+        shutdown.await.unwrap();
+        assert!(lifecycle.begin_invocation().is_err());
+    }
+
+    #[tokio::test]
+    async fn shutdown_waits_for_active_invocation() {
+        let lifecycle = Arc::new(ExecutorLifecycle::new());
+        let invocation = lifecycle.begin_invocation().unwrap();
+        let shutdown_lifecycle = lifecycle.clone();
+        let shutdown = tokio::spawn(async move {
+            let shutdown = shutdown_lifecycle.begin_shutdown().await.unwrap();
+            drop(shutdown);
+        });
+
+        wait_for_shutdown_to_start(&lifecycle).await;
+        assert!(!shutdown.is_finished());
+
+        drop(invocation);
+        shutdown.await.unwrap();
+    }
 }

--- a/crates/node_executor/src/noop.rs
+++ b/crates/node_executor/src/noop.rs
@@ -29,5 +29,7 @@ impl NodeExecutor for NoopNodeExecutor {
         anyhow::bail!("NoopNodeExecutor cannot be used to invoke code.");
     }
 
-    fn shutdown(&self) {}
+    async fn shutdown(&self) -> anyhow::Result<()> {
+        Ok(())
+    }
 }

--- a/npm-packages/node-executor/src/local.test.ts
+++ b/npm-packages/node-executor/src/local.test.ts
@@ -1,0 +1,97 @@
+import { afterEach, expect, test } from "vitest";
+import { build } from "esbuild";
+import { spawn, type ChildProcess } from "node:child_process";
+import { mkdtemp, rm, stat } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+const POLL_INTERVAL_MS = 50;
+const POLL_TIMEOUT_MS = 5_000;
+
+async function waitFor(predicate: () => Promise<boolean>) {
+  const deadline = Date.now() + POLL_TIMEOUT_MS;
+  while (Date.now() < deadline) {
+    if (await predicate()) {
+      return;
+    }
+    await new Promise((resolve) => setTimeout(resolve, POLL_INTERVAL_MS));
+  }
+  throw new Error("Timed out waiting for condition");
+}
+
+async function pathExists(filePath: string) {
+  try {
+    await stat(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function processExists(pid: number) {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+let childPid: number | undefined;
+
+afterEach(() => {
+  if (childPid !== undefined && processExists(childPid)) {
+    process.kill(childPid, "SIGKILL");
+  }
+  childPid = undefined;
+});
+
+test.skipIf(process.platform === "win32")(
+  "closes its listener and exits when its supervisor is killed",
+  async () => {
+    const tempdir = await mkdtemp(path.join(os.tmpdir(), "node-executor-test-"));
+    const bundlePath = path.join(tempdir, "local.cjs");
+    const socketPath = path.join(tempdir, "executor.sock");
+    let supervisor: ChildProcess | undefined;
+    try {
+      await build({
+        bundle: true,
+        entryPoints: [path.join(process.cwd(), "src", "local.ts")],
+        outfile: bundlePath,
+        platform: "node",
+        target: "esnext",
+      });
+      const supervisorScript = `
+      const { spawn } = require("node:child_process");
+      const child = spawn(process.execPath, [
+        process.argv[1],
+        "--ipc-path", process.argv[2],
+        "--tempdir", process.argv[3],
+        "--parent-pid", String(process.pid),
+      ], { stdio: ["ignore", "ignore", "ignore"] });
+      process.stdout.write(String(child.pid));
+      setInterval(() => {}, 1_000);
+    `;
+      supervisor = spawn(
+        process.execPath,
+        ["-e", supervisorScript, bundlePath, socketPath, tempdir],
+        { stdio: ["ignore", "pipe", "inherit"] },
+      );
+      const output = await new Promise<string>((resolve, reject) => {
+        supervisor!.stdout!.once("data", (data) => resolve(data.toString()));
+        supervisor!.once("error", reject);
+      });
+      childPid = Number.parseInt(output, 10);
+      expect(childPid).toBeGreaterThan(0);
+      await waitFor(async () => pathExists(socketPath));
+
+      supervisor.kill("SIGKILL");
+      await new Promise<void>((resolve) => supervisor!.once("exit", () => resolve()));
+
+      await waitFor(async () => !pathExists(socketPath) && !processExists(childPid!));
+    } finally {
+      supervisor?.kill("SIGKILL");
+      await rm(tempdir, { force: true, recursive: true });
+    }
+  },
+);

--- a/npm-packages/node-executor/src/local.test.ts
+++ b/npm-packages/node-executor/src/local.test.ts
@@ -1,14 +1,19 @@
 import { afterEach, expect, test } from "vitest";
 import { build } from "esbuild";
-import { spawn, type ChildProcess } from "node:child_process";
+import { spawn, spawnSync, type ChildProcess } from "node:child_process";
+import { once } from "node:events";
 import { mkdtemp, rm, stat } from "node:fs/promises";
+import net from "node:net";
 import os from "node:os";
 import path from "node:path";
 
 const POLL_INTERVAL_MS = 50;
 const POLL_TIMEOUT_MS = 5_000;
 
-async function waitFor(predicate: () => Promise<boolean>) {
+async function waitFor(
+  predicate: () => Promise<boolean>,
+  timeoutMessage: () => string,
+) {
   const deadline = Date.now() + POLL_TIMEOUT_MS;
   while (Date.now() < deadline) {
     if (await predicate()) {
@@ -16,7 +21,7 @@ async function waitFor(predicate: () => Promise<boolean>) {
     }
     await new Promise((resolve) => setTimeout(resolve, POLL_INTERVAL_MS));
   }
-  throw new Error("Timed out waiting for condition");
+  throw new Error(timeoutMessage());
 }
 
 async function pathExists(filePath: string) {
@@ -37,6 +42,18 @@ function processExists(pid: number) {
   }
 }
 
+function processStatus(pid: number) {
+  const result = spawnSync(
+    "ps",
+    ["-o", "pid=,ppid=,state=,command=", "-p", String(pid)],
+    { encoding: "utf8" },
+  );
+  if (result.status === 0) {
+    return result.stdout.trim();
+  }
+  return `not listed by ps (exit ${result.status}): ${result.stderr.trim()}`;
+}
+
 let childPid: number | undefined;
 
 afterEach(() => {
@@ -53,6 +70,8 @@ test.skipIf(process.platform === "win32")(
     const bundlePath = path.join(tempdir, "local.cjs");
     const socketPath = path.join(tempdir, "executor.sock");
     let supervisor: ChildProcess | undefined;
+    let connection: net.Socket | undefined;
+    let childOutput = "";
     try {
       await build({
         bundle: true,
@@ -68,28 +87,54 @@ test.skipIf(process.platform === "win32")(
         "--ipc-path", process.argv[2],
         "--tempdir", process.argv[3],
         "--parent-pid", String(process.pid),
-      ], { stdio: ["ignore", "ignore", "ignore"] });
+      ], { stdio: ["ignore", "pipe", "pipe"] });
+      child.stdout.pipe(process.stderr);
+      child.stderr.pipe(process.stderr);
+      child.once("exit", (code, signal) => {
+        process.stderr.write(
+          "node executor exited with code " + code + " and signal " + signal + "\\n",
+        );
+      });
       process.stdout.write(String(child.pid));
       setInterval(() => {}, 1_000);
     `;
       supervisor = spawn(
         process.execPath,
         ["-e", supervisorScript, bundlePath, socketPath, tempdir],
-        { stdio: ["ignore", "pipe", "inherit"] },
+        { stdio: ["ignore", "pipe", "pipe"] },
       );
+      supervisor.stderr!.on("data", (data) => {
+        childOutput += data.toString();
+      });
       const output = await new Promise<string>((resolve, reject) => {
         supervisor!.stdout!.once("data", (data) => resolve(data.toString()));
         supervisor!.once("error", reject);
       });
       childPid = Number.parseInt(output, 10);
       expect(childPid).toBeGreaterThan(0);
-      await waitFor(async () => pathExists(socketPath));
+      await waitFor(
+        async () => pathExists(socketPath),
+        () =>
+          `Timed out waiting for socket ${socketPath} to be created; child process status: ${processStatus(childPid!)}, child output: ${childOutput || "(none)"}`,
+      );
+      connection = net.createConnection(socketPath);
+      await once(connection, "connect");
 
       supervisor.kill("SIGKILL");
       await new Promise<void>((resolve) => supervisor!.once("exit", () => resolve()));
 
-      await waitFor(async () => !pathExists(socketPath) && !processExists(childPid!));
+      await waitFor(
+        async () => !(await pathExists(socketPath)),
+        () =>
+          `Timed out waiting for socket ${socketPath} to be removed; child process status: ${processStatus(childPid!)}, child output: ${childOutput || "(none)"}`,
+      );
+      await waitFor(
+        async () => !processExists(childPid!),
+        () =>
+          `Timed out waiting for child process ${childPid} to exit; socket was removed, child process status: ${processStatus(childPid!)}, child output: ${childOutput || "(none)"}`,
+      );
     } finally {
+      connection?.destroy();
       supervisor?.kill("SIGKILL");
       await rm(tempdir, { force: true, recursive: true });
     }

--- a/npm-packages/node-executor/src/local.ts
+++ b/npm-packages/node-executor/src/local.ts
@@ -8,6 +8,7 @@ import express, { Request, Response } from "express";
 
 const DEFAULT_PORT = 3002;
 const PARENT_CHECK_INTERVAL_MS = 1_000;
+const PARENT_DEATH_FORCE_EXIT_TIMEOUT_MS = 1_000;
 
 export async function startServer(
   listenTarget: number | { path: string },
@@ -64,7 +65,15 @@ export async function startServer(
     const parentCheck = setInterval(() => {
       if (process.ppid !== parentPid) {
         clearInterval(parentCheck);
-        server.close(() => process.exit(0));
+        const forceExit = setTimeout(
+          () => process.exit(0),
+          PARENT_DEATH_FORCE_EXIT_TIMEOUT_MS,
+        );
+        forceExit.unref();
+        server.close(() => {
+          clearTimeout(forceExit);
+          process.exit(0);
+        });
       }
     }, PARENT_CHECK_INTERVAL_MS);
     parentCheck.unref();

--- a/npm-packages/node-executor/src/local.ts
+++ b/npm-packages/node-executor/src/local.ts
@@ -7,11 +7,13 @@ import http from "node:http";
 import express, { Request, Response } from "express";
 
 const DEFAULT_PORT = 3002;
+const PARENT_CHECK_INTERVAL_MS = 1_000;
 
-async function startServer(
+export async function startServer(
   listenTarget: number | { path: string },
   debug: boolean,
   tempdir: string,
+  parentPid?: number,
 ) {
   setDebugLogging(debug);
   const app = express();
@@ -58,6 +60,15 @@ async function startServer(
   });
 
   const server = http.createServer(app);
+  if (parentPid !== undefined) {
+    const parentCheck = setInterval(() => {
+      if (process.ppid !== parentPid) {
+        clearInterval(parentCheck);
+        server.close(() => process.exit(0));
+      }
+    }, PARENT_CHECK_INTERVAL_MS);
+    parentCheck.unref();
+  }
   server.listen(listenTarget, () => {
     const addr = server.address();
     const addrStr =
@@ -90,12 +101,21 @@ program
     "temporary directory to use for downloading code and dependencies",
     "",
   )
+  .option(
+    "--parent-pid <pid>",
+    "exit when this parent process no longer owns the executor",
+  )
   .action(async (options) => {
     const listenTarget =
       options.ipcPath !== undefined
         ? { path: options.ipcPath }
         : parseInt(options.port, 10);
-    await startServer(listenTarget, options.debug, options.tempdir);
+    await startServer(
+      listenTarget,
+      options.debug,
+      options.tempdir,
+      options.parentPid === undefined ? undefined : parseInt(options.parentPid, 10),
+    );
   });
 
 program.parseAsync(process.argv);


### PR DESCRIPTION
## Summary

Local Node action executor children could survive backend or supervisor crashes as PPID-1 listeners. This change:

- makes normal asynchronous shutdown drain active invocations, reject replacement starts, kill and await the child, and clean temporary resources;
- adds a Node watchdog that detects supervisor death, closes its listener, and force-exits within a bounded interval;
- adds deterministic Rust lifecycle/socket tests and a macOS SIGKILL watchdog regression test with an active Unix connection.

## Focused validation

- `rustfmt --edition 2024 --check crates/node_executor/src/{executor,local,noop}.rs crates/application/src/application_function_runner/mod.rs`
- `cargo test -p node_executor` (3 passed)
- `cargo check -p application`
- `pnpm exec turbo run build --filter=node-executor...`
- `pnpm exec vitest run src/local.test.ts` (repeated 6 times; all passed)
- `pnpm exec vitest run` (1 passed)

## Validation limitations

- Whole-tree `cargo fmt --all -- --check` reports pre-existing unrelated formatting drift outside these touched files.
- The package `npm run test` integration stage is unavailable in this revision because its referenced `test/modules` and `test/integration-test.ts` fixtures are absent; the complete available Vitest suite was run.