### PR TITLE
values: remove shared UTF-8 comparison buffers

### DIFF
--- a/npm-packages/convex/src/values/compare.ts
+++ b/npm-packages/convex/src/values/compare.ts
@@ -30,11 +30,7 @@ function compareSameTypeValues<T>(v1: T, v2: T): number {
     }
     return compareUTF8(v1, v2);
   }
-  if (
-    typeof v1 === "bigint" ||
-    typeof v1 === "boolean" ||
-    typeof v1 === "string"
-  ) {
+  if (typeof v1 === "bigint" || typeof v1 === "boolean") {
     return v1 < v2 ? -1 : v1 === v2 ? 0 : 1;
   }
   if (!Array.isArray(v1) || !Array.isArray(v2)) {

--- a/npm-packages/convex/src/values/compare_utf8.test.ts
+++ b/npm-packages/convex/src/values/compare_utf8.test.ts
@@ -1,0 +1,156 @@
+import { expect, test } from "vitest";
+
+import { compareValues } from "./compare.js";
+import { compareUTF8 } from "./compare_utf8.js";
+
+function encodeCodePoint(codePoint: number): number[] {
+  // TextEncoder replaces lone surrogates with U+FFFD. Encode the numeric code
+  // point directly to model the historical comparator for malformed UTF-16.
+  if (codePoint < 0x80) {
+    return [codePoint];
+  }
+  if (codePoint <= 0x07ff) {
+    return [0xc0 | (codePoint >> 6), 0x80 | (codePoint & 0x3f)];
+  }
+  if (codePoint <= 0xffff) {
+    return [
+      0xe0 | (codePoint >> 12),
+      0x80 | ((codePoint >> 6) & 0x3f),
+      0x80 | (codePoint & 0x3f),
+    ];
+  }
+  return [
+    0xf0 | (codePoint >> 18),
+    0x80 | ((codePoint >> 12) & 0x3f),
+    0x80 | ((codePoint >> 6) & 0x3f),
+    0x80 | (codePoint & 0x3f),
+  ];
+}
+
+function referenceCompareUTF8(a: string, b: string): number {
+  const length = Math.min(a.length, b.length);
+  for (let i = 0; i < length; ) {
+    const aCodePoint = a.codePointAt(i)!;
+    const bCodePoint = b.codePointAt(i)!;
+    if (aCodePoint !== bCodePoint) {
+      const aBytes = encodeCodePoint(aCodePoint);
+      const bBytes = encodeCodePoint(bCodePoint);
+      const byteLength = Math.min(aBytes.length, bBytes.length);
+      for (let byte = 0; byte < byteLength; byte++) {
+        if (aBytes[byte] !== bBytes[byte]) {
+          return aBytes[byte] - bBytes[byte];
+        }
+      }
+      return aBytes.length - bBytes.length;
+    }
+    i += aCodePoint > 0xffff ? 2 : 1;
+  }
+  return a.length - b.length;
+}
+
+test("preserves exact historical numeric results", () => {
+  const cases = [
+    ["\u0000", "\u007f"],
+    ["\u007f", "\u0080"],
+    ["\u0080", "\u0100"],
+    ["\u0080", "\u00bf"],
+    ["\u07ff", "\u0800"],
+    ["\u0800", "\u1000"],
+    ["\u0800", "\u0840"],
+    ["\u0800", "\u083f"],
+    ["\uffff", "\u{10000}"],
+    ["\u{10000}", "\u{40000}"],
+    ["\u{10000}", "\u{11000}"],
+    ["\u{10000}", "\u{10040}"],
+    ["\u{10000}", "\u{1003f}"],
+    ["same", "same\u0800"],
+    ["same", "same\u{10000}"],
+  ] as const;
+
+  for (const [a, b] of cases) {
+    const expected = referenceCompareUTF8(a, b);
+    expect(
+      compareUTF8(a, b),
+      `${JSON.stringify(a)} < ${JSON.stringify(b)}`,
+    ).toBe(expected);
+    expect(
+      compareUTF8(b, a),
+      `${JSON.stringify(b)} > ${JSON.stringify(a)}`,
+    ).toBe(-expected);
+  }
+});
+
+test("preserves the numeric result exposed by compareValues", () => {
+  expect(compareValues("\u0080", "\u0100")).toBe(-2);
+  expect(compareValues("\u0800", "\u0840")).toBe(-1);
+  expect(compareValues("\u{10000}", "\u{1003f}")).toBe(-63);
+});
+
+test("preserves comparison behavior for lone and paired surrogates", () => {
+  const strings = [
+    "\ud7ff",
+    "\ud800",
+    "\ud800A",
+    "\ud800\udc00",
+    "\udbff\udfff",
+    "\udc00",
+    "\udfff",
+    "\ue000",
+  ];
+
+  for (const a of strings) {
+    for (const b of strings) {
+      expect(
+        compareUTF8(a, b),
+        `${JSON.stringify(a)}, ${JSON.stringify(b)}`,
+      ).toBe(referenceCompareUTF8(a, b));
+    }
+  }
+});
+
+test("matches the reference for every adjacent code point", () => {
+  let previous = String.fromCodePoint(0);
+  for (let codePoint = 1; codePoint <= 0x10ffff; codePoint++) {
+    const current = String.fromCodePoint(codePoint);
+    const ascending = compareUTF8(previous, current);
+    const expectedAscending = referenceCompareUTF8(previous, current);
+    const descending = compareUTF8(current, previous);
+    const expectedDescending = referenceCompareUTF8(current, previous);
+    if (ascending !== expectedAscending || descending !== expectedDescending) {
+      throw new Error(
+        `Mismatch around U+${codePoint.toString(16)}: ` +
+          `${ascending}, ${expectedAscending}, ${descending}, ${expectedDescending}`,
+      );
+    }
+    previous = current;
+  }
+});
+
+test("matches the reference for arbitrary UTF-16 strings", () => {
+  let state = 0x2f6e2b1;
+  const randomCodeUnit = () => {
+    state = (Math.imul(state, 1664525) + 1013904223) >>> 0;
+    return state >>> 16;
+  };
+  const randomString = () => {
+    const length = randomCodeUnit() % 12;
+    let value = "";
+    for (let i = 0; i < length; i++) {
+      value += String.fromCharCode(randomCodeUnit());
+    }
+    return value;
+  };
+
+  for (let i = 0; i < 25_000; i++) {
+    const a = randomString();
+    const b = randomString();
+    const actual = compareUTF8(a, b);
+    const expected = referenceCompareUTF8(a, b);
+    if (actual !== expected) {
+      throw new Error(
+        `Mismatch for ${JSON.stringify(a)}, ${JSON.stringify(b)}: ` +
+          `${actual}, ${expected}`,
+      );
+    }
+  }
+});

--- a/npm-packages/convex/src/values/compare_utf8.ts
+++ b/npm-packages/convex/src/values/compare_utf8.ts
@@ -1,149 +1,106 @@
 /**
- * Taken from https://github.com/rocicorp/compare-utf8/blob/main/LICENSE
+ * Derived from https://github.com/rocicorp/compare-utf8/tree/v0.1.1
  * (Apache Version 2.0, January 2004)
  */
 
 /**
- * This is copied here instead of added as a dependency to avoid bundling issues.
+ * This is kept here instead of added as a dependency to avoid bundling issues.
  */
 
 /**
- * Compares two JavaScript strings as if they were UTF-8 encoded byte arrays.
+ * Orders two JavaScript strings as if they were UTF-8 encoded byte arrays.
+ * Returns the difference between the first unequal bytes, or the difference
+ * between the UTF-16 lengths after all compared code points are equal. For
+ * malformed UTF-16, lone surrogate code units are treated as three-byte code
+ * points to preserve the historical behavior.
+ *
  * @param {string} a
  * @param {string} b
  * @returns {number}
  */
 export function compareUTF8(a: string, b: string): number {
+  if (a === b) {
+    return 0;
+  }
+
   const aLength = a.length;
   const bLength = b.length;
   const length = Math.min(aLength, bLength);
   for (let i = 0; i < length; ) {
-    const aCodePoint = a.codePointAt(i)!;
-    const bCodePoint = b.codePointAt(i)!;
-    if (aCodePoint !== bCodePoint) {
+    const aCodeUnit = a.charCodeAt(i);
+    const bCodeUnit = b.charCodeAt(i);
+    if (aCodeUnit !== bCodeUnit) {
       // Code points below 0x80 are represented the same way in UTF-8 as in
       // UTF-16.
-      if (aCodePoint < 0x80 && bCodePoint < 0x80) {
-        return aCodePoint - bCodePoint;
+      if (aCodeUnit < 0x80 && bCodeUnit < 0x80) {
+        return aCodeUnit - bCodeUnit;
       }
-
-      // get the UTF-8 bytes for the code points
-      const aLength = utf8Bytes(aCodePoint, aBytes);
-      const bLength = utf8Bytes(bCodePoint, bBytes);
-      return compareArrays(aBytes, aLength, bBytes, bLength);
+      const aCodePoint =
+        aCodeUnit >= 0xd800 && aCodeUnit <= 0xdbff
+          ? a.codePointAt(i)!
+          : aCodeUnit;
+      const bCodePoint =
+        bCodeUnit >= 0xd800 && bCodeUnit <= 0xdbff
+          ? b.codePointAt(i)!
+          : bCodeUnit;
+      return compareCodePointsAsUTF8(aCodePoint, bCodePoint);
     }
 
-    i += utf16LengthForCodePoint(aCodePoint);
+    if (aCodeUnit >= 0xd800 && aCodeUnit <= 0xdbff) {
+      // Equal leading surrogates can still represent different code points
+      // when only one string has a trailing surrogate.
+      const aCodePoint = a.codePointAt(i)!;
+      const bCodePoint = b.codePointAt(i)!;
+      if (aCodePoint !== bCodePoint) {
+        return compareCodePointsAsUTF8(aCodePoint, bCodePoint);
+      }
+      if (aCodePoint > 0xffff) {
+        i += 2;
+        continue;
+      }
+    }
+    i++;
   }
 
   return aLength - bLength;
 }
 
 /**
- * @param {number[]} a
- * @param {number} aLength
- * @param {number[]} b
- * @param {number} bLength
+ * Return the difference between the first unequal bytes in the UTF-8
+ * encodings of two different code points.
+ *
+ * @param {number} a
+ * @param {number} b
  * @returns {number}
  */
-function compareArrays(
-  a: number[],
-  aLength: number,
-  b: number[],
-  bLength: number,
-) {
-  const length = Math.min(aLength, bLength);
-  for (let i = 0; i < length; i++) {
-    const aValue = a[i];
-    const bValue = b[i];
-    if (aValue !== bValue) {
-      return aValue - bValue;
-    }
-  }
-  return aLength - bLength;
-}
+function compareCodePointsAsUTF8(a: number, b: number): number {
+  const aByteLength = a < 0x80 ? 1 : a <= 0x07ff ? 2 : a <= 0xffff ? 3 : 4;
+  const bByteLength = b < 0x80 ? 1 : b <= 0x07ff ? 2 : b <= 0xffff ? 3 : 4;
 
-/**
- * @param {number} aCodePoint
- * @returns {number}
- */
-export function utf16LengthForCodePoint(aCodePoint: number) {
-  return aCodePoint > 0xffff ? 2 : 1;
-}
-
-// 2 preallocated arrays for utf8Bytes.
-const arr = () => Array.from({ length: 4 }, () => 0);
-const aBytes = arr();
-const bBytes = arr();
-
-/**
- * @param {number} codePoint
- * @param {number[]} bytes
- * @returns {number}
- */
-function utf8Bytes(codePoint: number, bytes: number[]) {
-  if (codePoint < 0x80) {
-    bytes[0] = codePoint;
-    return 1;
+  if (aByteLength === bByteLength) {
+    // Code points fit in 21 bits, so signed 32-bit bitwise coercion preserves
+    // their values. UTF-8 stores those bits in six-bit groups. With equal byte
+    // lengths, the encoding prefixes cancel, so the highest differing group
+    // gives the first unequal byte without materializing either encoding.
+    const shift = Math.floor((31 - Math.clz32(a ^ b)) / 6) * 6;
+    return (a >> shift) - (b >> shift);
   }
 
-  let count;
-  let offset;
-
-  if (codePoint <= 0x07ff) {
-    count = 1;
-    offset = 0xc0;
-  } else if (codePoint <= 0xffff) {
-    count = 2;
-    offset = 0xe0;
-  } else if (codePoint <= 0x10ffff) {
-    count = 3;
-    offset = 0xf0;
-  } else {
-    throw new Error("Invalid code point");
-  }
-
-  bytes[0] = (codePoint >> (6 * count)) + offset;
-  let i = 1;
-  for (; count > 0; count--) {
-    const temp = codePoint >> (6 * (count - 1));
-    bytes[i++] = 0x80 | (temp & 0x3f);
-  }
-  return i;
-}
-
-/**
- * @param {string} a
- * @param {string} b
- * @returns {boolean}
- */
-export function greaterThan(a: string, b: string) {
-  return compareUTF8(a, b) > 0;
-}
-
-/**
- * @param {string} a
- * @param {string} b
- * @returns {boolean}
- */
-export function greaterThanEq(a: string, b: string) {
-  return compareUTF8(a, b) >= 0;
-}
-
-/**
- * @param {string} a
- * @param {string} b
- * @returns {boolean}
- */
-export function lessThan(a: string, b: string) {
-  return compareUTF8(a, b) < 0;
-}
-
-/**
- * @param {string} a
- * @param {string} b
- * @returns {boolean}
- */
-export function lessThanEq(a: string, b: string) {
-  return compareUTF8(a, b) <= 0;
+  const aLeadingByte =
+    aByteLength === 1
+      ? a
+      : aByteLength === 2
+        ? 0xc0 | (a >> 6)
+        : aByteLength === 3
+          ? 0xe0 | (a >> 12)
+          : 0xf0 | (a >> 18);
+  const bLeadingByte =
+    bByteLength === 1
+      ? b
+      : bByteLength === 2
+        ? 0xc0 | (b >> 6)
+        : bByteLength === 3
+          ? 0xe0 | (b >> 12)
+          : 0xf0 | (b >> 18);
+  return aLeadingByte - bLeadingByte;
 }


### PR DESCRIPTION
## Motivation

Convex context reuse intentionally keeps a loaded module instance alive across multiple function invocations. That changes the lifetime of module-scope variables: top-level state is not discarded when one invocation returns, and can be observed by later invocations that reuse the instance. Request-derived state must therefore remain invocation-local. Otherwise the implementation has to prove, for every path and every future change, that data retained in module state can never affect or be exposed to another invocation.

`compare_utf8` currently keeps two UTF-8 scratch arrays at module scope. Each comparison writes bytes derived from its input strings into those arrays, and the bytes remain there after the call until a later comparison or module teardown. The comparator is synchronous, so this is not a data race, and the stale bytes are not currently observable in its result. It is nevertheless unnecessary cross-invocation retention of request-derived data. It lengthens the data lifetime beyond the invocation boundary and makes the context-reuse contract depend on a subtle overwrite proof rather than on the simpler invariant that invocation data does not escape into module state.

Removing the arrays makes that invariant structural. The comparison state is local to the call, so it cannot survive an invocation, and future changes such as new early-return, error, reentrancy, or asynchronous call paths do not inherit a hidden module-level buffer to audit. This is a correctness and isolation improvement for reused module instances, not a claim that the old comparator currently returns incorrect values.

## Summary

Remove the module-scoped UTF-8 scratch arrays. Scan ordinary UTF-16 code units with `charCodeAt`, resolve full code points only at surrogate boundaries, and compute the first unequal UTF-8 byte directly from code-point bit groups. Also short-circuit equal strings.

This makes comparison state invocation-local without replacing the shared buffers with per-comparison heap allocation. Avoiding encoded byte arrays and their writes also keeps the comparator hot path small. The implementation preserves the exact existing numeric results of the comparator, including its historical handling of malformed UTF-16 and UTF-16 prefix lengths.

## Test plan

- Added reference-based tests for UTF-8 encoding boundaries and exact `compareValues` results.
- Covered paired and lone surrogates.
- Compared every adjacent code-point pair in both directions.
- Compared 25,000 deterministic arbitrary UTF-16 string pairs.
- Ran package lint, typecheck, and build.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

