### PR TITLE
`queueMicrotask` global

### DIFF
--- a/npm-packages/udf-runtime/src/02_timers.ts
+++ b/npm-packages/udf-runtime/src/02_timers.ts
@@ -91,17 +91,9 @@ const unusedTimerId = () => {
   }
 };
 
-// Implementation of https://html.spec.whatwg.org/multipage/timers-and-user-prompts.html#dom-queuemicrotask
-// V8 drains its native microtask queue at the isolate's explicit checkpoints,
-// the same way Promise reaction jobs run, so unlike the timers above this
-// needs no syscall and is deterministic in every environment. Dispatching via
-// a resolved Promise means an exception thrown by the callback surfaces as an
-// unhandled rejection rather than a reported exception; both fail the UDF.
 const queueMicrotask = (callback: (...args: any[]) => void) => {
   if (typeof callback !== "function") {
-    throw new TypeError(
-      "The callback provided as parameter 1 is not a function",
-    );
+    throw new TypeError("expected a function");
   }
   void Promise.resolve().then(() => callback());
 };

--- a/npm-packages/udf-runtime/src/02_timers.ts
+++ b/npm-packages/udf-runtime/src/02_timers.ts
@@ -91,9 +91,25 @@ const unusedTimerId = () => {
   }
 };
 
+// Implementation of https://html.spec.whatwg.org/multipage/timers-and-user-prompts.html#dom-queuemicrotask
+// V8 drains its native microtask queue at the isolate's explicit checkpoints,
+// the same way Promise reaction jobs run, so unlike the timers above this
+// needs no syscall and is deterministic in every environment. Dispatching via
+// a resolved Promise means an exception thrown by the callback surfaces as an
+// unhandled rejection rather than a reported exception; both fail the UDF.
+const queueMicrotask = (callback: (...args: any[]) => void) => {
+  if (typeof callback !== "function") {
+    throw new TypeError(
+      "The callback provided as parameter 1 is not a function",
+    );
+  }
+  void Promise.resolve().then(() => callback());
+};
+
 export const setupTimers = (global) => {
   global.setTimeout = setTimeout;
   global.setInterval = setInterval;
   global.clearTimeout = clearTimeout;
   global.clearInterval = clearInterval;
+  global.queueMicrotask = queueMicrotask;
 };


### PR DESCRIPTION
<!-- Describe your PR here. -->

Effect v4's synchronous scheduler requires `queueMicrotask`, which the Convex runtime does not support; this PR adds it. I will also shortly open a PR in the Effect repo to support a runtime without `queueMicrotask` (by falling back to the same implementation here when it is not available).

The rest is a more detailed, human-massaged and Fable-written description of the problem and alternative implementations considered.

<details>

<summary>moar</summary>

## Problem

The udf-runtime installs the isolate's web API surface by hand, and `queueMicrotask` — required by the [WinterCG Minimum Common Web Platform API draft](https://common-min-api.proposal.wintercg.org/) that `setup.ts` already cites for `self` — was never among the installed globals. It is an embedder-provided HTML API, not a V8 built-in, so user code and libraries that call it bare die with `ReferenceError: queueMicrotask is not defined` in every Convex environment (queries, mutations, and actions alike).

Effect is a concrete casualty: since `effect@4.0.0-beta.103` ([Effect-TS/effect#6657](https://github.com/Effect-TS/effect/pull/6657)) its synchronous scheduler dispatches cooperative fiber yields through bare `queueMicrotask` — a change made specifically so Effect could run inside Convex's timer-restricted isolates ([Effect-TS/effect#6651](https://github.com/Effect-TS/effect/issues/6651)) — and any sync run crossing the fiber op budget crashes on the missing global. Reproduced against a local backend.

## Change

Add `queueMicrotask` to `setupTimers` in `udf-runtime/src/02_timers.ts`: a `TypeError` on non-callable input, dispatch via `Promise.resolve().then`. Unlike the timers above it, this needs no syscall and no per-environment gating — V8's native microtask queue drains at the isolate's explicit checkpoints exactly as Promise reaction jobs already do, so it is deterministic in queries and mutations, where the identical capability has always been reachable as `Promise.resolve().then`.

The implementation mirrors the portable part of deno_core's `queueMicrotask` (`01_core.js`), which this isolate links — including its exact `TypeError("expected a function")` — with `Promise.resolve().then(() => callback())` standing in for `op_queue_microtask`, which is not available since the isolate uses deno_core only for its V8 bindings and loads none of its extension JS or ops.

## Alternatives considered

- **The `queue-microtask` npm package** (the pattern used for streams/AbortController polyfills): disqualified — its fallback rethrows callback exceptions via `setTimeout(() => { throw err }, 0)`, converting a callback exception inside a query/mutation into the banned-`setTimeout` failure path.
- **A native op over V8's `EnqueueMicrotask`**: feasible (ops can take raw V8 values, cf. `structured_clone.rs`) and would give spec-perfect [report-the-exception](https://html.spec.whatwg.org/multipage/webappapis.html#report-the-exception) semantics — the one divergence of the Promise dispatch is that a throwing callback surfaces as an unhandled rejection instead. Both fail the UDF, so the difference is unobservable in practice; left as a possible follow-up for maintainers.
- **`Promise.resolve().then(callback)` without the wrapper**: subtly non-spec — the callback would observably receive `undefined` as an argument; the spec invokes it with none.

</details>

<!--
  The following applies to third-party contributors.
  Convex employees and contractors can delete or ignore.
-->

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
