### PR TITLE
Fix WorkOS AuthKit token refresh handling

### DIFF
--- a/npm-packages/@convex-dev/workos/package.json
+++ b/npm-packages/@convex-dev/workos/package.json
@@ -19,7 +19,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@workos-inc/authkit-react": "^0.16.0"
+    "@workos-inc/authkit-react": "^0.16.2"
   },
   "devDependencies": {
     "@types/react": "^18.0.0",

--- a/npm-packages/@convex-dev/workos/src/index.test.tsx
+++ b/npm-packages/@convex-dev/workos/src/index.test.tsx
@@ -1,0 +1,89 @@
+import type { ReactElement } from "react";
+import { LoginRequiredError } from "@workos-inc/authkit-react";
+import { describe, expect, it, vi } from "vitest";
+import { ConvexProviderWithAuthKit } from "./index.js";
+
+vi.mock("react", async (importOriginal) => {
+  const react = await importOriginal<typeof import("react")>();
+  return {
+    ...react,
+    useCallback: <T,>(callback: T) => callback,
+    useMemo: <T,>(factory: () => T) => factory(),
+  };
+});
+
+type GetAccessToken = (options?: {
+  forceRefresh?: boolean;
+}) => Promise<string | null>;
+
+type Adapter = {
+  fetchAccessToken(args: {
+    forceRefreshToken: boolean;
+  }): Promise<string | null>;
+};
+
+function makeFetchAccessToken(getAccessToken: GetAccessToken) {
+  const element = ConvexProviderWithAuthKit({
+    children: null,
+    client: {
+      setAuth: () => {},
+      clearAuth: () => {},
+    },
+    useAuth: () => ({
+      isLoading: false,
+      user: {},
+      getAccessToken,
+    }),
+  }) as ReactElement<{ useAuth: () => Adapter }>;
+
+  return element.props.useAuth().fetchAccessToken;
+}
+
+describe("ConvexProviderWithAuthKit", () => {
+  it("returns null when AuthKit requires login", async () => {
+    const getAccessToken = vi
+      .fn<GetAccessToken>()
+      .mockRejectedValue(new LoginRequiredError());
+    const fetchAccessToken = makeFetchAccessToken(getAccessToken);
+
+    await expect(
+      fetchAccessToken({ forceRefreshToken: false }),
+    ).resolves.toBeNull();
+  });
+
+  it("preserves transient token failures", async () => {
+    const networkError = new TypeError("Failed to fetch");
+    const getAccessToken = vi
+      .fn<GetAccessToken>()
+      .mockRejectedValue(networkError);
+    const fetchAccessToken = makeFetchAccessToken(getAccessToken);
+
+    await expect(fetchAccessToken({ forceRefreshToken: false })).rejects.toBe(
+      networkError,
+    );
+  });
+
+  it("forces AuthKit to refresh when Convex requests it", async () => {
+    const getAccessToken = vi
+      .fn<GetAccessToken>()
+      .mockResolvedValue("fresh-token");
+    const fetchAccessToken = makeFetchAccessToken(getAccessToken);
+
+    await expect(fetchAccessToken({ forceRefreshToken: true })).resolves.toBe(
+      "fresh-token",
+    );
+    expect(getAccessToken).toHaveBeenCalledWith({ forceRefresh: true });
+  });
+
+  it("uses AuthKit's ordinary cached-token flow by default", async () => {
+    const getAccessToken = vi
+      .fn<GetAccessToken>()
+      .mockResolvedValue("cached-token");
+    const fetchAccessToken = makeFetchAccessToken(getAccessToken);
+
+    await expect(fetchAccessToken({ forceRefreshToken: false })).resolves.toBe(
+      "cached-token",
+    );
+    expect(getAccessToken).toHaveBeenCalledWith();
+  });
+});

--- a/npm-packages/@convex-dev/workos/src/index.test.tsx
+++ b/npm-packages/@convex-dev/workos/src/index.test.tsx
@@ -1,6 +1,6 @@
 import type { ReactElement } from "react";
 import { LoginRequiredError } from "@workos-inc/authkit-react";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { ConvexProviderWithAuthKit } from "./index.js";
 
 vi.mock("react", async (importOriginal) => {
@@ -40,6 +40,7 @@ function makeFetchAccessToken(getAccessToken: GetAccessToken) {
 }
 
 describe("ConvexProviderWithAuthKit", () => {
+  afterEach(() => vi.useRealTimers());
   it("returns null when AuthKit requires login", async () => {
     const getAccessToken = vi
       .fn<GetAccessToken>()
@@ -49,18 +50,59 @@ describe("ConvexProviderWithAuthKit", () => {
     await expect(
       fetchAccessToken({ forceRefreshToken: false }),
     ).resolves.toBeNull();
+    expect(getAccessToken).toHaveBeenCalledTimes(1);
   });
 
-  it("preserves transient token failures", async () => {
-    const networkError = new TypeError("Failed to fetch");
+  it.each([false, true])(
+    "recovers a transient failure (forced: %s)",
+    async (forceRefreshToken) => {
+      vi.useFakeTimers();
+      const networkError = new TypeError("Failed to fetch");
+      const getAccessToken = vi
+        .fn<GetAccessToken>()
+        .mockRejectedValueOnce(networkError)
+        .mockResolvedValue("recovered-token");
+      const fetchAccessToken = makeFetchAccessToken(getAccessToken);
+
+      const result = fetchAccessToken({ forceRefreshToken });
+      await vi.advanceTimersByTimeAsync(250);
+      await expect(result).resolves.toBe("recovered-token");
+      expect(getAccessToken).toHaveBeenCalledTimes(2);
+      for (const args of getAccessToken.mock.calls) {
+        expect(args).toEqual(forceRefreshToken ? [{ forceRefresh: true }] : []);
+      }
+    },
+  );
+
+  it("settles persistent failures without rejecting or retrying forever", async () => {
+    vi.useFakeTimers();
     const getAccessToken = vi
       .fn<GetAccessToken>()
-      .mockRejectedValue(networkError);
-    const fetchAccessToken = makeFetchAccessToken(getAccessToken);
+      .mockRejectedValue(new TypeError("offline"));
+    const result = makeFetchAccessToken(getAccessToken)({
+      forceRefreshToken: true,
+    });
+    await vi.advanceTimersByTimeAsync(749);
+    expect(getAccessToken).toHaveBeenCalledTimes(2);
+    await vi.advanceTimersByTimeAsync(1);
+    await expect(result).resolves.toBeNull();
+    expect(getAccessToken).toHaveBeenCalledTimes(3);
+    expect(vi.getTimerCount()).toBe(0);
+  });
 
-    await expect(fetchAccessToken({ forceRefreshToken: false })).rejects.toBe(
-      networkError,
-    );
+  it("stops retrying if a later attempt requires login", async () => {
+    vi.useFakeTimers();
+    const getAccessToken = vi
+      .fn<GetAccessToken>()
+      .mockRejectedValueOnce(new TypeError("offline"))
+      .mockRejectedValue(new LoginRequiredError());
+    const result = makeFetchAccessToken(getAccessToken)({
+      forceRefreshToken: true,
+    });
+    await vi.advanceTimersByTimeAsync(250);
+    await expect(result).resolves.toBeNull();
+    expect(getAccessToken).toHaveBeenCalledTimes(2);
+    expect(vi.getTimerCount()).toBe(0);
   });
 
   it("forces AuthKit to refresh when Convex requests it", async () => {

--- a/npm-packages/@convex-dev/workos/src/index.tsx
+++ b/npm-packages/@convex-dev/workos/src/index.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useMemo } from "react";
 import { type ReactNode } from "react";
+import { LoginRequiredError } from "@workos-inc/authkit-react";
 import { ConvexProviderWithAuth, type AuthTokenFetcher } from "convex/react";
 
 type IConvexReactClient = {
@@ -11,7 +12,9 @@ type IConvexReactClient = {
 type UseAuth = () => {
   isLoading: boolean;
   user: any | null;
-  getAccessToken: () => Promise<string | null>;
+  getAccessToken: (options?: {
+    forceRefresh?: boolean;
+  }) => Promise<string | null>;
 };
 
 /**
@@ -46,14 +49,21 @@ function useUseAuthFromAuthKit(useAuth: UseAuth) {
       function useAuthFromWorkOS() {
         const { isLoading, user, getAccessToken } = useAuth();
 
-        const fetchAccessToken = useCallback(async () => {
-          try {
-            const token = await getAccessToken();
-            return token;
-          } catch {
-            return null;
-          }
-        }, [getAccessToken]);
+        const fetchAccessToken = useCallback(
+          async ({ forceRefreshToken }: { forceRefreshToken: boolean }) => {
+            try {
+              return await (forceRefreshToken
+                ? getAccessToken({ forceRefresh: true })
+                : getAccessToken());
+            } catch (error) {
+              if (error instanceof LoginRequiredError) {
+                return null;
+              }
+              throw error;
+            }
+          },
+          [getAccessToken],
+        );
 
         return useMemo(
           () => ({

--- a/npm-packages/@convex-dev/workos/src/index.tsx
+++ b/npm-packages/@convex-dev/workos/src/index.tsx
@@ -51,16 +51,23 @@ function useUseAuthFromAuthKit(useAuth: UseAuth) {
 
         const fetchAccessToken = useCallback(
           async ({ forceRefreshToken }: { forceRefreshToken: boolean }) => {
-            try {
-              return await (forceRefreshToken
-                ? getAccessToken({ forceRefresh: true })
-                : getAccessToken());
-            } catch (error) {
-              if (error instanceof LoginRequiredError) {
-                return null;
+            // Convex's auth manager expects a token or null, not a rejection.
+            // Retry temporary failures before reporting authentication failure.
+            for (let attempt = 0; attempt < 3; attempt++) {
+              try {
+                return await (forceRefreshToken
+                  ? getAccessToken({ forceRefresh: true })
+                  : getAccessToken());
+              } catch (error) {
+                if (error instanceof LoginRequiredError || attempt === 2) {
+                  return null;
+                }
+                await new Promise((resolve) =>
+                  setTimeout(resolve, 250 * 2 ** attempt),
+                );
               }
-              throw error;
             }
+            return null;
           },
           [getAccessToken],
         );

--- a/npm-packages/pnpm-lock.yaml
+++ b/npm-packages/pnpm-lock.yaml
@@ -498,8 +498,8 @@ importers:
   '@convex-dev/workos':
     dependencies:
       '@workos-inc/authkit-react':
-        specifier: ^0.16.0
-        version: 0.16.1(react@18.3.1)
+        specifier: ^0.16.2
+        version: 0.16.2(react@18.3.1)
       react:
         specifier: ^18.0.0 || ^19.0.0-0 || ^19.0.0
         version: 18.3.1
@@ -15698,8 +15698,8 @@ packages:
   '@workflow/serde@4.1.0':
     resolution: {integrity: sha512-pav4F2BoirECWR7Nf1TKt+2eETcBj7jj4cBefQ8VXQCA6NPkaKeLfj/zMgi+3zYV5ZIBT4GuUiphsj0/b9hPQQ==}
 
-  '@workos-inc/authkit-js@0.20.0':
-    resolution: {integrity: sha512-8+sw8eH1+XCt3NDoIB2bKKbHvq1N7CVFJeyq1uVrUWG83GCIbNNrFwWrocVNfeQJyhKsVVuDpRcp03iSVsK5Gg==}
+  '@workos-inc/authkit-js@0.20.2':
+    resolution: {integrity: sha512-EEo8VitBko7ON5shVRS4AMmgezWhWfxKKtGV7QpJMgsejKBXi0DujCFf7blR7z46z3xr3Ge55yVEMSrOMtMOzg==}
 
   '@workos-inc/authkit-nextjs@2.17.0':
     resolution: {integrity: sha512-bvy7cyfG7NAc6nRgeutYIQKAdcKfQaNZpfkGqXSXtetS6X4biudSQOHreCaZNsMWGGshN8vDK+NG/y/sv010wA==}
@@ -15708,8 +15708,8 @@ packages:
       react: ^18.0 || ^19.0.0
       react-dom: ^18.0 || ^19.0.0
 
-  '@workos-inc/authkit-react@0.16.1':
-    resolution: {integrity: sha512-u8IJsAAyZFFM02+3JhvvNTopSNQoJk/hjOoBlmOkh6j+AnVYrR8hjzJn8j3m9Vi5tRE0il7mpsEDT9fI2xRNjg==}
+  '@workos-inc/authkit-react@0.16.2':
+    resolution: {integrity: sha512-Q10bTJ3sd8zfbIlxl8KavLeHLuW7v2aJLfq+syyWsVa9VzbrBVFyr7HNxt3aAVJq1kcMfTJu1p9gSJT3Gswulg==}
     peerDependencies:
       react: '>=17'
 
@@ -43092,7 +43092,7 @@ snapshots:
 
   '@workflow/serde@4.1.0': {}
 
-  '@workos-inc/authkit-js@0.20.0': {}
+  '@workos-inc/authkit-js@0.20.2': {}
 
   '@workos-inc/authkit-nextjs@2.17.0(next@15.5.21(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.94.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -43104,9 +43104,9 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  '@workos-inc/authkit-react@0.16.1(react@18.3.1)':
+  '@workos-inc/authkit-react@0.16.2(react@18.3.1)':
     dependencies:
-      '@workos-inc/authkit-js': 0.20.0
+      '@workos-inc/authkit-js': 0.20.2
       react: 18.3.1
 
   '@workos-inc/node@7.69.2(express@5.2.1)(next@15.5.21(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.94.0))':


### PR DESCRIPTION
## Summary

- Honor Convex's `forceRefreshToken` through AuthKit's `forceRefresh` option, preserving the zero-argument cached-token flow otherwise.
- Return `null` immediately when AuthKit requires login.
- Retry other token-fetch errors up to three total attempts, waiting 250 ms and 500 ms. Persistent failures resolve to `null`; no token-fetch rejection escapes to Convex's auth manager.
- Update AuthKit React to the patch release with transient refresh-error semantics.

Related to #523. This handles short-lived failures but does not provide automatic recovery after the retry budget is exhausted. A prolonged outage can still report unauthenticated until auth is reconfigured; this PR does not claim to fully solve that case.

## Follow-up validation

- Seven adapter tests pass, covering terminal login failures, transient recovery in cached/forced modes, bounded persistent failures, and login-required during retry.
- TypeScript checking passes for the adapter and tests.
- Tests used byte-identical source copies in a small isolated environment with Convex 1.42.3 and AuthKit React 0.16.2, one Vitest worker.
- Formatting and `git diff --check` pass.
- Full monorepo lint/build and browser integration were not rerun for this follow-up.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
