### PR TITLE
search: make the in-process searcher's archive cache size configurable

### DIFF
--- a/crates/search/src/searcher/in_process.rs
+++ b/crates/search/src/searcher/in_process.rs
@@ -4,6 +4,7 @@ use std::collections::BTreeMap;
 /// - InProcessSearcher implementation
 use std::sync::Arc;
 
+use anyhow::Context as _;
 use async_trait::async_trait;
 use common::{
     bootstrap_model::index::{
@@ -138,19 +139,60 @@ pub struct InProcessSearcher<RT: Runtime> {
     _tmpdir: Arc<TempDir>,
 }
 
+/// Resolve the archive disk-cache size in bytes from the
+/// `MAX_ARCHIVE_CACHE_SIZE_MIB` knob, rejecting values that cannot work:
+/// zero (a cache that evicts every segment immediately after fetch
+/// reintroduces the deleted-segment ENOENT race the knob exists to prevent)
+/// and values whose byte size overflows a `u64` (this build aborts on
+/// arithmetic overflow).
+fn archive_cache_size_bytes(cache_size_mib: u64) -> anyhow::Result<u64> {
+    anyhow::ensure!(
+        cache_size_mib > 0,
+        "MAX_ARCHIVE_CACHE_SIZE_MIB must be greater than zero",
+    );
+    cache_size_mib.checked_mul(bytesize::MIB).with_context(|| {
+        format!("MAX_ARCHIVE_CACHE_SIZE_MIB={cache_size_mib} overflows the u64 byte size")
+    })
+}
+
 impl<RT: Runtime> InProcessSearcher<RT> {
     pub fn new(runtime: RT) -> anyhow::Result<Self> {
         let tmpdir = TempDir::new()?;
+        let max_disk_cache_size =
+            archive_cache_size_bytes(*super::searchlight_knobs::MAX_ARCHIVE_CACHE_SIZE_MIB)?;
         Ok(Self {
             searcher: Arc::new(SearcherImpl::new(
                 tmpdir.path(),
-                bytesize::mib(500u64),
+                max_disk_cache_size,
                 100,
                 false,
                 runtime,
             )?),
             _tmpdir: Arc::new(tmpdir),
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::archive_cache_size_bytes;
+
+    #[test]
+    fn archive_cache_size_default_is_500_mib() {
+        assert_eq!(
+            archive_cache_size_bytes(500).unwrap(),
+            bytesize::mib(500u64)
+        );
+    }
+
+    #[test]
+    fn archive_cache_size_rejects_zero() {
+        assert!(archive_cache_size_bytes(0).is_err());
+    }
+
+    #[test]
+    fn archive_cache_size_rejects_u64_overflow() {
+        assert!(archive_cache_size_bytes(u64::MAX).is_err());
     }
 }
 

--- a/crates/search/src/searcher/in_process.rs
+++ b/crates/search/src/searcher/in_process.rs
@@ -139,12 +139,9 @@ pub struct InProcessSearcher<RT: Runtime> {
     _tmpdir: Arc<TempDir>,
 }
 
-/// Resolve the archive disk-cache size in bytes from the
-/// `MAX_ARCHIVE_CACHE_SIZE_MIB` knob, rejecting values that cannot work:
-/// zero (a cache that evicts every segment immediately after fetch
-/// reintroduces the deleted-segment ENOENT race the knob exists to prevent)
-/// and values whose byte size overflows a `u64` (this build aborts on
-/// arithmetic overflow).
+/// Resolve MAX_ARCHIVE_CACHE_SIZE_MIB into bytes, rejecting zero (a cache that
+/// evicts every segment immediately after fetch) and sizes whose byte count
+/// overflows u64.
 fn archive_cache_size_bytes(cache_size_mib: u64) -> anyhow::Result<u64> {
     anyhow::ensure!(
         cache_size_mib > 0,

--- a/crates/search/src/searcher/searchlight_knobs.rs
+++ b/crates/search/src/searcher/searchlight_knobs.rs
@@ -98,3 +98,20 @@ pub static MAX_TEXT_LRU_ENTRIES: LazyLock<u64> =
 /// so this knob also determines the maximum queue length.
 pub static MAX_CONCURRENT_TEXT_SEARCHES: LazyLock<usize> =
     LazyLock::new(|| env_config("MAX_CONCURRENT_TEXT_SEARCHES", 20));
+
+/// The size in MiB of the on-disk archive cache used by the in-process
+/// searcher (self-hosted backends) for unpacked text/vector index segments.
+///
+/// Lower bound: must be greater than zero — a zero-size cache evicts every
+/// segment immediately after fetch. Upper bound: the byte size must fit in a
+/// `u64`. Both are enforced when the searcher is constructed. There is no
+/// useful maximum beyond that; the practical guidance is to set this
+/// comfortably above the total unpacked size of the deployment's search
+/// indexes, because a cache smaller than that working set repeatedly evicts
+/// segment directories that the in-memory segment LRUs
+/// (MAX_TEXT_LRU_ENTRIES / MAX_VECTOR_LRU_ENTRIES) still reference —
+/// surfacing as intermittent "No such file or directory" search failures,
+/// a tantivy meta.json file-watcher log flood, and memory growth from
+/// deleted-but-mapped segment files.
+pub static MAX_ARCHIVE_CACHE_SIZE_MIB: LazyLock<u64> =
+    LazyLock::new(|| env_config("MAX_ARCHIVE_CACHE_SIZE_MIB", 500));

--- a/crates/search/src/searcher/searchlight_knobs.rs
+++ b/crates/search/src/searcher/searchlight_knobs.rs
@@ -99,19 +99,10 @@ pub static MAX_TEXT_LRU_ENTRIES: LazyLock<u64> =
 pub static MAX_CONCURRENT_TEXT_SEARCHES: LazyLock<usize> =
     LazyLock::new(|| env_config("MAX_CONCURRENT_TEXT_SEARCHES", 20));
 
-/// The size in MiB of the on-disk archive cache used by the in-process
-/// searcher (self-hosted backends) for unpacked text/vector index segments.
-///
-/// Lower bound: must be greater than zero — a zero-size cache evicts every
-/// segment immediately after fetch. Upper bound: the byte size must fit in a
-/// `u64`. Both are enforced when the searcher is constructed. There is no
-/// useful maximum beyond that; the practical guidance is to set this
-/// comfortably above the total unpacked size of the deployment's search
-/// indexes, because a cache smaller than that working set repeatedly evicts
-/// segment directories that the in-memory segment LRUs
-/// (MAX_TEXT_LRU_ENTRIES / MAX_VECTOR_LRU_ENTRIES) still reference —
-/// surfacing as intermittent "No such file or directory" search failures,
-/// a tantivy meta.json file-watcher log flood, and memory growth from
-/// deleted-but-mapped segment files.
+/// The size in MiB of the on-disk archive cache the in-process searcher uses
+/// for unpacked text and vector segments. Set this above the deployment's
+/// total unpacked segment size: a smaller cache evicts directories that the
+/// segment LRUs (MAX_TEXT_LRU_ENTRIES / MAX_VECTOR_LRU_ENTRIES) still hold
+/// open. Must be greater than zero; validated when the searcher is built.
 pub static MAX_ARCHIVE_CACHE_SIZE_MIB: LazyLock<u64> =
     LazyLock::new(|| env_config("MAX_ARCHIVE_CACHE_SIZE_MIB", 500));


### PR DESCRIPTION
`InProcessSearcher::new` hardcodes the on-disk archive cache at `bytesize::mib(500u64)`. That cache holds the *unpacked* text and vector segments, and it is not coordinated with the in-memory segment LRUs (`MAX_TEXT_LRU_ENTRIES` / `MAX_VECTOR_LRU_ENTRIES`), which key on path and are sized by entry count rather than bytes.

Once a deployment's unpacked working set passes 500 MiB, the two caches disagree: the disk cache evicts a segment directory while an LRU still holds that segment open. Re-opening it then fails. Symptoms, in the order they usually get noticed:

- intermittent `No such file or directory (os error 2)` surfacing out of `vectorSearch`, retried successfully on the next attempt because the segment is re-fetched under a fresh path
- a tantivy `meta.json` file-watcher log flood from watchers polling directories that no longer exist
- memory growth from deleted-but-mapped segment files, which stay resident until the LRU entry is finally evicted

This affects self-hosted backends, where `InProcessSearcher` is the searcher.

### Evidence

A/B on identical data (40k chunks, ~490 MiB of segments, both LRUs capped at 4 so the disk cache is the only variable), same binary with only this knob changed:

| archive cache | searches OK | ENOENT |
|---|---|---|
| 100 MiB (below working set) | 0 / 250 | 289 |
| 2048 MiB (above working set) | 400 / 400 | 0 |

At 100 MiB the backend additionally aborted after five runs (exit 133), which is the failure mode when a mapped segment disappears underneath a live searcher.

### The change

Expose the size as `MAX_ARCHIVE_CACHE_SIZE_MIB` next to the other searchlight knobs, defaulting to 500 so behaviour is identical unless the knob is set. Two values are rejected at construction rather than silently accepted:

- **zero** — a cache that evicts every segment immediately after fetch reintroduces exactly the race the knob exists to avoid
- **sizes whose byte count overflows `u64`** — the release profile aborts on arithmetic overflow, so this would be a panic rather than an error

The resolution lives in a small free function with unit tests for the default, the zero case, and the overflow case.

### Notes

This is the smallest change that makes the problem addressable by operators; it does not fix the underlying coherence issue between the disk cache and the segment LRUs, which is described in #525. #317 and #192 report the same ENOENT and are, I believe, the same root cause.

Formatted with the repo's pinned nightly `rustfmt`.
