### PR TITLE
storage: make LocalDirStorage::delete_object idempotent

### DIFF
--- a/crates/storage/src/lib.rs
+++ b/crates/storage/src/lib.rs
@@ -1222,14 +1222,10 @@ impl Display for StorageUseCase {
     }
 }
 
-/// Core of `LocalDirStorage`'s [`Storage::delete_object`], kept as a free
-/// function so the deletion semantics are unit-testable.
-///
-/// Deleting an already-absent object succeeds, matching S3 DeleteObject
-/// semantics: delete means "ensure it is gone". Only a missing object is
-/// tolerated — if the storage root itself is gone (unmounted or wiped),
-/// report the error rather than letting the caller commit a delete that
-/// never durably happened.
+/// Body of `LocalDirStorage::delete_object`, kept as a free function so the
+/// semantics are unit-testable. An already-absent object is a success, as in
+/// S3 DeleteObject. A missing storage root is not: that would let the caller
+/// commit a delete that never durably happened.
 fn remove_local_object(storage_root: &Path, path: PathBuf) -> anyhow::Result<()> {
     if let Err(e) = fs::remove_file(path) {
         if e.kind() == io::ErrorKind::NotFound && storage_root.exists() {

--- a/crates/storage/src/lib.rs
+++ b/crates/storage/src/lib.rs
@@ -1096,8 +1096,7 @@ impl<RT: Runtime> Storage for LocalDirStorage<RT> {
     async fn delete_object(&self, key: &ObjectKey) -> anyhow::Result<()> {
         let key = self.filename_for_key(key.clone());
         let path = self.dir.join(key);
-        fs::remove_file(path)?;
-        Ok(())
+        remove_local_object(&self.dir, path)
     }
 
     async fn put_object(&self, key: ObjectKey, bytes: Bytes) -> anyhow::Result<()> {
@@ -1220,5 +1219,82 @@ impl Display for StorageUseCase {
             StorageUseCase::Files => write!(f, "files"),
             StorageUseCase::SearchIndexes => write!(f, "search"),
         }
+    }
+}
+
+/// Core of `LocalDirStorage`'s [`Storage::delete_object`], kept as a free
+/// function so the deletion semantics are unit-testable.
+///
+/// Deleting an already-absent object succeeds, matching S3 DeleteObject
+/// semantics: delete means "ensure it is gone". Only a missing object is
+/// tolerated — if the storage root itself is gone (unmounted or wiped),
+/// report the error rather than letting the caller commit a delete that
+/// never durably happened.
+fn remove_local_object(storage_root: &Path, path: PathBuf) -> anyhow::Result<()> {
+    if let Err(e) = fs::remove_file(path) {
+        if e.kind() == io::ErrorKind::NotFound && storage_root.exists() {
+            return Ok(());
+        }
+        return Err(e.into());
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use tempfile::TempDir;
+
+    use super::remove_local_object;
+
+    #[test]
+    fn removes_existing_file() -> anyhow::Result<()> {
+        let root = TempDir::new()?;
+        let path = root.path().join("blob-1.blob");
+        std::fs::write(&path, b"payload")?;
+        remove_local_object(root.path(), path.clone())?;
+        assert!(!path.exists());
+        Ok(())
+    }
+
+    #[test]
+    fn delete_is_idempotent() -> anyhow::Result<()> {
+        let root = TempDir::new()?;
+        let path = root.path().join("deleted-twice.blob");
+        std::fs::write(&path, b"payload")?;
+        remove_local_object(root.path(), path.clone())?;
+        // The object is already gone, which is success under S3 DeleteObject
+        // semantics — not an ENOENT crash.
+        remove_local_object(root.path(), path)?;
+        Ok(())
+    }
+
+    #[test]
+    fn never_existed_is_ok() -> anyhow::Result<()> {
+        let root = TempDir::new()?;
+        remove_local_object(root.path(), root.path().join("never-existed.blob"))?;
+        Ok(())
+    }
+
+    #[test]
+    fn missing_storage_root_is_error() -> anyhow::Result<()> {
+        let root = TempDir::new()?;
+        let path = root.path().join("any.blob");
+        // A vanished storage root (unmounted or wiped) must NOT be treated as
+        // a successful delete — the caller would commit a removal that never
+        // durably happened.
+        std::fs::remove_dir_all(root.path())?;
+        assert!(remove_local_object(root.path(), path).is_err());
+        Ok(())
+    }
+
+    #[test]
+    fn directory_at_path_stays_an_error() -> anyhow::Result<()> {
+        let root = TempDir::new()?;
+        let path = root.path().join("actually-a-dir.blob");
+        std::fs::create_dir(&path)?;
+        // Only NotFound is tolerated; any other failure kind (here: trying to
+        // remove_file a directory) must keep surfacing.
+        assert!(remove_local_object(root.path(), path).is_err());
+        Ok(())
     }
 }


### PR DESCRIPTION
`LocalDirStorage::delete_object` calls `fs::remove_file` and propagates its error, so deleting an object that is already gone returns `ENOENT` instead of succeeding. Every other `Storage` implementation here is backed by S3 semantics, where `DeleteObject` on a missing key is a success — "delete" means "ensure it is gone", not "remove exactly once".

The practical effect on a self-hosted backend is that `SystemTableCleanupWorker` dies whenever it encounters an `_exports` row whose blob is no longer on disk. Because that worker deletes from several system tables in sequence, one unremovable object stops the rest of the cleanup as well: `_exports` blobs, source packages and `_session_requests` all stop being reclaimed, and the retry loop reproduces the same crash on the next tick indefinitely. On one deployment this ran at roughly 95 failures/day for five weeks, and the wedge is in the data rather than the process, so restarts do not clear it.

### The change

Treat a missing object as success — but only a missing object. If the storage root itself has vanished (volume unmounted, directory wiped), the error still surfaces, because in that case the caller would otherwise commit a deletion that never durably happened. That distinction is the reason this is a few lines rather than one.

The body is factored into a free function so the semantics can be unit-tested without constructing a `Runtime`. Five tests cover: removing an existing file, deleting twice, deleting something that never existed, a vanished storage root (must error), and a directory at the path (must keep erroring — only `NotFound` is tolerated).

### Notes

Root-cause write-up for the wider issue is in #525; this half of it stands on its own.

Formatted with the repo's pinned nightly `rustfmt`.
