### PR TITLE
ai-sdk-provider: surface gateway usage.cost as provider metadata

### DIFF
--- a/npm-packages/@convex-dev/ai-sdk-provider/src/index.ts
+++ b/npm-packages/@convex-dev/ai-sdk-provider/src/index.ts
@@ -1,6 +1,9 @@
 import { createAnthropic } from "@ai-sdk/anthropic";
 import { createOpenAI } from "@ai-sdk/openai";
-import { createOpenAICompatible } from "@ai-sdk/openai-compatible";
+import {
+  createOpenAICompatible,
+  type MetadataExtractor,
+} from "@ai-sdk/openai-compatible";
 import {
   defaultSettingsMiddleware,
   wrapEmbeddingModel,
@@ -44,11 +47,57 @@ async function gatewayFetch(
   return globalThis.fetch(input, { ...init, headers });
 }
 
+/**
+ * The gateway returns the authoritative dollar cost of each request in the
+ * OpenAI-compatible `usage` object — `usage.cost` (total USD) plus a
+ * `usage.cost_details` breakdown. The AI SDK's usage mapping doesn't carry
+ * these, so surface them as provider metadata under the `convexGateway` key:
+ *
+ *   const { providerMetadata } = await generateText({ model: convexGateway(id), ... });
+ *   providerMetadata?.convexGateway?.cost;         // e.g. 3.9e-6 (USD)
+ *   providerMetadata?.convexGateway?.costDetails;  // per-part breakdown
+ */
+type ProviderMetadata = Awaited<
+  ReturnType<MetadataExtractor["extractMetadata"]>
+>;
+
+function convexGatewayUsageMetadata(usage: unknown): ProviderMetadata {
+  if (!usage || typeof usage !== "object") return undefined;
+  const u = usage as Record<string, unknown>;
+  const meta: Record<string, unknown> = {};
+  if (typeof u.cost === "number") meta.cost = u.cost;
+  if (u.cost_details && typeof u.cost_details === "object") {
+    meta.costDetails = u.cost_details;
+  }
+  return Object.keys(meta).length > 0
+    ? ({ convexGateway: meta } as ProviderMetadata)
+    : undefined;
+}
+
+const costMetadataExtractor: MetadataExtractor = {
+  extractMetadata: async ({ parsedBody }) =>
+    convexGatewayUsageMetadata(
+      (parsedBody as { usage?: unknown } | undefined)?.usage,
+    ),
+  createStreamExtractor: () => {
+    // Streamed responses deliver usage (incl. cost) on the final chunk.
+    let usage: unknown;
+    return {
+      processChunk(parsedChunk: unknown) {
+        const chunk = parsedChunk as { usage?: unknown } | undefined;
+        if (chunk?.usage) usage = chunk.usage;
+      },
+      buildMetadata: () => convexGatewayUsageMetadata(usage),
+    };
+  },
+};
+
 function createGatewayProvider(): Provider {
   return createOpenAICompatible({
     name: "convexGateway",
     baseURL: gatewayBaseURL(),
     fetch: gatewayFetch,
+    metadataExtractor: costMetadataExtractor,
     supportsStructuredOutputs: true,
     supportedUrls: () => ({ "image/*": [/^https?:\/\/.*$/] }),
   });

--- a/npm-packages/@convex-dev/ai-sdk-provider/src/index.ts
+++ b/npm-packages/@convex-dev/ai-sdk-provider/src/index.ts
@@ -6,6 +6,8 @@ import {
 } from "@ai-sdk/openai-compatible";
 import {
   defaultSettingsMiddleware,
+  type JSONValue,
+  type ProviderMetadata,
   wrapEmbeddingModel,
   wrapLanguageModel,
 } from "ai";
@@ -47,30 +49,19 @@ async function gatewayFetch(
   return globalThis.fetch(input, { ...init, headers });
 }
 
-/**
- * The gateway returns the authoritative dollar cost of each request in the
- * OpenAI-compatible `usage` object — `usage.cost` (total USD) plus a
- * `usage.cost_details` breakdown. The AI SDK's usage mapping doesn't carry
- * these, so surface them as provider metadata under the `convexGateway` key:
- *
- *   const { providerMetadata } = await generateText({ model: convexGateway(id), ... });
- *   providerMetadata?.convexGateway?.cost;         // e.g. 3.9e-6 (USD)
- *   providerMetadata?.convexGateway?.costDetails;  // per-part breakdown
- */
-type ProviderMetadata = Awaited<
-  ReturnType<MetadataExtractor["extractMetadata"]>
->;
-
-function convexGatewayUsageMetadata(usage: unknown): ProviderMetadata {
+// The SDK's standard usage mapping omits the gateway's dollar costs.
+function convexGatewayUsageMetadata(
+  usage: unknown,
+): ProviderMetadata | undefined {
   if (!usage || typeof usage !== "object") return undefined;
-  const u = usage as Record<string, unknown>;
-  const meta: Record<string, unknown> = {};
-  if (typeof u.cost === "number") meta.cost = u.cost;
-  if (u.cost_details && typeof u.cost_details === "object") {
-    meta.costDetails = u.cost_details;
+  const { cost, cost_details } = usage as Record<string, JSONValue>;
+  const metadata: ProviderMetadata[string] = {};
+  if (typeof cost === "number") metadata.cost = cost;
+  if (cost_details && typeof cost_details === "object") {
+    metadata.costDetails = cost_details;
   }
-  return Object.keys(meta).length > 0
-    ? ({ convexGateway: meta } as ProviderMetadata)
+  return Object.keys(metadata).length > 0
+    ? { convexGateway: metadata }
     : undefined;
 }
 


### PR DESCRIPTION
> WIP for review.

## What

The Convex AI gateway already returns the **authoritative dollar cost** of each request in the OpenAI-compatible `usage` object, but the AI SDK's usage mapping drops it — so today callers can only *reconstruct* cost from token counts × their own price table.

This surfaces it as provider metadata via a `metadataExtractor` on the gateway's openai-compatible provider:

```ts
const { providerMetadata } = await generateText({ model: convexGateway(id), ... });
providerMetadata?.convexGateway?.cost;         // e.g. 3.9e-6  (USD, authoritative)
providerMetadata?.convexGateway?.costDetails;  // { upstream_inference_cost, ..._prompt_cost, ..._completions_cost }
```

Non-streaming (`extractMetadata`) and streaming (`createStreamExtractor` — usage arrives on the final chunk) are both handled. No other behavior change.

## Evidence

Raw gateway response body for a `gpt-4o-mini` call (captured by cloning the response in the provider's `fetch`), showing the fields the SDK currently discards:

```json
"usage": {
  "prompt_tokens": 14, "completion_tokens": 3, "total_tokens": 17,
  "cost": 3.9e-6,
  "prompt_tokens_details": { "cached_tokens": 0, "cache_write_tokens": 0 },
  "cost_details": {
    "upstream_inference_cost": 3.9e-6,
    "upstream_inference_prompt_cost": 2.1e-6,
    "upstream_inference_completions_cost": 1.8e-6
  }
}
```

Motivation: [`@convex-dev/ai-budget`](https://www.npmjs.com/package/@convex-dev/ai-budget) meters spend; `finishRequest` already prefers an authoritative `costNanos` when present — this is the missing piece to feed it `usage.cost` instead of a token estimate.

## Testing
- Type-checked the extractor in isolation against `@ai-sdk/openai-compatible@3.0.14` (the version this package pins) — clean.
- I couldn't run the full monorepo build/tests in my environment (pnpm workspace). Please run `npm run build` / `npm test` in the package before merge.

## Possible follow-ups
- Also surface `usage.prompt_tokens_details.cache_write_tokens` (cache-write pricing).
- Consider whether `convexGateway.messages` (Anthropic) / `.responses` (OpenAI) paths should expose cost too; the gateway's `cost` is on the same `usage` object, but those go through different providers.


---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
