### PR TITLE
Stop cached search index readers from polling deleted meta.json files, and make the archive cache ceiling configurable

### DIFF
--- a/crates/search/src/archive/cache.rs
+++ b/crates/search/src/archive/cache.rs
@@ -349,7 +349,7 @@ impl<RT: Runtime> ArchiveCacheManager<RT> {
         max_concurrent_fetches: usize,
         rt: RT,
     ) -> anyhow::Result<Self> {
-        let cleaner = CacheCleaner::new(rt.clone());
+        let cleaner = CacheCleaner::new(rt.clone(), max_size);
         let cache = AsyncLru::new(rt.clone(), max_size, max_concurrent_fetches, 200, "cache");
         let this = Self {
             path: local_storage_path.as_ref().to_owned(),
@@ -521,10 +521,11 @@ struct CacheCleaner {
 }
 
 impl CacheCleaner {
-    fn new<RT: Runtime>(rt: RT) -> Self {
+    fn new<RT: Runtime>(rt: RT, max_size: u64) -> Self {
         let (cleanup_tx, cleanup_rx) = mpsc::unbounded_channel();
-        let cleanup_handle =
-            Arc::new(rt.spawn_thread("search_cache_cleaner", || cleanup_thread(cleanup_rx)));
+        let cleanup_handle = Arc::new(rt.spawn_thread("search_cache_cleaner", move || {
+            cleanup_thread(cleanup_rx, max_size)
+        }));
         Self {
             cleanup_tx,
             _cleanup_handle: cleanup_handle,
@@ -547,18 +548,32 @@ impl CacheCleaner {
 /// recursive deletion doesn't need to be in the critical path and may block the
 /// for a meaningful amount of time as opposed to our other filesystem ops which
 /// should be quite fast.
-async fn cleanup_thread(mut rx: mpsc::UnboundedReceiver<(PathBuf, SearchFileType, u64)>) {
+async fn cleanup_thread(
+    mut rx: mpsc::UnboundedReceiver<(PathBuf, SearchFileType, u64)>,
+    max_size: u64,
+) {
     while let Some((path, search_file_type, size)) = rx.recv().await {
         // Yes, we'll panic and restart here. If we actually see panics in
         // production here, we should investigate further but for now, it's simpler
         // to disallow inconsistent filesystem state.
-        tracing::debug!("Removing path {} from disk", path.display());
         let result: io::Result<()> = try {
             clear_readonly_recursive(&path).await?;
             fs::remove_dir_all(&path).await?;
         };
         match result {
             Ok(()) => {
+                // One line per directory actually removed. This is the point
+                // where an extracted index disappears from disk, which readers
+                // still holding it cannot observe, so it is worth having in the
+                // log on deployments that scrape no metrics -- and it is bounded
+                // by the eviction rate rather than by the fetch rate, unlike the
+                // cache accounting logged at debug in `get_logged`.
+                tracing::info!(
+                    "Deleted cached search archive {} ({search_file_type:?}, {}, cache limit {})",
+                    path.display(),
+                    ByteSize(size),
+                    ByteSize(max_size),
+                );
                 metrics::subtract_bytes_by_file_type(search_file_type, size);
             },
             // Can happen if the path to clean up was never created
@@ -573,17 +588,36 @@ mod tests {
     use std::{
         io,
         path::Path,
+        sync::Arc,
         time::Duration,
     };
 
-    use common::types::SearchIndexMetricLabels;
+    use async_zip_0_0_9::{
+        write::ZipFileWriter,
+        Compression,
+        ZipEntryBuilder,
+    };
+    use bytes::Bytes;
+    use common::{
+        bounded_thread_pool::BoundedThreadPool,
+        types::{
+            ObjectKey,
+            SearchIndexMetricLabels,
+        },
+    };
     use runtime::prod::ProdRuntime;
+    use storage::{
+        LocalDirStorage,
+        Storage,
+        Upload,
+    };
     use tempfile::TempDir;
     use tokio::fs;
 
     use super::{
         clear_readonly_recursive,
         set_readonly,
+        ArchiveCacheManager,
         CacheCleaner,
         IndexTempDir,
         IndexTempDirWithSize,
@@ -650,7 +684,7 @@ mod tests {
         let cleaner_rt = rt.clone();
         rt.block_on("test_index_temp_dir", async move {
             let tmpdir = TempDir::new()?;
-            let cleaner = CacheCleaner::new(cleaner_rt);
+            let cleaner = CacheCleaner::new(cleaner_rt, bytesize::mib(1u64));
 
             // The failure path: `generate_value` builds an `IndexTempDir`
             // before the fetch starts, and when the fetch fails or times out
@@ -677,7 +711,7 @@ mod tests {
             let with_size = IndexTempDirWithSize::new(
                 IndexTempDir {
                     dir: fetched.clone(),
-                    cleaner,
+                    cleaner: cleaner.clone(),
                     search_file_type: SearchFileType::Text,
                     cleanup_on_drop: true,
                 },
@@ -693,6 +727,104 @@ mod tests {
             assert!(
                 wait_for_removal(&fetched).await,
                 "an evicted cache entry left its extracted directory behind"
+            );
+            // `ArchiveCacheManager` owns a `CacheCleaner` for its whole life;
+            // hold one here too, because dropping the last handle tears the
+            // cleaner thread down and can discard queued deletions.
+            drop(cleaner);
+            anyhow::Ok(())
+        })
+    }
+
+    /// Uploads a zip holding one stored (uncompressed) file of `size` bytes, so
+    /// that the size the cache accounts for matches the size on disk.
+    async fn upload_zip(
+        storage: &dyn Storage,
+        name: &str,
+        size: usize,
+    ) -> anyhow::Result<ObjectKey> {
+        let mut buffer = Vec::new();
+        let mut writer = ZipFileWriter::new(&mut buffer);
+        let entry = ZipEntryBuilder::new(name.to_owned(), Compression::Stored).build();
+        writer.write_entry_whole(entry, &vec![b'x'; size]).await?;
+        writer.close().await?;
+
+        let mut upload = storage.start_upload().await?;
+        upload.write(Bytes::from(buffer)).await?;
+        upload.complete().await
+    }
+
+    async fn count_entries(dir: &Path) -> anyhow::Result<usize> {
+        let mut read_dir = fs::read_dir(dir).await?;
+        let mut count = 0;
+        while read_dir.next_entry().await?.is_some() {
+            count += 1;
+        }
+        Ok(count)
+    }
+
+    /// The loop this cache exists for: fetch more archives than fit, and the
+    /// entries that fall out have to leave the disk too. Without a working
+    /// cleanup path the extracted directories just accumulate until the volume
+    /// fills.
+    #[test]
+    fn evicted_entries_are_deleted_from_disk() -> anyhow::Result<()> {
+        const ARCHIVE_BYTES: usize = 256 * 1024;
+        const ARCHIVES: usize = 6;
+        // Room for two archives, so four of the six have to be evicted.
+        const CACHE_BYTES: u64 = 2 * ARCHIVE_BYTES as u64;
+        // The cache is trimmed after an entry is added, so it can transiently
+        // hold one extra.
+        const MAX_EXTRACTED_DIRS: usize = 3;
+
+        cmd_util::env::config_test();
+        let tokio = ProdRuntime::init_tokio()?;
+        let rt = ProdRuntime::new(&tokio);
+        let inner_rt = rt.clone();
+        rt.block_on("test_eviction", async move {
+            let storage_dir = TempDir::new()?;
+            let storage: Arc<dyn Storage> = Arc::new(LocalDirStorage::new_at_path(
+                inner_rt.clone(),
+                storage_dir.path().to_owned(),
+            )?);
+            let mut keys = Vec::with_capacity(ARCHIVES);
+            for i in 0..ARCHIVES {
+                keys.push(upload_zip(&*storage, &format!("segment-{i}"), ARCHIVE_BYTES).await?);
+            }
+
+            let cache_dir = TempDir::new()?;
+            let manager = ArchiveCacheManager::new(
+                cache_dir.path(),
+                CACHE_BYTES,
+                BoundedThreadPool::new(inner_rt.clone(), 20, 4, "test_archive_cache"),
+                2,
+                inner_rt.clone(),
+            )?;
+            for key in &keys {
+                let path = manager
+                    .get(
+                        storage.clone(),
+                        key,
+                        SearchFileType::Text,
+                        SearchIndexMetricLabels::unknown(),
+                    )
+                    .await?;
+                assert!(path.exists(), "the archive we just fetched is not on disk");
+            }
+
+            // Eviction hands the directory to the cleaner thread, so the disk
+            // catches up shortly after the last fetch returns.
+            let mut extracted = usize::MAX;
+            for _ in 0..100 {
+                extracted = count_entries(cache_dir.path()).await?;
+                if extracted <= MAX_EXTRACTED_DIRS {
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(50)).await;
+            }
+            assert!(
+                extracted <= MAX_EXTRACTED_DIRS,
+                "a cache sized for 2 archives left {extracted} extracted directories on disk"
             );
             anyhow::Ok(())
         })

--- a/crates/search/src/archive/cache.rs
+++ b/crates/search/src/archive/cache.rs
@@ -59,6 +59,23 @@ struct IndexTempDir {
     dir: PathBuf,
     cleaner: CacheCleaner,
     search_file_type: SearchFileType,
+    /// Cleared once an `IndexTempDirWithSize` has taken over responsibility for
+    /// deleting `dir`.
+    cleanup_on_drop: bool,
+}
+
+impl Drop for IndexTempDir {
+    fn drop(&mut self) {
+        if !self.cleanup_on_drop {
+            return;
+        }
+        // Only reached when the fetch failed or timed out before the size of
+        // the extracted directory was known. Nothing was ever added to the
+        // cache's accounting, so there are no bytes to subtract.
+        let _ = self
+            .cleaner
+            .attempt_cleanup(self.dir.clone(), self.search_file_type, 0);
+    }
 }
 
 struct IndexTempDirWithSize {
@@ -84,13 +101,16 @@ impl Drop for IndexTempDirWithSize {
 
 impl IndexTempDirWithSize {
     pub fn new(
-        index_temp_dir: IndexTempDir,
+        mut index_temp_dir: IndexTempDir,
         metric_labels: SearchIndexMetricLabels<'static>,
         size: u64,
     ) -> Self {
+        // We take over deletion of the directory, so the fetch-failed cleanup
+        // must not also fire when `index_temp_dir` drops below.
+        index_temp_dir.cleanup_on_drop = false;
         Self {
-            dir: index_temp_dir.dir,
-            cleaner: index_temp_dir.cleaner,
+            dir: index_temp_dir.dir.clone(),
+            cleaner: index_temp_dir.cleaner.clone(),
             search_file_type: index_temp_dir.search_file_type,
             metric_labels,
             size,
@@ -275,6 +295,7 @@ impl<RT: Runtime> ArchiveFetcher<RT> {
             cleaner: self.cleaner.clone(),
             dir: destination.clone(),
             search_file_type,
+            cleanup_on_drop: true,
         };
         let new_self = self.clone();
         let new_key = key.clone();
@@ -461,6 +482,38 @@ async fn set_readonly(path: &PathBuf, readonly: bool) -> io::Result<()> {
     Ok(())
 }
 
+/// Clears the readonly bit on `path` and everything underneath it.
+///
+/// `set_readonly(_, true)` is applied to the directory the archive was
+/// extracted into, which for a `FragmentedVectorSegment` is `<uuid>/segment`,
+/// nested inside the entry's own directory. Clearing the bit on `<uuid>` alone
+/// leaves `remove_dir_all` unable to unlink the contents of the nested
+/// directory, unless the process happens to be running as root.
+async fn clear_readonly_recursive(path: &Path) -> io::Result<()> {
+    let mut stack = vec![path.to_owned()];
+    while let Some(current) = stack.pop() {
+        let metadata = match fs::symlink_metadata(&current).await {
+            Ok(metadata) => metadata,
+            Err(e) if e.kind() == io::ErrorKind::NotFound => continue,
+            Err(e) => return Err(e),
+        };
+        // Never follow a link back out of the cache directory.
+        if metadata.is_symlink() {
+            continue;
+        }
+        if metadata.permissions().readonly() {
+            set_readonly(&current, false).await?;
+        }
+        if metadata.is_dir() {
+            let mut entries = fs::read_dir(&current).await?;
+            while let Some(entry) = entries.next_entry().await? {
+                stack.push(entry.path());
+            }
+        }
+    }
+    Ok(())
+}
+
 #[derive(Clone)]
 struct CacheCleaner {
     cleanup_tx: mpsc::UnboundedSender<(PathBuf, SearchFileType, u64)>,
@@ -501,8 +554,8 @@ async fn cleanup_thread(mut rx: mpsc::UnboundedReceiver<(PathBuf, SearchFileType
         // to disallow inconsistent filesystem state.
         tracing::debug!("Removing path {} from disk", path.display());
         let result: io::Result<()> = try {
-            set_readonly(&path, false).await?;
-            fs::remove_dir_all(path).await?;
+            clear_readonly_recursive(&path).await?;
+            fs::remove_dir_all(&path).await?;
         };
         match result {
             Ok(()) => {
@@ -512,5 +565,136 @@ async fn cleanup_thread(mut rx: mpsc::UnboundedReceiver<(PathBuf, SearchFileType
             Err(e) if e.kind() == io::ErrorKind::NotFound => (),
             Err(e) => panic!("ArchiveCacheManager failed to clean up archive directory: {e:?}"),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        io,
+        path::Path,
+        time::Duration,
+    };
+
+    use common::types::SearchIndexMetricLabels;
+    use runtime::prod::ProdRuntime;
+    use tempfile::TempDir;
+    use tokio::fs;
+
+    use super::{
+        clear_readonly_recursive,
+        set_readonly,
+        CacheCleaner,
+        IndexTempDir,
+        IndexTempDirWithSize,
+    };
+    use crate::SearchFileType;
+
+    /// Reproduces the layout `extract_segment` leaves behind for a
+    /// `FragmentedVectorSegment`: the entry's directory contains a nested
+    /// `segment` directory, and it is the nested one that is marked readonly.
+    async fn write_readonly_segment_layout(entry: &Path) -> anyhow::Result<()> {
+        let segment = entry.join("segment");
+        fs::create_dir_all(&segment).await?;
+        fs::write(segment.join("payload"), b"contents").await?;
+        set_readonly(&segment, true).await?;
+        Ok(())
+    }
+
+    async fn wait_for_removal(path: &Path) -> bool {
+        for _ in 0..100 {
+            if !path.exists() {
+                return true;
+            }
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+        false
+    }
+
+    #[tokio::test]
+    async fn nested_readonly_directories_can_be_removed() -> anyhow::Result<()> {
+        let tmpdir = TempDir::new()?;
+        let entry = tmpdir.path().join("entry");
+        write_readonly_segment_layout(&entry).await?;
+
+        // What the cleanup thread used to do: clear the bit on the entry's own
+        // directory only. That is not enough to unlink the contents of the
+        // nested directory, and the resulting error takes the cleanup thread
+        // down with a panic.
+        set_readonly(&entry, false).await?;
+        match fs::remove_dir_all(&entry).await {
+            Err(e) if e.kind() == io::ErrorKind::PermissionDenied => {},
+            // Running as root, where the permission check is skipped and the
+            // old code happens to work -- which is the only reason this never
+            // fired in the container. There is nothing to regress against, so
+            // this reports a pass without having asserted anything; say so.
+            Ok(()) => {
+                eprintln!(
+                    "SKIPPED: running as root, where removing a readonly tree succeeds anyway"
+                );
+                return Ok(());
+            },
+            Err(e) => return Err(e.into()),
+        }
+
+        clear_readonly_recursive(&entry).await?;
+        fs::remove_dir_all(&entry).await?;
+        assert!(!entry.exists());
+        Ok(())
+    }
+
+    #[test]
+    fn index_temp_dir_deletes_its_directory_exactly_once() -> anyhow::Result<()> {
+        let tokio = ProdRuntime::init_tokio()?;
+        let rt = ProdRuntime::new(&tokio);
+        let cleaner_rt = rt.clone();
+        rt.block_on("test_index_temp_dir", async move {
+            let tmpdir = TempDir::new()?;
+            let cleaner = CacheCleaner::new(cleaner_rt);
+
+            // The failure path: `generate_value` builds an `IndexTempDir`
+            // before the fetch starts, and when the fetch fails or times out
+            // that value is the only thing that knows the directory exists.
+            let failed = tmpdir.path().join("failed");
+            fs::create_dir(&failed).await?;
+            fs::write(failed.join("partial"), b"half an archive").await?;
+            drop(IndexTempDir {
+                dir: failed.clone(),
+                cleaner: cleaner.clone(),
+                search_file_type: SearchFileType::Text,
+                cleanup_on_drop: true,
+            });
+            assert!(
+                wait_for_removal(&failed).await,
+                "a failed fetch left its extracted directory behind"
+            );
+
+            // The success path: `IndexTempDirWithSize` takes over. The
+            // directory has to survive the transfer -- it is about to be handed
+            // to a reader -- and be deleted when the cache entry drops.
+            let fetched = tmpdir.path().join("fetched");
+            fs::create_dir(&fetched).await?;
+            let with_size = IndexTempDirWithSize::new(
+                IndexTempDir {
+                    dir: fetched.clone(),
+                    cleaner,
+                    search_file_type: SearchFileType::Text,
+                    cleanup_on_drop: true,
+                },
+                SearchIndexMetricLabels::unknown(),
+                0,
+            );
+            tokio::time::sleep(Duration::from_millis(200)).await;
+            assert!(
+                fetched.exists(),
+                "the transfer to IndexTempDirWithSize deleted a live directory"
+            );
+            drop(with_size);
+            assert!(
+                wait_for_removal(&fetched).await,
+                "an evicted cache entry left its extracted directory behind"
+            );
+            anyhow::Ok(())
+        })
     }
 }

--- a/crates/search/src/disk_index.rs
+++ b/crates/search/src/disk_index.rs
@@ -39,6 +39,7 @@ use tantivy::{
     Index,
     IndexReader,
     IndexWriter,
+    ReloadPolicy,
 };
 use tokio::{
     fs,
@@ -84,7 +85,18 @@ pub async fn index_reader_for_directory<P: AsRef<Path>>(
     index
         .tokenizers()
         .register(CONVEX_EN_TOKENIZER, convex_en());
-    let reader = index.reader()?;
+    // These directories hold an immutable snapshot of a single already-committed
+    // segment, and nothing in this process ever commits to them, so there is
+    // never a new version to pick up. The default `ReloadPolicy::OnCommit`
+    // would spawn a thread that polls `meta.json` every 500ms for as long as
+    // the reader is alive, and readers outlive the directory they were opened
+    // from: the archive cache deletes the extracted directory when its entry is
+    // evicted while the text segment cache still holds the reader, and the
+    // poller then warns about the missing meta file twice a second forever.
+    let reader = index
+        .reader_builder()
+        .reload_policy(ReloadPolicy::Manual)
+        .try_into()?;
     timer.finish();
     Ok(reader)
 }
@@ -372,4 +384,97 @@ async fn zip_single_file<R: AsyncBufRead + Unpin, W: AsyncWrite + Unpin>(
     tokio::io::copy_buf(reader, &mut stream).await?;
     stream.close().await?;
     Ok(())
+}
+
+// Every assertion in here reads thread names out of /proc.
+#[cfg(all(test, target_os = "linux"))]
+mod tests {
+    use std::{
+        path::Path,
+        time::Duration,
+    };
+
+    use tantivy::{
+        doc,
+        schema::{
+            Schema,
+            TEXT,
+        },
+        Index,
+    };
+    use tempfile::TempDir;
+
+    use super::index_reader_for_directory;
+
+    /// Writes the shape `index_reader_for_directory` is always pointed at: a
+    /// directory holding one committed segment.
+    fn write_single_segment_index(directory: &Path) -> anyhow::Result<()> {
+        let mut schema_builder = Schema::builder();
+        let body = schema_builder.add_text_field("body", TEXT);
+        let index = Index::create_in_dir(directory, schema_builder.build())?;
+        let mut writer = index.writer_with_num_threads(1, 15_000_000)?;
+        writer.add_document(doc!(body => "hello world"))?;
+        writer.commit()?;
+        Ok(())
+    }
+
+    /// tantivy names its poller "thread-tantivy-meta-file-watcher"; Linux
+    /// truncates `comm` to 15 bytes.
+    fn meta_file_watcher_threads() -> usize {
+        std::fs::read_dir("/proc/self/task")
+            .expect("Failed to list this process's threads")
+            .filter_map(|entry| std::fs::read_to_string(entry.ok()?.path().join("comm")).ok())
+            .filter(|comm| comm.trim_end() == "thread-tantivy-")
+            .count()
+    }
+
+    /// A spawned thread names itself once it starts running, so the count only
+    /// converges shortly after `spawn` returns.
+    fn wait_for_watcher_threads(expected: usize) -> bool {
+        for _ in 0..100 {
+            if meta_file_watcher_threads() == expected {
+                return true;
+            }
+            std::thread::sleep(Duration::from_millis(50));
+        }
+        false
+    }
+
+    /// Readers opened by `index_reader_for_directory` outlive the directory
+    /// they were opened from, so they must not leave a `meta.json` poller
+    /// behind.
+    #[tokio::test]
+    async fn index_reader_for_directory_spawns_no_meta_file_watcher() -> anyhow::Result<()> {
+        let tmpdir = TempDir::new()?;
+        write_single_segment_index(tmpdir.path())?;
+        let baseline = meta_file_watcher_threads();
+
+        // Positive control: tantivy's default policy does spawn a poller for
+        // this fixture, so the assertion below fails for the right reason.
+        {
+            let index = Index::open_in_dir(tmpdir.path())?;
+            let _reader = index.reader()?;
+            assert!(
+                wait_for_watcher_threads(baseline + 1),
+                "the default ReloadPolicy should have spawned a meta file watcher"
+            );
+        }
+        // The poller notices its owner is gone within one polling interval;
+        // wait for it so the two arms cannot contaminate each other.
+        assert!(
+            wait_for_watcher_threads(baseline),
+            "the control's meta file watcher outlived its reader"
+        );
+
+        let _reader = index_reader_for_directory(tmpdir.path()).await?;
+        // Give a would-be poller the same chance to appear that the control
+        // needed.
+        std::thread::sleep(Duration::from_secs(1));
+        assert_eq!(
+            meta_file_watcher_threads(),
+            baseline,
+            "index_reader_for_directory spawned a meta file watcher"
+        );
+        Ok(())
+    }
 }

--- a/crates/search/src/searcher/in_process.rs
+++ b/crates/search/src/searcher/in_process.rs
@@ -39,6 +39,7 @@ use super::{
         TokenMatch,
         TokenQuery,
     },
+    searchlight_knobs::SEARCHLIGHT_DISK_CACHE_MIB,
     FragmentedTextStorageKeys,
     SearcherImpl,
     TermValue,
@@ -144,7 +145,7 @@ impl<RT: Runtime> InProcessSearcher<RT> {
         Ok(Self {
             searcher: Arc::new(SearcherImpl::new(
                 tmpdir.path(),
-                bytesize::mib(500u64),
+                bytesize::mib(*SEARCHLIGHT_DISK_CACHE_MIB),
                 100,
                 false,
                 runtime,

--- a/crates/search/src/searcher/searchlight_knobs.rs
+++ b/crates/search/src/searcher/searchlight_knobs.rs
@@ -54,6 +54,17 @@ pub static MAX_CONCURRENT_SEGMENT_COMPACTIONS: LazyLock<usize> =
 pub static MAX_CONCURRENT_SEGMENT_FETCHES: LazyLock<usize> =
     LazyLock::new(|| env_config("MAX_CONCURRENT_SEGMENT_FETCHES", 8));
 
+/// The maximum size, in MiB, of the on-disk cache of extracted search
+/// indexes (`ArchiveCacheManager`).
+///
+/// The cache evicts by total size, and evicting an entry deletes the
+/// directory it was extracted into, so this bounds the disk footprint of the
+/// searcher's local storage path. Deployments whose working set of segments
+/// exceeds this limit will re-fetch and re-extract segments continuously;
+/// raise it to trade disk for fetch traffic.
+pub static SEARCHLIGHT_DISK_CACHE_MIB: LazyLock<u64> =
+    LazyLock::new(|| env_config("SEARCHLIGHT_DISK_CACHE_MIB", 500));
+
 /// The maximum number of concurrent vector searches we'll run at once,
 /// based on a very rough estimate of memory used per search.
 ///


### PR DESCRIPTION
## Problem

#525 describes an in-process searcher whose archive disk cache and segment LRUs are uncoordinated, and lists three consequences: RAM held by deleted-but-mapped segments, a `meta.json` watcher log flood, and ENOENT query failures. This PR does not implement the coordination fix (suggestion 1 in that issue); it takes suggestions 2 and 3, which stand on their own, and adds two cleanup bugs found while reading that code.

We hit the same thing on an unrelated self-hosted deployment and arrived at the same two mechanisms independently, which is why they are proposed separately: neither depends on the larger refcounting change, and both are useful whether or not it lands.

## The watcher flood is unbounded in time, not just in volume

`index_reader_for_directory` is only ever pointed at a directory the archive cache extracted: an immutable snapshot of one already-committed segment. Both call sites assert `segment_readers().len() == 1`, take `reader.searcher()` immediately, and never reload. Nothing in the process commits to those directories, so the default `ReloadPolicy::OnCommit` buys nothing and costs a thread per reader polling `meta.json` every 500 ms.

The poll outlives the file. Once the archive cache deletes the extracted directory, the watcher cannot stop or succeed: `compute_checksum` logs `Failed to open meta file` and the thread sleeps and retries forever. On our instance that was a sustained ~137 lines/sec, several GB of JSON logs per day, from watchers that can never recover. #525 reports 117 lines/sec from the same mechanism.

`ReloadPolicy::Manual` registers no watch callback at all, so no thread is spawned.

## Two cleanup bugs in the archive cache

Both let extracted directories outlive the entry that owns them, and neither is mentioned in #525.

**`IndexTempDir` never had the `Drop` its construction site documents.** The comment at the call site reads "Create this right away so its Drop impl (which deletes the path) runs even on failure", but only `IndexTempDirWithSize` has one, and a fetch reaches that type only after it knows the extracted size. A fetch that fails or times out after `extract_archive` created the directory therefore drops the handle without deleting anything, leaking a directory that nothing will ever account for or clean up. This PR gives `IndexTempDir` the `Drop` it was documented to have, disarmed when `IndexTempDirWithSize` takes over so the transfer does not schedule a deletion of a live entry.

**The cleanup thread clears the readonly bit on the wrong directory.** It clears it on the entry's top-level directory, but the `FragmentedVectorSegment` path extracts into a nested `<uuid>/segment` and marks *that* readonly. Removing the tree then has to unlink files inside a directory with no write bit, which fails with `EACCES` for any process not running as root — and that error hits the `panic!` arm. Since the release profile sets `panic = "abort"`, that is a process abort on the first such eviction, not a silently dead cleanup thread. It is masked today only because the published image runs as root. This PR clears the bit recursively; the `panic!` arm is left alone, so any other IO error still behaves as before.

## Configurable ceiling

`SEARCHLIGHT_DISK_CACHE_MIB` (default 500, unchanged behavior) joins the other `env_config` knobs in `searchlight_knobs.rs`. As #525 notes, this was the only piece of the searcher without one. `SearcherImpl::new` already logs the effective ceiling at startup, so the configured value is visible without a metrics endpoint.

## Observability

`SEARCHLIGHT_USED_BYTES` already tracks the cache's disk usage, but a self-hosted backend exports no Prometheus endpoint, so on those deployments there is no way to tell a working cache from one that is thrashing. This PR logs one line per directory the cleaner actually removes, with its size and the configured ceiling. The rate is bounded by evictions, not by cache hits — deliberately not the per-fetch "space used" accounting next to it, which stays at `debug` precisely because log volume is the failure mode being addressed.

## Tests

`crates/search` had no test module; this PR adds one.

- `index_reader_for_directory_spawns_no_meta_file_watcher` — asserts no watcher thread exists after opening a reader, with a **positive control** that first asserts tantivy's default policy *does* spawn one for the same fixture, so a zero cannot mean the fixture was wrong. Linux-only: it reads thread names from `/proc`.
- `nested_readonly_directories_can_be_removed` — builds the `<uuid>/segment` layout with the readonly bit where `extract_segment` puts it, asserts the old sequence fails with `PermissionDenied`, then that the recursive clear succeeds. Running as root it self-skips (there is nothing to regress against) and says so on stderr.
- `index_temp_dir_deletes_its_directory_exactly_once` — the failure path, the transfer to `IndexTempDirWithSize` (which must *not* delete a live directory), and eviction.
- `evicted_entries_are_deleted_from_disk` — drives real evictions through `ArchiveCacheManager`: six archives into a cache sized for two, asserting the extracted directories leave the disk. Under `RUST_LOG=search=info` it also shows the new log line firing exactly four times, once per eviction and never per fetch.

Each fix was checked by reverting it with its test in place; each corresponding test fails. Validation: `cargo test -p search` green, `cargo fmt` clean, `cargo clippy -p search --lib --tests` introduces no new warnings. Each commit builds and passes on its own.

`cargo clippy -p search --all-targets` currently fails on `benches/memory_index.rs` (`unresolved import value::assert_obj`) on `main`, independently of this PR.

## What this does not do

It does not coordinate the two caches, which is the root cause in #525 and the only thing that removes the race. With this PR the operator can raise the disk ceiling until the working set fits, which is what the issue reporter achieved by tuning the LRU knobs — still tuning around the race rather than removing it. The log flood, however, is gone outright: with no watcher there is nothing left to flood.

We have not yet run a patched build in production, so there is no before/after RSS measurement here — the evidence is the tests above plus the production symptom measurements described in #525 and repeated on our own instance.

Addresses #525.
