### PR TITLE
Fix function-spec crash on v.literal(BigInt) validators

### DIFF
--- a/npm-packages/convex/src/cli/lib/functionSpec.test.ts
+++ b/npm-packages/convex/src/cli/lib/functionSpec.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, test } from "vitest";
+import { v } from "../../values/validator.js";
+import { convexToJson } from "../../values/value.js";
+import {
+  apiSpecFunctionsToJson,
+  validatorSpecToJson,
+} from "./functionSpecJson.js";
+
+function bigintLiteralValidatorJson() {
+  return JSON.stringify(
+    v.object({
+      i: v.literal(BigInt(1)),
+    }).json,
+  );
+}
+
+describe("function-spec bigint literals", () => {
+  test("convexToJson rejects parsed validator JSON that contains $integer", () => {
+    const parsed = JSON.parse(bigintLiteralValidatorJson());
+    expect(() => convexToJson(parsed)).toThrow(
+      /Field name \$integer starts with a '\$', which is reserved/,
+    );
+  });
+
+  test("raw validator strings with bigint literals serialize without crashing", () => {
+    const validatorJson = bigintLiteralValidatorJson();
+    const json = apiSpecFunctionsToJson([
+      {
+        identifier: "messages:query12",
+        functionType: "Query",
+        visibility: { kind: "public" },
+        args: validatorJson,
+        returns: validatorJson,
+      },
+    ]);
+    expect(Array.isArray(json)).toBe(true);
+    const spec = (json as any[])[0];
+    expect(spec.args.value.i.fieldType.type).toBe("literal");
+    expect(spec.args.value.i.fieldType.value).toHaveProperty("$integer");
+    expect(spec.returns.value.i.fieldType.value).toHaveProperty("$integer");
+  });
+
+  test("legacy object validators still go through convexToJson", () => {
+    expect(validatorSpecToJson({ type: "any" })).toEqual({ type: "any" });
+  });
+});

--- a/npm-packages/convex/src/cli/lib/functionSpec.ts
+++ b/npm-packages/convex/src/cli/lib/functionSpec.ts
@@ -3,7 +3,7 @@ import chalk from "chalk";
 import { logOutput } from "../../bundler/log.js";
 import { runSystemQuery } from "./run.js";
 import { Context } from "../../bundler/context.js";
-import { convexToJson } from "../../values/value.js";
+import { apiSpecFunctionsToJson } from "./functionSpecJson.js";
 
 export async function functionSpecForDeployment(
   ctx: Context,
@@ -18,7 +18,7 @@ export async function functionSpecForDeployment(
     adminKey: options.adminKey,
     functionName: "_system/cli/modules:apiSpec",
     componentPath: undefined,
-    args: {},
+    args: { rawValidators: true },
   })) as any[];
   const url = (await runSystemQuery(ctx, {
     deploymentUrl: options.deploymentUrl,
@@ -29,7 +29,7 @@ export async function functionSpecForDeployment(
   })) as string;
 
   const output = JSON.stringify(
-    { url, functions: convexToJson(functions) },
+    { url, functions: apiSpecFunctionsToJson(functions) },
     null,
     2,
   );

--- a/npm-packages/convex/src/cli/lib/functionSpecJson.ts
+++ b/npm-packages/convex/src/cli/lib/functionSpecJson.ts
@@ -1,0 +1,39 @@
+import { convexToJson, JSONValue, Value } from "../../values/value.js";
+
+export function validatorSpecToJson(validator: Value): JSONValue {
+  if (typeof validator === "string") {
+    return JSON.parse(validator) as JSONValue;
+  }
+  return convexToJson(validator);
+}
+
+export function apiSpecFunctionsToJson(functions: Value): JSONValue {
+  if (!Array.isArray(functions)) {
+    return convexToJson(functions);
+  }
+  return functions.map((fn) => {
+    if (typeof fn !== "object" || fn === null || Array.isArray(fn)) {
+      return convexToJson(fn);
+    }
+    if (fn.functionType === "HttpAction") {
+      return convexToJson(fn);
+    }
+    const out: { [key: string]: JSONValue } = {};
+    if (fn.identifier !== undefined) {
+      out.identifier = convexToJson(fn.identifier);
+    }
+    if (fn.functionType !== undefined) {
+      out.functionType = convexToJson(fn.functionType);
+    }
+    if (fn.visibility !== undefined) {
+      out.visibility = convexToJson(fn.visibility);
+    }
+    if (fn.args !== undefined) {
+      out.args = validatorSpecToJson(fn.args);
+    }
+    if (fn.returns !== undefined) {
+      out.returns = validatorSpecToJson(fn.returns);
+    }
+    return out;
+  });
+}

--- a/npm-packages/convex/src/cli/lib/mcp/tools/functionSpec.ts
+++ b/npm-packages/convex/src/cli/lib/mcp/tools/functionSpec.ts
@@ -3,7 +3,7 @@ import { ConvexTool } from "./index.js";
 import { loadSelectedDeploymentCredentials } from "../../api.js";
 import { runSystemQuery } from "../../run.js";
 import { getMcpDeploymentSelection } from "../requestContext.js";
-import { convexToJson } from "../../../../values/index.js";
+import { apiSpecFunctionsToJson } from "../../functionSpecJson.js";
 
 const inputSchema = z.object({
   deploymentSelector: z
@@ -53,8 +53,8 @@ export const FunctionSpecTool: ConvexTool<
       adminKey: credentials.adminKey,
       functionName: "_system/cli/modules:apiSpec",
       componentPath: undefined,
-      args: {},
+      args: { rawValidators: true },
     });
-    return convexToJson(functions);
+    return apiSpecFunctionsToJson(functions);
   },
 };

--- a/npm-packages/convex/src/cli/lib/run.ts
+++ b/npm-packages/convex/src/cli/lib/run.ts
@@ -78,7 +78,7 @@ export async function runFunctionAndLog(
         adminKey: args.adminKey,
         functionName: "_system/cli/modules:apiSpec",
         componentPath: args.componentPath,
-        args: {},
+        args: { rawValidators: true },
       })) as (
         | {
             functionType: "Query" | "Mutation" | "Action";

--- a/npm-packages/system-udfs/convex/_system/cli/modules.ts
+++ b/npm-packages/system-udfs/convex/_system/cli/modules.ts
@@ -21,11 +21,19 @@ type FunctionSpecs = (FunctionSpec | HttpFunctionSpec)[];
 export const DEFAULT_ARGS_VALIDATOR = '{ "type": "any" }';
 export const DEFAULT_RETURN_VALIDATOR = '{ "type": "any" }';
 
+function encodeValidator(validatorJson: string, rawValidators: boolean): Value {
+  if (rawValidators) {
+    return validatorJson;
+  }
+  return jsonToConvex(JSON.parse(validatorJson));
+}
+
 export const apiSpec = queryPrivateSystem("ViewData")({
   args: {
     componentId: v.optional(v.union(v.string(), v.null())),
+    rawValidators: v.optional(v.boolean()),
   },
-  handler: async ({ db }): Promise<FunctionSpecs> => {
+  handler: async ({ db }, { rawValidators }): Promise<FunctionSpecs> => {
     const result: FunctionSpecs = [];
     for await (const module of db.query("_modules")) {
       const analyzeResult = module.analyzeResult;
@@ -40,8 +48,8 @@ export const apiSpec = queryPrivateSystem("ViewData")({
           identifier: module.path + ":" + fn.name,
           functionType: fn.udfType,
           visibility: fn.visibility ?? { kind: "public" },
-          args: jsonToConvex(JSON.parse(argsValidator)),
-          returns: jsonToConvex(JSON.parse(returnsValidator)),
+          args: encodeValidator(argsValidator, rawValidators === true),
+          returns: encodeValidator(returnsValidator, rawValidators === true),
         });
       }
 


### PR DESCRIPTION
`npx convex function-spec` crashed with `Field name $integer starts with a '$', which is reserved` whenever a function used `v.literal(BigInt(...))` (and the same path broke special float literals). Validator JSON is not a Convex value: `$integer` / `$float` encodings are reserved field names when that JSON is returned from a query.

`apiSpec` now accepts `rawValidators`. New CLI/MCP callers request that flag and get arg/return validators as JSON strings, then parse them client-side. Older CLIs keep the previous `jsonToConvex` path.

## Test plan
- [x] `tsx --test npm-packages/convex/src/cli/lib/functionSpec.test.ts` (3 passing): `convexToJson` still rejects parsed `$integer` validator JSON; string validators with `v.literal(BigInt(1))` serialize; legacy object validators still round-trip through `convexToJson`.

Fixes #212

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
