### PR TITLE
Fix Windows local executor lifecycle

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -48,6 +48,48 @@ Build and run the local backend from the source in this repo:
 just run-local-backend
 ```
 
+#### Local process lifecycle on Windows
+
+The Convex CLI owns every local backend it starts. Current CLI and backend
+versions keep the backend's standard input connected; closing that pipe asks the
+backend to drain requests, stop workers, and remove its temporary files. The
+pipe also closes when the CLI exits unexpectedly. On Windows, the CLI starts
+current backends in a hidden, detached process group. This prevents Windows from
+ending the backend with its Node parent before the backend can observe the
+closed pipe.
+
+The local backend owns each Node action executor. On Windows it assigns the
+executor to a Job Object configured with `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE`.
+Windows therefore terminates the executor if the backend is terminated before
+Rust cleanup can run. During an ordinary shutdown, the backend stops and reaps
+the executor before removing its temporary directory. Removal uses a short,
+fixed retry window for transient Windows sharing violations and reports a
+persistent cleanup failure instead of silently leaking the directory.
+
+Run the focused Windows lifecycle tests after changing this boundary:
+
+```powershell
+cargo test -p node_executor force_killing_job_owner_terminates_assigned_process
+cargo test -p node_executor ordinary_drop_stops_executor_and_removes_temp_dir
+cargo test -p node_executor explicit_shutdown_stops_executor_and_removes_temp_dir
+cargo test -p node_executor force_killing_launcher_triggers_clean_executor_shutdown
+```
+
+The first test force-terminates the process that owns a Job Object and verifies
+that the assigned process does not survive. The next two exercise Drop and the
+explicit application shutdown interface. The final test force-terminates a
+launcher that owns the backend's stdin pipe, then verifies that the backend
+closes the Node executor, named pipe, and temporary directory before exiting.
+
+The lifecycle contract activates when the installed CLI and downloaded local
+backend both contain this change. Verify activation by running a Node action,
+ending `convex dev`, and confirming that its backend PID, executor PID,
+`cvx-node-executor-*` pipe, and `.tmp*` executor directory are absent. To roll
+back while diagnosing an unrelated regression, pass the previous release tag
+through the CLI's hidden `--local-backend-version` option. That rollback also
+restores the previous Windows teardown behavior, so stop the current backend
+cleanly and inspect its process tree before switching versions.
+
 ### Provisioning a demo app locally
 
 This example will go through running the backend with the included demo project.

--- a/BUILD.md
+++ b/BUILD.md
@@ -85,10 +85,11 @@ The lifecycle contract activates when the installed CLI and downloaded local
 backend both contain this change. Verify activation by running a Node action,
 ending `convex dev`, and confirming that its backend PID, executor PID,
 `cvx-node-executor-*` pipe, and `.tmp*` executor directory are absent. To roll
-back while diagnosing an unrelated regression, pass the previous release tag
-through the CLI's hidden `--local-backend-version` option. That rollback also
-restores the previous Windows teardown behavior, so stop the current backend
-cleanly and inspect its process tree before switching versions.
+back while diagnosing an unrelated regression, use the previous CLI release
+with its matching backend release. A current CLI may add arguments that a
+pre-lifecycle backend cannot parse. Stop the current backend cleanly and inspect
+its process tree before switching versions; the older pair restores the
+previous Windows teardown behavior.
 
 ### Provisioning a demo app locally
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6704,6 +6704,7 @@ dependencies = [
  "tracing",
  "udf",
  "value",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -266,6 +266,7 @@ value = { path = "crates/value" }
 vector = { path = "crates/vector" }
 vergen = { version = "8.1.0" }
 walkdir = "2"
+windows-sys = { version = "0.61.2", features = [ "Win32_Foundation", "Win32_System_JobObjects", "Win32_System_Threading" ] }
 xorf = { git = "https://github.com/sujayakar/xorf.git", rev = "62a32de47bb3ad8b34d6d4feac034a24be2c881a" }
 
 [profile.release]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -266,7 +266,7 @@ value = { path = "crates/value" }
 vector = { path = "crates/vector" }
 vergen = { version = "8.1.0" }
 walkdir = "2"
-windows-sys = { version = "0.61.2", features = [ "Win32_Foundation", "Win32_System_JobObjects", "Win32_System_Threading" ] }
+windows-sys = { version = "0.61.2", features = [ "Win32_Foundation", "Win32_System_Diagnostics_ToolHelp", "Win32_System_JobObjects", "Win32_System_Threading" ] }
 xorf = { git = "https://github.com/sujayakar/xorf.git", rev = "62a32de47bb3ad8b34d6d4feac034a24be2c881a" }
 
 [profile.release]

--- a/crates/application/src/application_function_runner/mod.rs
+++ b/crates/application/src/application_function_runner/mod.rs
@@ -772,7 +772,7 @@ impl<RT: Runtime> ApplicationFunctionRunner<RT> {
     }
 
     pub(crate) async fn shutdown(&self) -> anyhow::Result<()> {
-        self.node_actions.shutdown();
+        self.node_actions.shutdown().await?;
         Ok(())
     }
 

--- a/crates/local_backend/src/config.rs
+++ b/crates/local_backend/src/config.rs
@@ -120,6 +120,11 @@ pub struct LocalConfig {
     #[clap(long, hide = true)]
     pub beacon_fields: Option<JsonValue>,
 
+    /// Shut down cleanly when the process that launched this local backend
+    /// closes stdin. The Convex CLI uses this to own the backend lifetime.
+    #[clap(long, hide = true)]
+    pub shutdown_on_stdin_close: bool,
+
     /// If set, logs will be redacted from clients. Set this on production
     /// deployments, to prevent information like stacktraces of serverside
     /// code from being leaked to clients.
@@ -248,5 +253,4 @@ impl LocalConfig {
             }
         }
     }
-
 }

--- a/crates/local_backend/src/main.rs
+++ b/crates/local_backend/src/main.rs
@@ -1,4 +1,7 @@
-use std::time::Duration;
+use std::{
+    io::Read,
+    time::Duration,
+};
 
 use clap::Parser;
 use cmd_util::env::{
@@ -45,10 +48,6 @@ use local_backend::{
 };
 use runtime::prod::ProdRuntime;
 use tokio::{
-    io::{
-        self,
-        AsyncReadExt,
-    },
     signal::{
         self,
     },
@@ -271,11 +270,25 @@ async fn wait_for_stdin_close(enabled: bool) -> anyhow::Result<()> {
         return std::future::pending().await;
     }
 
-    let mut stdin = io::stdin();
-    let mut buffer = [0; 256];
-    loop {
-        if stdin.read(&mut buffer).await? == 0 {
-            return Ok(());
-        }
-    }
+    let (closed_tx, closed_rx) = oneshot::channel();
+    // Tokio implements stdin with a runtime-owned blocking read. If another
+    // shutdown path wins, dropping that future can leave runtime teardown
+    // waiting for the read forever. A detached OS thread may remain blocked,
+    // but it does not hold the Tokio runtime open and exits with the process.
+    std::thread::Builder::new()
+        .name("local-backend-stdin-close".to_owned())
+        .spawn(move || {
+            let mut stdin = std::io::stdin();
+            let mut buffer = [0; 256];
+            let result = loop {
+                match stdin.read(&mut buffer) {
+                    Ok(0) => break Ok(()),
+                    Ok(_) => {},
+                    Err(error) => break Err(error),
+                }
+            };
+            let _ = closed_tx.send(result);
+        })?;
+    closed_rx.await??;
+    Ok(())
 }

--- a/crates/local_backend/src/main.rs
+++ b/crates/local_backend/src/main.rs
@@ -45,6 +45,10 @@ use local_backend::{
 };
 use runtime::prod::ProdRuntime;
 use tokio::{
+    io::{
+        self,
+        AsyncReadExt,
+    },
     signal::{
         self,
     },
@@ -137,6 +141,7 @@ async fn run_server(runtime: ProdRuntime, config: LocalConfig) -> anyhow::Result
 }
 
 async fn run_server_inner(runtime: ProdRuntime, config: LocalConfig) -> anyhow::Result<()> {
+    let shutdown_on_stdin_close = config.shutdown_on_stdin_close;
     // Used to receive fatal errors from the database or /preempt endpoint.
     let (preempt_tx, preempt_rx) = oneshot::channel();
     let preempt_signal = ShutdownSignal::new(preempt_tx);
@@ -184,6 +189,8 @@ async fn run_server_inner(runtime: ProdRuntime, config: LocalConfig) -> anyhow::
 
     let serve_future = future::try_join(serve_http_future, proxy_future).fuse();
     futures::pin_mut!(serve_future);
+    let stdin_close_future = wait_for_stdin_close(shutdown_on_stdin_close).fuse();
+    futures::pin_mut!(stdin_close_future);
 
     // Start shutdown when we get a manual shutdown signal or with the first
     // ctrl-c.
@@ -202,6 +209,11 @@ async fn run_server_inner(runtime: ProdRuntime, config: LocalConfig) -> anyhow::
         r = signal::ctrl_c().fuse() => {
             tracing::info!("Received Ctrl-C signal!");
             r?;
+            let _: Result<_, _> = shutdown_tx.broadcast(()).await;
+        },
+        r = stdin_close_future => {
+            r?;
+            tracing::info!("The launching process closed stdin. Shutting down.");
             let _: Result<_, _> = shutdown_tx.broadcast(()).await;
         },
     }
@@ -252,4 +264,18 @@ async fn run_server_inner(runtime: ProdRuntime, config: LocalConfig) -> anyhow::
     }
 
     Ok(())
+}
+
+async fn wait_for_stdin_close(enabled: bool) -> anyhow::Result<()> {
+    if !enabled {
+        return std::future::pending().await;
+    }
+
+    let mut stdin = io::stdin();
+    let mut buffer = [0; 256];
+    loop {
+        if stdin.read(&mut buffer).await? == 0 {
+            return Ok(());
+        }
+    }
 }

--- a/crates/node_executor/Cargo.toml
+++ b/crates/node_executor/Cargo.toml
@@ -49,6 +49,9 @@ tracing = { workspace = true }
 udf = { workspace = true }
 value = { workspace = true }
 
+[target.'cfg(windows)'.dependencies]
+windows-sys = { workspace = true }
+
 [build-dependencies]
 anyhow = "1"
 

--- a/crates/node_executor/src/executor.rs
+++ b/crates/node_executor/src/executor.rs
@@ -148,7 +148,7 @@ pub trait NodeExecutor: Sync + Send {
         request: ExecutorRequest,
         log_line_sender: mpsc::UnboundedSender<LogLine>,
     ) -> anyhow::Result<InvokeResponse>;
-    fn shutdown(&self);
+    async fn shutdown(&self) -> anyhow::Result<()>;
 }
 
 pub struct InvokeResponse {
@@ -229,8 +229,8 @@ impl<RT: Runtime> NodeActions<RT> {
         self.executor.enable()
     }
 
-    pub fn shutdown(&self) {
-        self.executor.shutdown()
+    pub async fn shutdown(&self) -> anyhow::Result<()> {
+        self.executor.shutdown().await
     }
 
     #[rustfmt::skip]

--- a/crates/node_executor/src/lib.rs
+++ b/crates/node_executor/src/lib.rs
@@ -13,6 +13,9 @@ mod metrics;
 pub mod noop;
 pub mod source_package;
 
+#[cfg(windows)]
+mod windows_job;
+
 pub use crate::executor::{
     error_response_json,
     handle_node_executor_stream,

--- a/crates/node_executor/src/local.rs
+++ b/crates/node_executor/src/local.rs
@@ -5,7 +5,11 @@ use std::{
         Child,
         Command,
     },
-    sync::Arc,
+    sync::{
+        Arc,
+        Mutex as StdMutex,
+    },
+    thread::JoinHandle,
     time::{
         Duration,
         Instant,
@@ -63,6 +67,7 @@ pub struct LocalNodeExecutor {
 
 struct LocalNodeExecutorConfig {
     node_process_timeout: Duration,
+    cleanup_jobs: Arc<CleanupJobs>,
     /// Overrides the initial callback retry backoff in the spawned node
     /// process (read by syscalls.ts at module load). Tests zero this so
     /// callbacks retrying against an unreachable backend settle within test
@@ -77,12 +82,51 @@ struct InnerLocalNodeExecutor {
     _server_handle: Option<NodeExecutorProcess>,
     _source_dir: Option<TempDir>,
     client: Option<reqwest::Client>,
+    cleanup_jobs: Arc<CleanupJobs>,
 }
 
 struct NodeExecutorProcess {
     child: Option<Child>,
     #[cfg(windows)]
     _job: Option<KillOnCloseJob>,
+}
+
+#[derive(Default)]
+struct CleanupJobs {
+    jobs: StdMutex<Vec<JoinHandle<anyhow::Result<()>>>>,
+}
+
+impl CleanupJobs {
+    fn spawn(&self, process: Option<NodeExecutorProcess>, source_dir: Option<TempDir>) {
+        let job = std::thread::Builder::new()
+            .name("local-node-executor-cleanup".to_owned())
+            .spawn(move || cleanup_owned_resources(process, source_dir))
+            .expect("spawn local Node executor cleanup thread");
+        self.jobs.lock().expect("cleanup jobs lock").push(job);
+    }
+
+    fn wait(&self) -> anyhow::Result<()> {
+        let jobs = std::mem::take(&mut *self.jobs.lock().expect("cleanup jobs lock"));
+        let mut result = Ok(());
+        for job in jobs {
+            let job_result = job
+                .join()
+                .map_err(|_| anyhow::anyhow!("local Node executor cleanup thread panicked"))
+                .and_then(|result| result);
+            if result.is_ok() && job_result.is_err() {
+                result = job_result;
+            }
+        }
+        result
+    }
+}
+
+impl Drop for CleanupJobs {
+    fn drop(&mut self) {
+        if let Err(error) = self.wait() {
+            tracing::error!("Local Node executor cleanup failed during drop: {error:#}");
+        }
+    }
 }
 
 impl Drop for NodeExecutorProcess {
@@ -141,16 +185,32 @@ impl Drop for InnerLocalNodeExecutor {
         if process.is_none() && source_dir.is_none() {
             return;
         }
-        let _ = std::thread::Builder::new()
-            .name("local-node-executor-cleanup".to_owned())
-            .spawn(move || {
-                if let Some(mut process) = process {
-                    let _ = process.shutdown();
-                }
-                if let Some(source_dir) = source_dir {
-                    let _ = cleanup_temp_dir_blocking(source_dir);
-                }
-            });
+        self.cleanup_jobs.spawn(process, source_dir);
+    }
+}
+
+fn cleanup_owned_resources(
+    mut process: Option<NodeExecutorProcess>,
+    source_dir: Option<TempDir>,
+) -> anyhow::Result<()> {
+    let process_result = match process.as_mut() {
+        Some(process) => process.shutdown(),
+        None => Ok(()),
+    };
+    // Release the Windows Job Object before retrying directory removal if
+    // process shutdown failed. Closing the job still terminates its process
+    // tree, and cleanup must not retain that ownership handle while it waits.
+    drop(process);
+    let source_dir_result = match source_dir {
+        Some(source_dir) => cleanup_temp_dir_blocking(source_dir),
+        None => Ok(()),
+    };
+    match (process_result, source_dir_result) {
+        (Ok(()), Ok(())) => Ok(()),
+        (Err(error), Ok(())) | (Ok(()), Err(error)) => Err(error),
+        (Err(process_error), Err(source_dir_error)) => Err(process_error.context(format!(
+            "local Node executor directory cleanup also failed: {source_dir_error:#}"
+        ))),
     }
 }
 
@@ -203,6 +263,14 @@ impl InnerLocalNodeExecutor {
         };
         let server_handle =
             Self::start_node_with_listener(config, &source_path, &source_dir, &socket_path).await?;
+        // Assemble the owned resource boundary immediately after the process
+        // starts so every later startup failure follows the same cleanup path.
+        let mut inner = Self {
+            _server_handle: Some(server_handle),
+            _source_dir: Some(source_dir),
+            client: None,
+            cleanup_jobs: config.cleanup_jobs.clone(),
+        };
         // Don't keep idle connections in the pool. The Node HTTP server closes
         // idle keep-alive connections after its (default 5s) `keepAliveTimeout`,
         // but hyper's pool would hold one much longer and reuse it right as the
@@ -217,15 +285,7 @@ impl InnerLocalNodeExecutor {
         {
             client_builder = client_builder.windows_named_pipe(socket_path);
         }
-        let client = client_builder.build()?;
-
-        // Assemble the owned resource boundary before health checks so every
-        // startup failure uses the same process-first, directory-second cleanup.
-        let inner = Self {
-            _server_handle: Some(server_handle),
-            _source_dir: Some(source_dir),
-            client: Some(client),
-        };
+        inner.client = Some(client_builder.build()?);
         // Wait for the Node process to be ready to handle HTTP requests.
         for _ in 0..MAX_HEALTH_CHECK_ATTEMPTS {
             if Self::check_server_health(inner.client.as_ref().expect("client present")).await? {
@@ -262,17 +322,9 @@ impl InnerLocalNodeExecutor {
         drop(self.client.take());
         let process = self._server_handle.take();
         let source_dir = self._source_dir.take();
-        tokio::task::spawn_blocking(move || {
-            if let Some(mut process) = process {
-                process.shutdown()?;
-            }
-            if let Some(source_dir) = source_dir {
-                cleanup_temp_dir_blocking(source_dir)?;
-            }
-            anyhow::Ok(())
-        })
-        .await
-        .context("join local Node executor cleanup")?
+        tokio::task::spawn_blocking(move || cleanup_owned_resources(process, source_dir))
+            .await
+            .context("join local Node executor cleanup")?
     }
 
     async fn check_server_health(client: &Client) -> anyhow::Result<bool> {
@@ -340,11 +392,13 @@ impl InnerLocalNodeExecutor {
 
 impl LocalNodeExecutor {
     pub async fn new(node_process_timeout: Duration) -> anyhow::Result<Self> {
+        let cleanup_jobs = Arc::new(CleanupJobs::default());
         let executor = Self {
             inner: Arc::new(Mutex::new(None)),
             config: LocalNodeExecutorConfig {
                 node_process_timeout,
                 callback_initial_backoff: None,
+                cleanup_jobs,
             },
         };
 
@@ -475,10 +529,14 @@ impl NodeExecutor for LocalNodeExecutor {
 
     async fn shutdown(&self) -> anyhow::Result<()> {
         let inner = self.inner.lock().await.take();
-        match inner {
-            Some(inner) => inner.shutdown().await,
-            None => Ok(()),
+        if let Some(inner) = inner {
+            inner.shutdown().await?;
         }
+        let cleanup_jobs = self.config.cleanup_jobs.clone();
+        tokio::task::spawn_blocking(move || cleanup_jobs.wait())
+            .await
+            .context("join local Node executor pending cleanup")??;
+        Ok(())
     }
 }
 
@@ -509,6 +567,7 @@ mod tests {
         let config = LocalNodeExecutorConfig {
             node_process_timeout: Duration::from_secs(5),
             callback_initial_backoff: Some(Duration::ZERO),
+            cleanup_jobs: Arc::new(CleanupJobs::default()),
         };
         let inner = InnerLocalNodeExecutor::new(&config)
             .await
@@ -533,6 +592,22 @@ mod tests {
                 .await
                 .is_err(),
             "executor named pipe still accepted requests after shutdown",
+        );
+    }
+
+    #[test]
+    fn pending_cleanup_is_joined_before_shutdown_returns() {
+        let cleanup_jobs = CleanupJobs::default();
+        let source_dir = TempDir::new().expect("create executor temporary directory");
+        let source_dir_path = source_dir.path().to_owned();
+
+        cleanup_jobs.spawn(None, Some(source_dir));
+        cleanup_jobs.wait().expect("join executor cleanup");
+
+        assert!(
+            !source_dir_path.exists(),
+            "executor temporary directory survived joined cleanup: {}",
+            source_dir_path.display(),
         );
     }
 
@@ -580,6 +655,7 @@ mod tests {
         let config = LocalNodeExecutorConfig {
             node_process_timeout: Duration::from_secs(5),
             callback_initial_backoff: Some(Duration::ZERO),
+            cleanup_jobs: Arc::new(CleanupJobs::default()),
         };
         let inner = InnerLocalNodeExecutor::new(&config)
             .await

--- a/crates/node_executor/src/local.rs
+++ b/crates/node_executor/src/local.rs
@@ -6,7 +6,10 @@ use std::{
         Command,
     },
     sync::Arc,
-    time::Duration,
+    time::{
+        Duration,
+        Instant,
+    },
 };
 
 use anyhow::Context;
@@ -50,6 +53,8 @@ const HEALTH_CHECK_INTERVAL: Duration = Duration::from_millis(100);
 const MAX_HEALTH_CHECK_ATTEMPTS: u32 = 50;
 const TEMP_DIR_CLEANUP_INTERVAL: Duration = Duration::from_millis(50);
 const TEMP_DIR_CLEANUP_MAX_ATTEMPTS: u32 = 40;
+const PROCESS_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(5);
+const PROCESS_SHUTDOWN_POLL_INTERVAL: Duration = Duration::from_millis(25);
 
 pub struct LocalNodeExecutor {
     inner: Arc<Mutex<Option<InnerLocalNodeExecutor>>>,
@@ -69,33 +74,104 @@ struct InnerLocalNodeExecutor {
     // Stop and reap Node before removing the directory it uses for source and
     // runtime files. This order matters on Windows, where open files prevent
     // recursive directory removal.
-    _server_handle: NodeExecutorProcess,
-    _source_dir: TempDir,
-    client: reqwest::Client,
+    _server_handle: Option<NodeExecutorProcess>,
+    _source_dir: Option<TempDir>,
+    client: Option<reqwest::Client>,
 }
 
 struct NodeExecutorProcess {
-    child: Child,
+    child: Option<Child>,
     #[cfg(windows)]
-    _job: KillOnCloseJob,
+    _job: Option<KillOnCloseJob>,
 }
 
 impl Drop for NodeExecutorProcess {
     fn drop(&mut self) {
-        // std::process::Child does not kill or reap on drop. The local executor
-        // is owned by this backend, so stop it before TempDir cleanup runs.
-        let _ = self.shutdown();
+        let Some(mut child) = self.child.take() else {
+            return;
+        };
+        #[cfg(windows)]
+        let job = self._job.take();
+        // Drop can run on a Tokio worker after an invoke error. Keep blocking
+        // process operations off that worker; the job remains owned by the
+        // cleanup thread until the child has stopped.
+        let _ = std::thread::Builder::new()
+            .name("local-node-executor-drop".to_owned())
+            .spawn(move || {
+                let _ = shutdown_child(&mut child);
+                #[cfg(windows)]
+                drop(job);
+            });
     }
 }
 
 impl NodeExecutorProcess {
     fn shutdown(&mut self) -> anyhow::Result<()> {
-        if self.child.try_wait()?.is_none() {
-            self.child.kill().context("kill local Node executor")?;
+        if let Some(mut child) = self.child.take() {
+            shutdown_child(&mut child)?;
         }
-        self.child.wait().context("reap local Node executor")?;
+        #[cfg(windows)]
+        drop(self._job.take());
         Ok(())
     }
+}
+
+fn shutdown_child(child: &mut Child) -> anyhow::Result<()> {
+    if child.try_wait()?.is_some() {
+        return Ok(());
+    }
+    child.kill().context("kill local Node executor")?;
+    let deadline = Instant::now() + PROCESS_SHUTDOWN_TIMEOUT;
+    loop {
+        if child.try_wait()?.is_some() {
+            return Ok(());
+        }
+        if Instant::now() >= deadline {
+            anyhow::bail!("timed out reaping local Node executor after termination");
+        }
+        std::thread::sleep(PROCESS_SHUTDOWN_POLL_INTERVAL);
+    }
+}
+
+impl Drop for InnerLocalNodeExecutor {
+    fn drop(&mut self) {
+        drop(self.client.take());
+        let process = self._server_handle.take();
+        let source_dir = self._source_dir.take();
+        if process.is_none() && source_dir.is_none() {
+            return;
+        }
+        let _ = std::thread::Builder::new()
+            .name("local-node-executor-cleanup".to_owned())
+            .spawn(move || {
+                if let Some(mut process) = process {
+                    let _ = process.shutdown();
+                }
+                if let Some(source_dir) = source_dir {
+                    let _ = cleanup_temp_dir_blocking(source_dir);
+                }
+            });
+    }
+}
+
+fn cleanup_temp_dir_blocking(source_dir: TempDir) -> anyhow::Result<()> {
+    let source_dir_path = source_dir.path().to_owned();
+    if source_dir.close().is_ok() {
+        return Ok(());
+    }
+    for _ in 0..TEMP_DIR_CLEANUP_MAX_ATTEMPTS {
+        match fs::remove_dir_all(&source_dir_path) {
+            Ok(()) => return Ok(()),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+            Err(_) => std::thread::sleep(TEMP_DIR_CLEANUP_INTERVAL),
+        }
+    }
+    fs::remove_dir_all(&source_dir_path).with_context(|| {
+        format!(
+            "remove local Node executor temporary directory {}",
+            source_dir_path.display()
+        )
+    })
 }
 
 impl InnerLocalNodeExecutor {
@@ -143,14 +219,17 @@ impl InnerLocalNodeExecutor {
         }
         let client = client_builder.build()?;
 
+        // Assemble the owned resource boundary before health checks so every
+        // startup failure uses the same process-first, directory-second cleanup.
+        let inner = Self {
+            _server_handle: Some(server_handle),
+            _source_dir: Some(source_dir),
+            client: Some(client),
+        };
         // Wait for the Node process to be ready to handle HTTP requests.
         for _ in 0..MAX_HEALTH_CHECK_ATTEMPTS {
-            if Self::check_server_health(&client).await? {
-                return Ok(Self {
-                    _server_handle: server_handle,
-                    _source_dir: source_dir,
-                    client,
-                });
+            if Self::check_server_health(inner.client.as_ref().expect("client present")).await? {
+                return Ok(inner);
             }
             tokio::time::sleep(HEALTH_CHECK_INTERVAL).await;
         }
@@ -179,42 +258,21 @@ impl InnerLocalNodeExecutor {
         Ok(())
     }
 
-    async fn shutdown(self) -> anyhow::Result<()> {
-        let Self {
-            mut _server_handle,
-            _source_dir,
-            client,
-        } = self;
-        let source_dir_path = _source_dir.path().to_owned();
-
-        // Release the named-pipe client before stopping Node, then wait for the
-        // process handle to close before removing the files it was using.
-        drop(client);
-        _server_handle.shutdown()?;
-        drop(_server_handle);
-
-        if _source_dir.close().is_ok() {
-            return Ok(());
-        }
-
-        // Windows may report a transient sharing violation just after the
-        // process exits. TempDir's Drop suppresses that error, which made old
-        // local-dev sessions silently leak. Retry within a fixed bound and
-        // make persistent cleanup failure part of backend shutdown.
-        for _ in 0..TEMP_DIR_CLEANUP_MAX_ATTEMPTS {
-            match fs::remove_dir_all(&source_dir_path) {
-                Ok(()) => return Ok(()),
-                Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
-                Err(_) => tokio::time::sleep(TEMP_DIR_CLEANUP_INTERVAL).await,
+    async fn shutdown(mut self) -> anyhow::Result<()> {
+        drop(self.client.take());
+        let process = self._server_handle.take();
+        let source_dir = self._source_dir.take();
+        tokio::task::spawn_blocking(move || {
+            if let Some(mut process) = process {
+                process.shutdown()?;
             }
-        }
-
-        fs::remove_dir_all(&source_dir_path).with_context(|| {
-            format!(
-                "remove local Node executor temporary directory {}",
-                source_dir_path.display()
-            )
+            if let Some(source_dir) = source_dir {
+                cleanup_temp_dir_blocking(source_dir)?;
+            }
+            anyhow::Ok(())
         })
+        .await
+        .context("join local Node executor cleanup")?
     }
 
     async fn check_server_health(client: &Client) -> anyhow::Result<bool> {
@@ -265,21 +323,17 @@ impl InnerLocalNodeExecutor {
         #[cfg(windows)]
         let job = KillOnCloseJob::new().context("Failed to create Node executor job object")?;
 
-        let mut child = cmd.spawn()?;
-
         #[cfg(windows)]
-        if let Err(error) = job.assign(&child) {
-            // Assignment is part of spawning a managed executor. Do not leave
-            // an unmanaged process running if Windows rejects the job.
-            let _ = child.kill();
-            let _ = child.wait();
-            return Err(error).context("Failed to assign Node executor to job object");
-        }
+        let child = job
+            .spawn_assigned(&mut cmd)
+            .context("Failed to spawn Node executor in job object")?;
+        #[cfg(not(windows))]
+        let child = cmd.spawn()?;
 
         Ok(NodeExecutorProcess {
-            child,
+            child: Some(child),
             #[cfg(windows)]
-            _job: job,
+            _job: Some(job),
         })
     }
 }
@@ -355,7 +409,7 @@ impl NodeExecutor for LocalNodeExecutor {
                 )
             }
             let inner = inner.as_ref().unwrap();
-            inner.client.clone()
+            inner.client.as_ref().expect("client present").clone()
         };
         let request_json = JsonValue::try_from(request)?;
 
@@ -459,10 +513,12 @@ mod tests {
         let inner = InnerLocalNodeExecutor::new(&config)
             .await
             .expect("start local Node executor");
-        let source_dir = inner._source_dir.path().to_owned();
-        let client = inner.client.clone();
+        let source_dir = inner._source_dir.as_ref().unwrap().path().to_owned();
+        let client = inner.client.as_ref().unwrap().clone();
 
         drop(inner);
+
+        wait_for_path_removal(&source_dir).await;
 
         assert!(
             !source_dir.exists(),
@@ -488,8 +544,8 @@ mod tests {
         let inner = InnerLocalNodeExecutor::new(&executor.config)
             .await
             .expect("start local Node executor");
-        let source_dir = inner._source_dir.path().to_owned();
-        let client = inner.client.clone();
+        let source_dir = inner._source_dir.as_ref().unwrap().path().to_owned();
+        let client = inner.client.as_ref().unwrap().clone();
         *executor.inner.lock().await = Some(inner);
 
         executor
@@ -528,9 +584,16 @@ mod tests {
         let inner = InnerLocalNodeExecutor::new(&config)
             .await
             .expect("start local Node executor");
-        let source_dir = inner._source_dir.path().to_owned();
-        let executor_pid = inner._server_handle.child.id();
-        let client = inner.client.clone();
+        let source_dir = inner._source_dir.as_ref().unwrap().path().to_owned();
+        let executor_pid = inner
+            ._server_handle
+            .as_ref()
+            .unwrap()
+            .child
+            .as_ref()
+            .unwrap()
+            .id();
+        let client = inner.client.as_ref().unwrap().clone();
         fs::write(
             ready_file,
             format!(
@@ -551,6 +614,7 @@ mod tests {
         .expect("join stdin reader");
 
         drop(inner);
+        wait_for_path_removal(&source_dir).await;
         assert!(
             !source_dir.exists(),
             "executor temporary directory survived launcher death: {}",
@@ -567,6 +631,13 @@ mod tests {
             "executor_process=stopped\nnamed_pipe=closed\ntemp_dir=removed\n",
         )
         .expect("publish clean shutdown");
+    }
+
+    async fn wait_for_path_removal(path: &std::path::Path) {
+        let deadline = Instant::now() + PROCESS_SHUTDOWN_TIMEOUT + Duration::from_secs(1);
+        while path.exists() && Instant::now() < deadline {
+            tokio::time::sleep(PROCESS_SHUTDOWN_POLL_INTERVAL).await;
+        }
     }
 
     #[test]

--- a/crates/node_executor/src/local.rs
+++ b/crates/node_executor/src/local.rs
@@ -1,6 +1,10 @@
 use std::{
     fs,
     path::PathBuf,
+    process::{
+        Child,
+        Command,
+    },
     sync::Arc,
     time::Duration,
 };
@@ -20,16 +24,15 @@ use reqwest::Client;
 use serde_json::Value as JsonValue;
 use tempfile::TempDir;
 use tokio::{
-    process::{
-        Child,
-        Command as TokioCommand,
-    },
+    process::Command as TokioCommand,
     sync::{
         mpsc,
         Mutex,
     },
 };
 
+#[cfg(windows)]
+use crate::windows_job::KillOnCloseJob;
 use crate::{
     executor::{
         ExecutorRequest,
@@ -45,6 +48,8 @@ use crate::{
 const NVMRC_VERSION: &str = include_str!("../../../.nvmrc");
 const HEALTH_CHECK_INTERVAL: Duration = Duration::from_millis(100);
 const MAX_HEALTH_CHECK_ATTEMPTS: u32 = 50;
+const TEMP_DIR_CLEANUP_INTERVAL: Duration = Duration::from_millis(50);
+const TEMP_DIR_CLEANUP_MAX_ATTEMPTS: u32 = 40;
 
 pub struct LocalNodeExecutor {
     inner: Arc<Mutex<Option<InnerLocalNodeExecutor>>>,
@@ -61,9 +66,36 @@ struct LocalNodeExecutorConfig {
 }
 
 struct InnerLocalNodeExecutor {
+    // Stop and reap Node before removing the directory it uses for source and
+    // runtime files. This order matters on Windows, where open files prevent
+    // recursive directory removal.
+    _server_handle: NodeExecutorProcess,
     _source_dir: TempDir,
     client: reqwest::Client,
-    _server_handle: Child,
+}
+
+struct NodeExecutorProcess {
+    child: Child,
+    #[cfg(windows)]
+    _job: KillOnCloseJob,
+}
+
+impl Drop for NodeExecutorProcess {
+    fn drop(&mut self) {
+        // std::process::Child does not kill or reap on drop. The local executor
+        // is owned by this backend, so stop it before TempDir cleanup runs.
+        let _ = self.shutdown();
+    }
+}
+
+impl NodeExecutorProcess {
+    fn shutdown(&mut self) -> anyhow::Result<()> {
+        if self.child.try_wait()?.is_none() {
+            self.child.kill().context("kill local Node executor")?;
+        }
+        self.child.wait().context("reap local Node executor")?;
+        Ok(())
+    }
 }
 
 impl InnerLocalNodeExecutor {
@@ -115,9 +147,9 @@ impl InnerLocalNodeExecutor {
         for _ in 0..MAX_HEALTH_CHECK_ATTEMPTS {
             if Self::check_server_health(&client).await? {
                 return Ok(Self {
+                    _server_handle: server_handle,
                     _source_dir: source_dir,
                     client,
-                    _server_handle: server_handle,
                 });
             }
             tokio::time::sleep(HEALTH_CHECK_INTERVAL).await;
@@ -147,6 +179,44 @@ impl InnerLocalNodeExecutor {
         Ok(())
     }
 
+    async fn shutdown(self) -> anyhow::Result<()> {
+        let Self {
+            mut _server_handle,
+            _source_dir,
+            client,
+        } = self;
+        let source_dir_path = _source_dir.path().to_owned();
+
+        // Release the named-pipe client before stopping Node, then wait for the
+        // process handle to close before removing the files it was using.
+        drop(client);
+        _server_handle.shutdown()?;
+        drop(_server_handle);
+
+        if _source_dir.close().is_ok() {
+            return Ok(());
+        }
+
+        // Windows may report a transient sharing violation just after the
+        // process exits. TempDir's Drop suppresses that error, which made old
+        // local-dev sessions silently leak. Retry within a fixed bound and
+        // make persistent cleanup failure part of backend shutdown.
+        for _ in 0..TEMP_DIR_CLEANUP_MAX_ATTEMPTS {
+            match fs::remove_dir_all(&source_dir_path) {
+                Ok(()) => return Ok(()),
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+                Err(_) => tokio::time::sleep(TEMP_DIR_CLEANUP_INTERVAL).await,
+            }
+        }
+
+        fs::remove_dir_all(&source_dir_path).with_context(|| {
+            format!(
+                "remove local Node executor temporary directory {}",
+                source_dir_path.display()
+            )
+        })
+    }
+
     async fn check_server_health(client: &Client) -> anyhow::Result<bool> {
         match client
             .get("http://localhost/health".to_string())
@@ -164,7 +234,7 @@ impl InnerLocalNodeExecutor {
         source_path: &PathBuf,
         temp_dir: &TempDir,
         socket_path: &PathBuf,
-    ) -> anyhow::Result<Child> {
+    ) -> anyhow::Result<NodeExecutorProcess> {
         let preferred_node_version = NVMRC_VERSION.trim();
 
         // Look for node in a few places.
@@ -179,13 +249,12 @@ impl InnerLocalNodeExecutor {
         };
         Self::check_node_version(&node_path).await?;
 
-        let mut cmd = TokioCommand::new(node_path);
+        let mut cmd = Command::new(node_path);
         cmd.arg(source_path)
             .arg("--ipc-path")
             .arg(socket_path)
             .arg("--tempdir")
-            .arg(temp_dir.path())
-            .kill_on_drop(true);
+            .arg(temp_dir.path());
         if let Some(backoff) = config.callback_initial_backoff {
             cmd.env(
                 "CALLBACK_INITIAL_BACKOFF_MS",
@@ -193,9 +262,25 @@ impl InnerLocalNodeExecutor {
             );
         }
 
-        let child = cmd.spawn()?;
+        #[cfg(windows)]
+        let job = KillOnCloseJob::new().context("Failed to create Node executor job object")?;
 
-        Ok(child)
+        let mut child = cmd.spawn()?;
+
+        #[cfg(windows)]
+        if let Err(error) = job.assign(&child) {
+            // Assignment is part of spawning a managed executor. Do not leave
+            // an unmanaged process running if Windows rejects the job.
+            let _ = child.kill();
+            let _ = child.wait();
+            return Err(error).context("Failed to assign Node executor to job object");
+        }
+
+        Ok(NodeExecutorProcess {
+            child,
+            #[cfg(windows)]
+            _job: job,
+        })
     }
 }
 
@@ -334,5 +419,278 @@ impl NodeExecutor for LocalNodeExecutor {
         }
     }
 
-    fn shutdown(&self) {}
+    async fn shutdown(&self) -> anyhow::Result<()> {
+        let inner = self.inner.lock().await.take();
+        match inner {
+            Some(inner) => inner.shutdown().await,
+            None => Ok(()),
+        }
+    }
+}
+
+#[cfg(all(test, windows))]
+mod tests {
+    use std::{
+        env,
+        fs,
+        io::Read,
+        process::Stdio,
+        thread,
+        time::Instant,
+    };
+
+    use super::*;
+    use crate::windows_job::{
+        is_process_running,
+        terminate_process,
+    };
+
+    const BACKEND_HELPER: &str = "CONVEX_TEST_LOCAL_EXECUTOR_BACKEND_HELPER";
+    const LAUNCHER_HELPER: &str = "CONVEX_TEST_LOCAL_EXECUTOR_LAUNCHER_HELPER";
+    const READY_FILE: &str = "CONVEX_TEST_LOCAL_EXECUTOR_READY_FILE";
+    const CLEAN_FILE: &str = "CONVEX_TEST_LOCAL_EXECUTOR_CLEAN_FILE";
+
+    #[tokio::test]
+    async fn ordinary_drop_stops_executor_and_removes_temp_dir() {
+        let config = LocalNodeExecutorConfig {
+            node_process_timeout: Duration::from_secs(5),
+            callback_initial_backoff: Some(Duration::ZERO),
+        };
+        let inner = InnerLocalNodeExecutor::new(&config)
+            .await
+            .expect("start local Node executor");
+        let source_dir = inner._source_dir.path().to_owned();
+        let client = inner.client.clone();
+
+        drop(inner);
+
+        assert!(
+            !source_dir.exists(),
+            "executor temporary directory survived ordinary shutdown: {}",
+            source_dir.display(),
+        );
+        assert!(
+            client
+                .get("http://localhost/health")
+                .timeout(Duration::from_secs(1))
+                .send()
+                .await
+                .is_err(),
+            "executor named pipe still accepted requests after shutdown",
+        );
+    }
+
+    #[tokio::test]
+    async fn explicit_shutdown_stops_executor_and_removes_temp_dir() {
+        let executor = LocalNodeExecutor::new(Duration::from_secs(5))
+            .await
+            .expect("construct local Node executor");
+        let inner = InnerLocalNodeExecutor::new(&executor.config)
+            .await
+            .expect("start local Node executor");
+        let source_dir = inner._source_dir.path().to_owned();
+        let client = inner.client.clone();
+        *executor.inner.lock().await = Some(inner);
+
+        executor
+            .shutdown()
+            .await
+            .expect("shutdown local Node executor");
+
+        assert!(
+            !source_dir.exists(),
+            "executor temporary directory survived explicit shutdown: {}",
+            source_dir.display(),
+        );
+        assert!(
+            client
+                .get("http://localhost/health")
+                .timeout(Duration::from_secs(1))
+                .send()
+                .await
+                .is_err(),
+            "executor named pipe still accepted requests after explicit shutdown",
+        );
+    }
+
+    #[tokio::test]
+    async fn local_executor_backend_helper() {
+        if env::var_os(BACKEND_HELPER).is_none() {
+            return;
+        }
+
+        let ready_file = PathBuf::from(env::var_os(READY_FILE).expect("missing ready file"));
+        let clean_file = PathBuf::from(env::var_os(CLEAN_FILE).expect("missing clean file"));
+        let config = LocalNodeExecutorConfig {
+            node_process_timeout: Duration::from_secs(5),
+            callback_initial_backoff: Some(Duration::ZERO),
+        };
+        let inner = InnerLocalNodeExecutor::new(&config)
+            .await
+            .expect("start local Node executor");
+        let source_dir = inner._source_dir.path().to_owned();
+        let executor_pid = inner._server_handle.child.id();
+        let client = inner.client.clone();
+        fs::write(
+            ready_file,
+            format!(
+                "{}\n{}\n{}\n",
+                std::process::id(),
+                executor_pid,
+                source_dir.display()
+            ),
+        )
+        .expect("publish executor ownership");
+
+        tokio::task::spawn_blocking(|| {
+            let mut stdin = std::io::stdin();
+            let mut buffer = [0; 256];
+            while stdin.read(&mut buffer).expect("read launcher pipe") != 0 {}
+        })
+        .await
+        .expect("join stdin reader");
+
+        drop(inner);
+        assert!(
+            !source_dir.exists(),
+            "executor temporary directory survived launcher death: {}",
+            source_dir.display(),
+        );
+        assert!(
+            !InnerLocalNodeExecutor::check_server_health(&client)
+                .await
+                .expect("check executor health"),
+            "executor named pipe survived launcher death",
+        );
+        fs::write(
+            clean_file,
+            "executor_process=stopped\nnamed_pipe=closed\ntemp_dir=removed\n",
+        )
+        .expect("publish clean shutdown");
+    }
+
+    #[test]
+    fn local_executor_launcher_helper() {
+        if env::var_os(LAUNCHER_HELPER).is_none() {
+            return;
+        }
+
+        let mut backend = Command::new(env::current_exe().expect("locate test executable"))
+            .args([
+                "--exact",
+                "local::tests::local_executor_backend_helper",
+                "--nocapture",
+            ])
+            .env(BACKEND_HELPER, "1")
+            .env(
+                READY_FILE,
+                env::var_os(READY_FILE).expect("missing ready file"),
+            )
+            .env(
+                CLEAN_FILE,
+                env::var_os(CLEAN_FILE).expect("missing clean file"),
+            )
+            .stdin(Stdio::piped())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("spawn backend helper");
+
+        loop {
+            assert!(
+                backend
+                    .try_wait()
+                    .expect("inspect backend helper")
+                    .is_none(),
+                "backend helper exited before launcher termination",
+            );
+            thread::sleep(Duration::from_secs(60));
+        }
+    }
+
+    #[test]
+    fn force_killing_launcher_triggers_clean_executor_shutdown() {
+        let temp_dir = TempDir::new().expect("create test directory");
+        let ready_file = temp_dir.path().join("ready.txt");
+        let clean_file = temp_dir.path().join("clean.txt");
+        let mut launcher = Command::new(env::current_exe().expect("locate test executable"))
+            .args([
+                "--exact",
+                "local::tests::local_executor_launcher_helper",
+                "--nocapture",
+            ])
+            .env(LAUNCHER_HELPER, "1")
+            .env(READY_FILE, &ready_file)
+            .env(CLEAN_FILE, &clean_file)
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("spawn launcher helper");
+
+        let (backend_pid, executor_pid) = wait_for_owned_processes(&ready_file);
+        assert!(
+            is_process_running(backend_pid),
+            "backend helper never started"
+        );
+        assert!(
+            is_process_running(executor_pid),
+            "Node executor never started"
+        );
+
+        // Child::kill uses TerminateProcess on Windows. The launcher cannot run
+        // cleanup, so the backend must observe stdin EOF and own the teardown.
+        launcher.kill().expect("force kill launcher helper");
+        launcher.wait().expect("reap launcher helper");
+
+        let deadline = Instant::now() + Duration::from_secs(10);
+        while !clean_file.exists() && Instant::now() < deadline {
+            thread::sleep(Duration::from_millis(25));
+        }
+        if !clean_file.exists() {
+            terminate_process(executor_pid);
+            terminate_process(backend_pid);
+            panic!("backend did not publish clean shutdown after launcher death");
+        }
+
+        while (is_process_running(backend_pid) || is_process_running(executor_pid))
+            && Instant::now() < deadline
+        {
+            thread::sleep(Duration::from_millis(25));
+        }
+        if is_process_running(executor_pid) || is_process_running(backend_pid) {
+            terminate_process(executor_pid);
+            terminate_process(backend_pid);
+            panic!("backend or executor survived launcher death");
+        }
+
+        assert_eq!(
+            fs::read_to_string(clean_file).expect("read shutdown evidence"),
+            "executor_process=stopped\nnamed_pipe=closed\ntemp_dir=removed\n",
+        );
+    }
+
+    fn wait_for_owned_processes(ready_file: &std::path::Path) -> (u32, u32) {
+        let deadline = Instant::now() + Duration::from_secs(10);
+        loop {
+            if let Ok(contents) = fs::read_to_string(ready_file) {
+                let mut lines = contents.lines();
+                let backend_pid = lines
+                    .next()
+                    .expect("backend PID")
+                    .parse()
+                    .expect("valid backend PID");
+                let executor_pid = lines
+                    .next()
+                    .expect("executor PID")
+                    .parse()
+                    .expect("valid executor PID");
+                return (backend_pid, executor_pid);
+            }
+            assert!(
+                Instant::now() < deadline,
+                "backend did not publish executor ownership",
+            );
+            thread::sleep(Duration::from_millis(25));
+        }
+    }
 }

--- a/crates/node_executor/src/noop.rs
+++ b/crates/node_executor/src/noop.rs
@@ -29,5 +29,7 @@ impl NodeExecutor for NoopNodeExecutor {
         anyhow::bail!("NoopNodeExecutor cannot be used to invoke code.");
     }
 
-    fn shutdown(&self) {}
+    async fn shutdown(&self) -> anyhow::Result<()> {
+        Ok(())
+    }
 }

--- a/crates/node_executor/src/windows_job.rs
+++ b/crates/node_executor/src/windows_job.rs
@@ -1,0 +1,207 @@
+use std::{
+    io,
+    mem::size_of,
+    os::windows::io::{
+        AsRawHandle,
+        FromRawHandle,
+        OwnedHandle,
+    },
+    process::Child,
+    ptr,
+};
+
+use windows_sys::Win32::System::JobObjects::{
+    AssignProcessToJobObject,
+    CreateJobObjectW,
+    JobObjectExtendedLimitInformation,
+    SetInformationJobObject,
+    JOBOBJECT_EXTENDED_LIMIT_INFORMATION,
+    JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE,
+};
+#[cfg(test)]
+use windows_sys::Win32::{
+    Foundation::STILL_ACTIVE,
+    System::Threading::{
+        GetExitCodeProcess,
+        OpenProcess,
+        TerminateProcess,
+        PROCESS_QUERY_LIMITED_INFORMATION,
+        PROCESS_TERMINATE,
+    },
+};
+
+/// Owns a Windows Job Object that terminates its assigned process tree when
+/// this backend closes its final job handle, including abrupt termination.
+pub(crate) struct KillOnCloseJob {
+    handle: OwnedHandle,
+}
+
+impl KillOnCloseJob {
+    pub(crate) fn new() -> io::Result<Self> {
+        // SAFETY: Both optional pointer arguments are null, so Windows creates
+        // an unnamed job with the caller's default security descriptor.
+        let raw_handle = unsafe { CreateJobObjectW(ptr::null(), ptr::null()) };
+        if raw_handle.is_null() {
+            return Err(io::Error::last_os_error());
+        }
+
+        // SAFETY: CreateJobObjectW returned a new owned handle on success.
+        let handle = unsafe { OwnedHandle::from_raw_handle(raw_handle) };
+        let mut limits = JOBOBJECT_EXTENDED_LIMIT_INFORMATION::default();
+        limits.BasicLimitInformation.LimitFlags = JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE;
+
+        // SAFETY: The handle is a live job handle, and `limits` points to a
+        // correctly sized value for JobObjectExtendedLimitInformation.
+        let configured = unsafe {
+            SetInformationJobObject(
+                handle.as_raw_handle(),
+                JobObjectExtendedLimitInformation,
+                ptr::from_ref(&limits).cast(),
+                size_of::<JOBOBJECT_EXTENDED_LIMIT_INFORMATION>() as u32,
+            )
+        };
+        if configured == 0 {
+            return Err(io::Error::last_os_error());
+        }
+
+        Ok(Self { handle })
+    }
+
+    pub(crate) fn assign(&self, child: &Child) -> io::Result<()> {
+        // SAFETY: Both handles are live for this call. The job is configured
+        // before assignment, so closing its final handle owns child teardown.
+        let assigned =
+            unsafe { AssignProcessToJobObject(self.handle.as_raw_handle(), child.as_raw_handle()) };
+        if assigned == 0 {
+            return Err(io::Error::last_os_error());
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+pub(crate) fn is_process_running(pid: u32) -> bool {
+    // SAFETY: OpenProcess returns a new owned handle when the PID exists.
+    let raw_handle = unsafe { OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, 0, pid) };
+    if raw_handle.is_null() {
+        return false;
+    }
+    // SAFETY: OpenProcess returned an owned process handle.
+    let handle = unsafe { OwnedHandle::from_raw_handle(raw_handle) };
+    let mut exit_code = 0;
+    // SAFETY: The handle is live and exit_code is writable for this call.
+    let succeeded = unsafe { GetExitCodeProcess(handle.as_raw_handle(), &mut exit_code) };
+    succeeded != 0 && exit_code == STILL_ACTIVE as u32
+}
+
+#[cfg(test)]
+pub(crate) fn terminate_process(pid: u32) {
+    // SAFETY: Any returned handle is owned locally and closed by OwnedHandle.
+    let raw_handle = unsafe { OpenProcess(PROCESS_TERMINATE, 0, pid) };
+    if raw_handle.is_null() {
+        return;
+    }
+    // SAFETY: OpenProcess returned an owned process handle.
+    let handle = unsafe { OwnedHandle::from_raw_handle(raw_handle) };
+    // SAFETY: The handle was opened with PROCESS_TERMINATE.
+    let _ = unsafe { TerminateProcess(handle.as_raw_handle(), 1) };
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        env,
+        fs,
+        process::Command,
+        thread,
+        time::{
+            Duration,
+            Instant,
+        },
+    };
+
+    use tempfile::TempDir;
+
+    use super::*;
+
+    const JOB_OWNER_HELPER: &str = "CONVEX_TEST_JOB_OWNER_HELPER";
+    const CHILD_PID_FILE: &str = "CONVEX_TEST_CHILD_PID_FILE";
+
+    #[test]
+    fn job_owner_helper() {
+        if env::var_os(JOB_OWNER_HELPER).is_none() {
+            return;
+        }
+
+        let pid_file = env::var_os(CHILD_PID_FILE).expect("missing child PID file");
+        let job = KillOnCloseJob::new().expect("create job");
+        let child = Command::new("powershell.exe")
+            .args([
+                "-NoLogo",
+                "-NoProfile",
+                "-NonInteractive",
+                "-Command",
+                "Start-Sleep -Seconds 300",
+            ])
+            .spawn()
+            .expect("spawn child");
+        job.assign(&child).expect("assign child");
+        fs::write(pid_file, child.id().to_string()).expect("publish child PID");
+
+        let _job = job;
+        let _child = child;
+        loop {
+            thread::sleep(Duration::from_secs(60));
+        }
+    }
+
+    #[test]
+    fn force_killing_job_owner_terminates_assigned_process() {
+        let temp_dir = TempDir::new().expect("create test directory");
+        let pid_file = temp_dir.path().join("child.pid");
+        let mut owner = Command::new(env::current_exe().expect("locate test executable"))
+            .args([
+                "--exact",
+                "windows_job::tests::job_owner_helper",
+                "--nocapture",
+            ])
+            .env(JOB_OWNER_HELPER, "1")
+            .env(CHILD_PID_FILE, &pid_file)
+            .spawn()
+            .expect("spawn job owner");
+
+        let child_pid = wait_for_child_pid(&pid_file);
+        assert!(
+            is_process_running(child_pid),
+            "assigned child never started"
+        );
+
+        // std uses TerminateProcess on Windows. The owner's destructors do not
+        // run, so only the kernel's job-handle semantics can stop the child.
+        owner.kill().expect("force kill job owner");
+        owner.wait().expect("reap job owner");
+
+        let deadline = Instant::now() + Duration::from_secs(5);
+        while is_process_running(child_pid) && Instant::now() < deadline {
+            thread::sleep(Duration::from_millis(25));
+        }
+        if is_process_running(child_pid) {
+            terminate_process(child_pid);
+            panic!("assigned child survived forced job-owner termination");
+        }
+    }
+
+    fn wait_for_child_pid(pid_file: &std::path::Path) -> u32 {
+        let deadline = Instant::now() + Duration::from_secs(5);
+        loop {
+            if let Ok(pid) = fs::read_to_string(pid_file) {
+                return pid.parse().expect("valid child PID");
+            }
+            assert!(
+                Instant::now() < deadline,
+                "job owner did not publish child PID",
+            );
+            thread::sleep(Duration::from_millis(25));
+        }
+    }
+}

--- a/crates/node_executor/src/windows_job.rs
+++ b/crates/node_executor/src/windows_job.rs
@@ -1,22 +1,46 @@
 use std::{
     io,
     mem::size_of,
-    os::windows::io::{
-        AsRawHandle,
-        FromRawHandle,
-        OwnedHandle,
+    os::windows::{
+        io::{
+            AsRawHandle,
+            FromRawHandle,
+            OwnedHandle,
+        },
+        process::CommandExt,
     },
-    process::Child,
+    process::{
+        Child,
+        Command,
+    },
     ptr,
 };
 
-use windows_sys::Win32::System::JobObjects::{
-    AssignProcessToJobObject,
-    CreateJobObjectW,
-    JobObjectExtendedLimitInformation,
-    SetInformationJobObject,
-    JOBOBJECT_EXTENDED_LIMIT_INFORMATION,
-    JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE,
+use windows_sys::Win32::{
+    Foundation::INVALID_HANDLE_VALUE,
+    System::{
+        Diagnostics::ToolHelp::{
+            CreateToolhelp32Snapshot,
+            Thread32First,
+            Thread32Next,
+            TH32CS_SNAPTHREAD,
+            THREADENTRY32,
+        },
+        JobObjects::{
+            AssignProcessToJobObject,
+            CreateJobObjectW,
+            JobObjectExtendedLimitInformation,
+            SetInformationJobObject,
+            JOBOBJECT_EXTENDED_LIMIT_INFORMATION,
+            JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE,
+        },
+        Threading::{
+            OpenThread,
+            ResumeThread,
+            CREATE_SUSPENDED,
+            THREAD_SUSPEND_RESUME,
+        },
+    },
 };
 #[cfg(test)]
 use windows_sys::Win32::{
@@ -77,6 +101,63 @@ impl KillOnCloseJob {
         }
         Ok(())
     }
+
+    /// Starts a process suspended, assigns it to this kill-on-close job, and
+    /// only then lets its primary thread run. This closes the orphan window
+    /// between process creation and job assignment.
+    pub(crate) fn spawn_assigned(&self, command: &mut Command) -> io::Result<Child> {
+        command.creation_flags(CREATE_SUSPENDED);
+        let mut child = command.spawn()?;
+        if let Err(error) = self
+            .assign(&child)
+            .and_then(|()| resume_process(child.id()))
+        {
+            let _ = child.kill();
+            let _ = child.wait();
+            return Err(error);
+        }
+        Ok(child)
+    }
+}
+
+fn resume_process(pid: u32) -> io::Result<()> {
+    // SAFETY: The snapshot handle is owned locally and contains a point-in-time
+    // list of system threads.
+    let snapshot = unsafe { CreateToolhelp32Snapshot(TH32CS_SNAPTHREAD, 0) };
+    if snapshot == INVALID_HANDLE_VALUE {
+        return Err(io::Error::last_os_error());
+    }
+    // SAFETY: CreateToolhelp32Snapshot returned an owned handle.
+    let snapshot = unsafe { OwnedHandle::from_raw_handle(snapshot) };
+    let mut entry = THREADENTRY32 {
+        dwSize: size_of::<THREADENTRY32>() as u32,
+        ..Default::default()
+    };
+    // SAFETY: snapshot and entry are live for the enumeration calls.
+    let mut found = unsafe { Thread32First(snapshot.as_raw_handle(), &mut entry) } != 0;
+    while found {
+        if entry.th32OwnerProcessID == pid {
+            // SAFETY: OpenThread returns an owned handle when the thread still
+            // exists and grants the requested resume right.
+            let raw_thread = unsafe { OpenThread(THREAD_SUSPEND_RESUME, 0, entry.th32ThreadID) };
+            if raw_thread.is_null() {
+                return Err(io::Error::last_os_error());
+            }
+            // SAFETY: OpenThread returned an owned handle.
+            let thread = unsafe { OwnedHandle::from_raw_handle(raw_thread) };
+            // SAFETY: The handle was opened with THREAD_SUSPEND_RESUME.
+            if unsafe { ResumeThread(thread.as_raw_handle()) } == u32::MAX {
+                return Err(io::Error::last_os_error());
+            }
+            return Ok(());
+        }
+        // SAFETY: snapshot and entry remain valid across enumeration.
+        found = unsafe { Thread32Next(snapshot.as_raw_handle(), &mut entry) } != 0;
+    }
+    Err(io::Error::new(
+        io::ErrorKind::NotFound,
+        format!("suspended process {pid} had no resumable thread"),
+    ))
 }
 
 #[cfg(test)]
@@ -135,17 +216,17 @@ mod tests {
 
         let pid_file = env::var_os(CHILD_PID_FILE).expect("missing child PID file");
         let job = KillOnCloseJob::new().expect("create job");
-        let child = Command::new("powershell.exe")
-            .args([
-                "-NoLogo",
-                "-NoProfile",
-                "-NonInteractive",
-                "-Command",
-                "Start-Sleep -Seconds 300",
-            ])
-            .spawn()
-            .expect("spawn child");
-        job.assign(&child).expect("assign child");
+        let mut command = Command::new("powershell.exe");
+        command.args([
+            "-NoLogo",
+            "-NoProfile",
+            "-NonInteractive",
+            "-Command",
+            "Start-Sleep -Seconds 300",
+        ]);
+        let child = job
+            .spawn_assigned(&mut command)
+            .expect("spawn assigned child");
         fs::write(pid_file, child.id().to_string()).expect("publish child PID");
 
         let _job = job;

--- a/npm-packages/convex/src/cli/lib/localDeployment/run.ts
+++ b/npm-packages/convex/src/cli/lib/localDeployment/run.ts
@@ -91,6 +91,7 @@ export async function runLocalBackend(
         );
       }
     }
+    commandArgs.push("--shutdown-on-stdin-close");
   }
 
   // Check that binary works by running with --help
@@ -132,7 +133,15 @@ export async function runLocalBackend(
   logVerbose(`Starting local backend: \`${commandStr}\``);
   const p = child_process
     .spawn(args.binaryPath, commandArgs, {
-      stdio: "ignore",
+      // Current local backends treat stdin EOF as a graceful shutdown signal.
+      // The pipe also closes if the CLI exits abruptly, so the backend can
+      // drain workers and remove executor temporary state before it exits.
+      stdio: args.isLatestVersion ? ["pipe", "ignore", "ignore"] : "ignore",
+      // Windows otherwise terminates the backend with its Node parent before
+      // the stdin EOF handler can run. A hidden, detached process group keeps
+      // the backend alive only long enough to complete its owned shutdown.
+      detached: process.platform === "win32" && args.isLatestVersion,
+      windowsHide: true,
       env: {
         ...process.env,
         SENTRY_DSN: LOCAL_BACKEND_SENTRY_DSN,
@@ -144,7 +153,17 @@ export async function runLocalBackend(
     });
   const cleanupHandle = ctx.registerCleanup(async () => {
     logVerbose(`Stopping local backend on port ${ports.cloud}`);
+    if (args.isLatestVersion && p.stdin !== null) {
+      p.stdin.end();
+      if (await waitForProcessExit(p, 5_000)) {
+        return;
+      }
+    }
+
+    // Older backends do not understand the stdin lifecycle contract. Current
+    // backends also reach this fallback if graceful shutdown exceeds its bound.
     p.kill("SIGTERM");
+    await waitForProcessExit(p, 5_000);
   });
 
   await ensureBackendRunning(ctx, {
@@ -156,6 +175,39 @@ export async function runLocalBackend(
   return {
     cleanupHandle,
   };
+}
+
+function waitForProcessExit(
+  child: child_process.ChildProcess,
+  timeoutMs: number,
+): Promise<boolean> {
+  if (child.exitCode !== null || child.signalCode !== null) {
+    return Promise.resolve(true);
+  }
+
+  return new Promise((resolve) => {
+    let settled = false;
+    const finish = (exited: boolean) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      clearTimeout(timeout);
+      child.removeListener("exit", onExit);
+      resolve(exited);
+    };
+    const onExit = () => {
+      finish(true);
+    };
+    const timeout = setTimeout(() => {
+      finish(false);
+    }, timeoutMs);
+    child.once("exit", onExit);
+    // Close the race between the check above and listener registration.
+    if (child.exitCode !== null || child.signalCode !== null) {
+      finish(true);
+    }
+  });
 }
 
 /** Crash if correct local backend is not currently listening on the expected port. */

--- a/npm-packages/convex/src/cli/lib/localDeployment/run.ts
+++ b/npm-packages/convex/src/cli/lib/localDeployment/run.ts
@@ -91,15 +91,14 @@ export async function runLocalBackend(
         );
       }
     }
-    commandArgs.push("--shutdown-on-stdin-close");
   }
 
-  // Check that binary works by running with --help
+  // Probe the binary's actual lifecycle capability. `isLatestVersion` describes
+  // the selected upgrade path, but that path can intentionally point at an
+  // older downloaded backend during a downgrade.
+  let supportsStdinShutdown = false;
   try {
-    const result = child_process.spawnSync(args.binaryPath, [
-      ...commandArgs,
-      "--help",
-    ]);
+    const result = child_process.spawnSync(args.binaryPath, ["--help"]);
     if (result.status === 3221225781) {
       const message =
         "Local backend exited because shared libraries are missing. These may include libraries installed via 'Microsoft Visual C++ Redistributable for Visual Studio.'";
@@ -120,6 +119,8 @@ export async function runLocalBackend(
         errForSentry: new LocalDeploymentError(message),
       });
     }
+    const help = `${result.stdout?.toString() ?? ""}\n${result.stderr?.toString() ?? ""}`;
+    supportsStdinShutdown = help.includes("--shutdown-on-stdin-close");
   } catch (e) {
     const message = `Failed to run backend binary: ${(e as any).toString()}`;
     return ctx.crash({
@@ -129,6 +130,9 @@ export async function runLocalBackend(
       errForSentry: new LocalDeploymentError(message),
     });
   }
+  if (supportsStdinShutdown) {
+    commandArgs.push("--shutdown-on-stdin-close");
+  }
   const commandStr = `${args.binaryPath} ${commandArgs.join(" ")}`;
   logVerbose(`Starting local backend: \`${commandStr}\``);
   const p = child_process
@@ -136,11 +140,11 @@ export async function runLocalBackend(
       // Current local backends treat stdin EOF as a graceful shutdown signal.
       // The pipe also closes if the CLI exits abruptly, so the backend can
       // drain workers and remove executor temporary state before it exits.
-      stdio: args.isLatestVersion ? ["pipe", "ignore", "ignore"] : "ignore",
+      stdio: supportsStdinShutdown ? ["pipe", "ignore", "ignore"] : "ignore",
       // Windows otherwise terminates the backend with its Node parent before
       // the stdin EOF handler can run. A hidden, detached process group keeps
       // the backend alive only long enough to complete its owned shutdown.
-      detached: process.platform === "win32" && args.isLatestVersion,
+      detached: process.platform === "win32" && supportsStdinShutdown,
       windowsHide: true,
       env: {
         ...process.env,
@@ -153,7 +157,7 @@ export async function runLocalBackend(
     });
   const cleanupHandle = ctx.registerCleanup(async () => {
     logVerbose(`Stopping local backend on port ${ports.cloud}`);
-    if (args.isLatestVersion && p.stdin !== null) {
+    if (supportsStdinShutdown && p.stdin !== null) {
       p.stdin.end();
       if (await waitForProcessExit(p, 5_000)) {
         return;

--- a/npm-packages/convex/src/cli/lib/localDeployment/run.ts
+++ b/npm-packages/convex/src/cli/lib/localDeployment/run.ts
@@ -119,8 +119,14 @@ export async function runLocalBackend(
         errForSentry: new LocalDeploymentError(message),
       });
     }
-    const help = `${result.stdout?.toString() ?? ""}\n${result.stderr?.toString() ?? ""}`;
-    supportsStdinShutdown = help.includes("--shutdown-on-stdin-close");
+    // The lifecycle flag is intentionally hidden from operator help. Probe it
+    // alongside --version, which exits before startup: current backends accept
+    // the flag and older backends reject it without opening the database.
+    const lifecycleProbe = child_process.spawnSync(args.binaryPath, [
+      "--shutdown-on-stdin-close",
+      "--version",
+    ]);
+    supportsStdinShutdown = lifecycleProbe.status === 0;
   } catch (e) {
     const message = `Failed to run backend binary: ${(e as any).toString()}`;
     return ctx.crash({


### PR DESCRIPTION
## Summary

- Keep current Windows local backends alive long enough to observe CLI stdin EOF and complete application shutdown, while keeping the backend window hidden.
- Assign each Windows Node action executor to a kill-on-close Job Object so abrupt backend termination cannot strand the executor process tree.
- Make executor shutdown explicit: stop and reap Node, close the named-pipe client, remove the executor temp directory with a bounded Windows retry, and propagate persistent cleanup failures.
- Preserve the existing SIGTERM fallback for older backend versions and document activation, verification, and rollback.

## Failure reproduced

Force-terminating a running Convex CLI previously ended its Node-spawned backend before Rust cleanup could run. The backend's Node action executor, named pipe, and temporary source directory could therefore outlive the dev session. The implementation separates the backend from the CLI's Windows process group but retains the stdin ownership pipe; the backend now receives EOF, drains, and cleans up. The Job Object covers abrupt backend termination.

## Verification

- cargo test -p node_executor --lib -- --nocapture (7 passed)
- cargo build -p local_backend --bin convex-local-backend
- Convex package Prettier, ESLint, and TypeScript checks
- Built the CLI and backend, ran a real Node action, and verified ordinary CLI exit left no backend PID, executor PID, named pipe, or executor temp directory.
- Repeated with forced CLI termination and verified all four resources were absent after shutdown.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/get-convex/convex-backend/pull/537?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

