### PR TITLE
SQLite: paginate index_scan/load_documents and stream each page by walking the primary key

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9762,6 +9762,7 @@ dependencies = [
  "futures",
  "futures-async-stream",
  "parking_lot",
+ "proptest",
  "rusqlite",
  "serde",
  "serde_json",

--- a/crates/sqlite/Cargo.toml
+++ b/crates/sqlite/Cargo.toml
@@ -24,6 +24,7 @@ serde_json = { workspace = true }
 
 [dev-dependencies]
 common = { workspace = true, features = ["testing"] }
+proptest = { workspace = true }
 tempfile = { workspace = true }
 tokio = { workspace = true }
 

--- a/crates/sqlite/src/lib.rs
+++ b/crates/sqlite/src/lib.rs
@@ -49,7 +49,6 @@ use common::{
     },
     query::Order,
     runtime::CoopStreamExt as _,
-    try_anyhow,
     types::{
         IndexId,
         PersistenceVersion,
@@ -61,10 +60,7 @@ use common::{
         TabletId,
     },
 };
-use futures::{
-    stream,
-    StreamExt,
-};
+use futures::StreamExt;
 use futures_async_stream::try_stream;
 use parking_lot::Mutex;
 use rusqlite::{
@@ -104,105 +100,195 @@ impl SqlitePersistence {
         })
     }
 
-    #[allow(clippy::needless_lifetimes)]
-    #[try_stream(ok = T, error = anyhow::Error)]
-    async fn validate_snapshot<T: 'static>(
+    /// Read one page of the documents log, at most `page_size` rows, resuming
+    /// strictly after `cursor` — the `(ts, table_id, id)` primary key of the
+    /// last row the previous page read, in scan order.
+    fn _load_documents_page(
         &self,
-        ts: Timestamp,
-        retention_validator: Arc<dyn RetentionValidator>,
-    ) {
-        retention_validator.validate_snapshot(ts).await?;
+        tablet_id: Option<TabletId>,
+        range: TimestampRange,
+        order: Order,
+        page_size: usize,
+        cursor: Option<&(u64, Vec<u8>, Vec<u8>)>,
+    ) -> anyhow::Result<Vec<DocumentLogEntry>> {
+        // Outlives `params`, which borrows from it.
+        let tablet_id_bytes = tablet_id.map(|tablet_id| tablet_id.0);
+        let tablet_id_slice = tablet_id_bytes.as_ref().map(|bytes| &bytes[..]);
+        let mut params: Vec<&dyn ToSql> = vec![];
+        // Placeholder numbers are derived from `params` as each one is bound,
+        // so adding a parameter can never silently renumber the ones after it.
+        let tablet_bound = match tablet_id_slice {
+            Some(ref tablet_id) => {
+                params.push(tablet_id);
+                format!(" AND table_id = ${}", params.len())
+            },
+            None => String::new(),
+        };
+        let cursor_bound = match cursor {
+            // `table_id` here is the middle component of the primary key, used
+            // to break ties within a timestamp. It is unrelated to
+            // `tablet_bound` above, which restricts the rows considered at all.
+            Some((ts, table_id, id)) => {
+                let cmp = match order {
+                    Order::Asc => ">",
+                    Order::Desc => "<",
+                };
+                params.push(ts);
+                let ts_param = params.len();
+                params.push(table_id);
+                let table_param = params.len();
+                params.push(id);
+                let id_param = params.len();
+                format!(
+                    " AND (ts {cmp} ${ts_param} OR (ts = ${ts_param} AND (table_id {cmp} \
+                     ${table_param} OR (table_id = ${table_param} AND id {cmp} ${id_param}))))"
+                )
+            },
+            None => String::new(),
+        };
+        let order_str = match order {
+            Order::Asc => "ASC",
+            Order::Desc => "DESC",
+        };
+        let query = format!(
+            r#"
+SELECT id, ts, table_id, json_value, deleted, prev_ts
+FROM documents
+WHERE ts >= {min} AND ts < {max}{tablet_bound}{cursor_bound}
+ORDER BY ts {order_str}, table_id {order_str}, id {order_str}
+LIMIT {page_size}
+"#,
+            min = range.min_timestamp_inclusive(),
+            max = range.max_timestamp_exclusive(),
+        );
+        let connection = &self.inner.lock().connection;
+        let mut stmt = connection.prepare(&query)?;
+        let mut page = vec![];
+        for row in stmt.query_map(&params[..], load_document_row)? {
+            let (document_id, ts, document, prev_ts) = row_to_document(row)?;
+            page.push(DocumentLogEntry {
+                ts,
+                id: document_id,
+                value: document,
+                prev_ts,
+            });
+        }
+        Ok(page)
     }
 
-    #[allow(clippy::needless_lifetimes)]
-    #[try_stream(ok = T, error = anyhow::Error)]
-    async fn validate_document_snapshot<T: 'static>(
+    /// Stream the documents log one page at a time. As in the Postgres
+    /// reader, the snapshot is validated against retention after each page is
+    /// read and before any of its rows are yielded: pages are read at
+    /// different times, and each read is only valid while the range's minimum
+    /// timestamp is still within retention. Unlike `_index_scan_paginated`,
+    /// nothing is dropped after the query runs — deletes are part of the log,
+    /// and `tablet_id` restricts the rows the query considers at all, so
+    /// `LIMIT` counts exactly the rows that get yielded — and a short page
+    /// therefore always means the range is exhausted.
+    #[try_stream(ok = DocumentLogEntry, error = anyhow::Error)]
+    async fn _load_documents_paginated(
         &self,
-        ts: Timestamp,
+        tablet_id: Option<TabletId>,
+        range: TimestampRange,
+        order: Order,
+        page_size: usize,
         retention_validator: Arc<dyn RetentionValidator>,
     ) {
-        retention_validator.validate_document_snapshot(ts).await?;
+        let mut cursor: Option<(u64, Vec<u8>, Vec<u8>)> = None;
+        loop {
+            let page =
+                self._load_documents_page(tablet_id, range, order, page_size, cursor.as_ref())?;
+            let page_len = page.len();
+            retention_validator
+                .validate_document_snapshot(range.min_timestamp_inclusive())
+                .await?;
+            for entry in page {
+                cursor = Some((
+                    u64::from(entry.ts),
+                    entry.id.table().0[..].to_vec(),
+                    entry.id.internal_id()[..].to_vec(),
+                ));
+                yield entry;
+            }
+            if page_len < page_size {
+                break;
+            }
+        }
     }
 
-    fn _index_scan_inner(
+    /// Read one page of an index scan, at most `batch_size` keys, resuming
+    /// after `cursor` (the last key the previous page scanned, in scan
+    /// order). Tombstoned keys are returned as `(key, None)`: they must
+    /// still advance the cursor, but must not be emitted to the caller.
+    fn _index_scan_page(
         &self,
         index_id: IndexId,
         tablet_id: TabletId,
         read_timestamp: Timestamp,
         interval: &Interval,
         order: Order,
-    ) -> anyhow::Result<Vec<anyhow::Result<(IndexKeyBytes, LatestDocument)>>> {
+        batch_size: usize,
+        cursor: Option<&IndexKeyBytes>,
+    ) -> anyhow::Result<Vec<(IndexKeyBytes, Option<LatestDocument>)>> {
         let interval = interval.clone();
         let index_id = &index_id.0[..];
         let read_timestamp: u64 = read_timestamp.into();
 
+        // Placeholders are numbered by bind position (`?N`), never by name:
+        // SQLite numbers `$name` placeholders by first textual appearance, and
+        // the read timestamp is used inside the correlated subquery, after
+        // the key bounds. Bind order: ?1 index_id, ?2 read_timestamp, ?3 lower
+        // key, then the upper key and the cursor when present.
         let mut params = params![index_id, read_timestamp].to_vec();
 
         let StartIncluded(ref start) = interval.start;
         let start_bytes = &start[..];
-
         params.push(&start_bytes);
-        let lower = format!(" AND key >= ${}", params.len());
 
         let end_bytes = match interval.end {
             End::Excluded(ref t) => Some(&t[..]),
             End::Unbounded => None,
         };
-        let upper = match end_bytes {
-            Some(ref t) => {
-                params.push(t);
-                format!(" AND key < ${}", params.len())
-            },
-            None => "".to_owned(),
-        };
+        if let Some(ref t) = end_bytes {
+            params.push(t);
+        }
 
-        let order = match order {
-            Order::Asc => "ASC",
-            Order::Desc => "DESC",
-        };
-        let query = format!(
-            r#"
-SELECT B.key, B.ts, B.document_id, C.table_id, C.json_value, C.prev_ts
-FROM (
-    SELECT index_id, key, MAX(ts) as max_ts
-    FROM indexes
-    WHERE index_id = $1 AND ts <= $2{lower}{upper}
-    GROUP BY index_id, key
-) A
-JOIN indexes B
-ON B.deleted is FALSE
-AND A.index_id = B.index_id
-AND A.key = B.key
-AND A.max_ts = B.ts
-LEFT JOIN documents C
-ON B.ts = C.ts
-AND B.table_id = c.table_id
-AND B.document_id = C.id
-ORDER BY B.key {order}
-"#,
-        );
+        let cursor_bytes = cursor.map(|key| &key.0[..]);
+        if let Some(ref t) = cursor_bytes {
+            params.push(t);
+        }
+
+        let query = index_scan_page_sql(order, end_bytes.is_some(), cursor.is_some(), batch_size);
 
         let connection = &self.inner.lock().connection;
         let mut stmt = connection.prepare(&query)?;
         let row_iter = stmt.query_map(&params[..], |row| {
             let key = IndexKeyBytes(row.get::<_, Vec<u8>>(0)?);
             let ts = Timestamp::try_from(row.get::<_, u64>(1)?).expect("timestamp out of bounds");
-            let document_id = row.get::<_, Vec<u8>>(2)?;
+            let document_id: Option<Vec<u8>> = row.get(2)?;
             let table: Option<Vec<u8>> = row.get(3)?;
             let json_value: Option<String> = row.get(4)?;
             let prev_ts: Option<Timestamp> = row
                 .get::<_, Option<u64>>(5)?
                 .map(|ts| Timestamp::try_from(ts).expect("prev_ts out of bounds"));
+            let deleted = row.get::<_, u32>(6)? != 0;
 
-            Ok((key, ts, document_id, table, json_value, prev_ts))
+            Ok((key, ts, document_id, table, json_value, prev_ts, deleted))
         })?;
-        let mut triples = vec![];
+        let mut page = vec![];
         for row in row_iter {
-            let (key, ts, document_id, table, json_value, prev_ts) = row?;
+            let (key, ts, document_id, table, json_value, prev_ts, deleted) = row?;
+            if deleted {
+                page.push((key, None));
+                continue;
+            }
             let table = table.ok_or_else(|| {
                 anyhow::anyhow!("Dangling index reference for {:?} {:?}", key, ts)
             })?;
             let table = TabletId(table.try_into()?);
+            let document_id = document_id.ok_or_else(|| {
+                anyhow::anyhow!("Dangling index reference for {:?} {:?}", key, ts)
+            })?;
             let _document_id = InternalDocumentId::new(table, InternalId::try_from(document_id)?);
             let json_value = json_value.ok_or_else(|| {
                 anyhow::anyhow!("Index reference to deleted document {:?} {:?}", key, ts)
@@ -210,16 +296,59 @@ ORDER BY B.key {order}
             let json_value: serde_json::Value = serde_json::from_str(&json_value)?;
             let value: ConvexValue = json_value.try_into()?;
             let document = ResolvedDocument::from_database(tablet_id, value)?;
-            triples.push(Ok((
+            page.push((
                 key,
-                LatestDocument {
+                Some(LatestDocument {
                     ts,
                     value: document,
                     prev_ts,
-                },
-            )));
+                }),
+            ));
         }
-        Ok(triples)
+        Ok(page)
+    }
+
+    /// Stream an index scan one page at a time. The snapshot is validated
+    /// against retention after each page is read and before any of its rows
+    /// are yielded, mirroring the Postgres reader: pages are read at
+    /// different times, and each read is only valid if the snapshot is still
+    /// within retention.
+    #[try_stream(ok = (IndexKeyBytes, LatestDocument), error = anyhow::Error)]
+    async fn _index_scan_paginated(
+        &self,
+        index_id: IndexId,
+        tablet_id: TabletId,
+        read_timestamp: Timestamp,
+        interval: Interval,
+        order: Order,
+        batch_size: usize,
+        retention_validator: Arc<dyn RetentionValidator>,
+    ) {
+        let mut cursor: Option<IndexKeyBytes> = None;
+        loop {
+            let page = self._index_scan_page(
+                index_id,
+                tablet_id,
+                read_timestamp,
+                &interval,
+                order,
+                batch_size,
+                cursor.as_ref(),
+            )?;
+            let page_len = page.len();
+            retention_validator
+                .validate_snapshot(read_timestamp)
+                .await?;
+            for (key, doc) in page {
+                cursor = Some(key.clone());
+                if let Some(doc) = doc {
+                    yield (key, doc);
+                }
+            }
+            if page_len < batch_size {
+                break;
+            }
+        }
     }
 
     fn _get_persistence_global(
@@ -428,47 +557,23 @@ impl Persistence for SqlitePersistence {
 impl SqlitePersistence {
     /// Read the document log in `range`, restricted to `tablet_id` if given.
     ///
-    /// Rows are collected eagerly, so restricting in SQL keeps the untargeted
-    /// ones out of memory entirely.
+    /// Restricting in SQL keeps the untargeted rows out of memory entirely,
+    /// and reading one bounded page per query keeps the targeted ones from
+    /// being materialized all at once.
     fn stream_document_log(
         &self,
         tablet_id: Option<TabletId>,
         range: TimestampRange,
         order: Order,
+        page_size: u32,
         retention_validator: Arc<dyn RetentionValidator>,
     ) -> DocumentStream<'_> {
-        let entries = try_anyhow!({
-            let connection = &self.inner.lock().connection;
-            let load_docs_query = load_docs(range, order, tablet_id.is_some());
-            let mut stmt = connection.prepare(load_docs_query.as_str())?;
-
-            let tablet_id_bytes = tablet_id.map(|tablet_id| tablet_id.0);
-            let tablet_id_slice = tablet_id_bytes.as_ref().map(|tablet_id| &tablet_id[..]);
-            let params: Vec<&dyn ToSql> = match tablet_id_slice {
-                Some(ref tablet_id) => vec![tablet_id],
-                None => vec![],
-            };
-
-            let mut entries = vec![];
-            for row in stmt.query_map(params.as_slice(), load_document_row)? {
-                let (document_id, ts, document, prev_ts) = row_to_document(row)?;
-                entries.push(Ok(DocumentLogEntry {
-                    ts,
-                    id: document_id,
-                    value: document,
-                    prev_ts,
-                }));
-            }
-            entries
-        });
-        // The caller isn't async so we have to validate snapshot as part of the
-        // stream.
-        let validate =
-            self.validate_document_snapshot(range.min_timestamp_inclusive(), retention_validator);
-        match entries {
-            Ok(s) => validate.chain(stream::iter(s).cooperative()).boxed(),
-            Err(e) => stream::once(async { Err(e) }).boxed(),
-        }
+        // `page_size` comes from the caller; guard against 0, which would never
+        // terminate.
+        let page_size = page_size.max(1) as usize;
+        self._load_documents_paginated(tablet_id, range, order, page_size, retention_validator)
+            .cooperative()
+            .boxed()
     }
 }
 
@@ -478,10 +583,10 @@ impl PersistenceReader for SqlitePersistence {
         &self,
         range: TimestampRange,
         order: Order,
-        _page_size: u32,
+        page_size: u32,
         retention_validator: Arc<dyn RetentionValidator>,
     ) -> DocumentStream<'_> {
-        self.stream_document_log(None, range, order, retention_validator)
+        self.stream_document_log(None, range, order, page_size, retention_validator)
     }
 
     fn load_documents_from_table(
@@ -489,10 +594,16 @@ impl PersistenceReader for SqlitePersistence {
         tablet_id: TabletId,
         range: TimestampRange,
         order: Order,
-        _page_size: u32,
+        page_size: u32,
         retention_validator: Arc<dyn RetentionValidator>,
     ) -> DocumentStream<'_> {
-        self.stream_document_log(Some(tablet_id), range, order, retention_validator)
+        self.stream_document_log(
+            Some(tablet_id),
+            range,
+            order,
+            page_size,
+            retention_validator,
+        )
     }
 
     async fn previous_revisions(
@@ -579,16 +690,23 @@ impl PersistenceReader for SqlitePersistence {
         read_timestamp: Timestamp,
         interval: &Interval,
         order: Order,
-        _size_hint: usize,
+        size_hint: usize,
         retention_validator: Arc<dyn RetentionValidator>,
     ) -> IndexStream<'_> {
-        let triples = self._index_scan_inner(index_id, tablet_id, read_timestamp, interval, order);
-        // index_scan isn't async so we have to validate snapshot as part of the stream.
-        let validate = self.validate_snapshot(read_timestamp, retention_validator);
-        match triples {
-            Ok(s) => (validate.chain(stream::iter(s))).boxed(),
-            Err(e) => stream::once(async { Err(e) }).boxed(),
-        }
+        // Mirror the Postgres reader: use the caller's size_hint to bound how
+        // much of the interval each query materializes, so a small take()
+        // over a large table no longer loads the entire range into memory.
+        let batch_size = size_hint.clamp(1, 5000);
+        self._index_scan_paginated(
+            index_id,
+            tablet_id,
+            read_timestamp,
+            interval.clone(),
+            order,
+            batch_size,
+            retention_validator,
+        )
+        .boxed()
     }
 
     async fn get_persistence_global(
@@ -671,30 +789,6 @@ fn row_to_document(
     Ok((document_id, prev_ts, document, prev_prev_ts))
 }
 
-fn load_docs(range: TimestampRange, order: Order, tablet_filter: bool) -> String {
-    let order_str = match order {
-        Order::Asc => " ORDER BY ts ASC, table_id ASC, id ASC ",
-        Order::Desc => " ORDER BY ts DESC, table_id DESC, id DESC ",
-    };
-    format!(
-        r#"
-SELECT id, ts, table_id, json_value, deleted, prev_ts
-FROM documents
-WHERE ts >= {} AND ts < {}
-{}
-{}
-"#,
-        range.min_timestamp_inclusive(),
-        range.max_timestamp_exclusive(),
-        if tablet_filter {
-            "AND table_id = $1"
-        } else {
-            ""
-        },
-        order_str,
-    )
-}
-
 fn load_document_row(
     row: &Row<'_>,
 ) -> rusqlite::Result<(Vec<u8>, u64, Vec<u8>, Option<String>, bool, Option<u64>)> {
@@ -746,3 +840,1038 @@ WHERE
     ts = $3
 ORDER BY ts ASC, table_id ASC, id ASC
 "#;
+
+/// One page of an index scan.
+///
+/// Walks the `(index_id, key, ts)` primary key in key order and keeps, for
+/// each key, the row whose `ts` is the newest at or before the read
+/// timestamp; `LIMIT` stops the walk after `batch_size` keys.
+///
+/// This is the shape SQLite can stream. It has neither Postgres's
+/// `DISTINCT ON` nor MySQL's loose index scan, so the
+/// `GROUP BY key … ORDER BY key LIMIT` form the other readers use makes
+/// SQLite materialize every group in the interval into a temporary B-tree
+/// before it applies the limit (`USE TEMP B-TREE FOR ORDER BY` in
+/// `EXPLAIN QUERY PLAN`, both orders, bounded or not): cost proportional to
+/// the range, not to the page. The correlated `MAX(ts)` below is one seek on
+/// the same primary key per visited row, so a page costs the visited
+/// versions of its own keys — bounded by index retention — whatever the
+/// size of the range. `plan_never_sorts` in the tests pins that plan.
+///
+/// Tombstones are selected (`B.deleted`), not filtered out: they count
+/// toward the page so a page of nothing but tombstones cannot be mistaken
+/// for the end of the interval; the caller drops them.
+///
+/// Placeholders: `?1` index_id, `?2` read timestamp, `?3` inclusive lower
+/// key, then `?4` exclusive upper key if `has_upper`, then the cursor
+/// (strictly past the last scanned key, in scan order) as the next number
+/// if `has_cursor`. Numbered placeholders bind by position wherever they
+/// appear in the text.
+fn index_scan_page_sql(
+    order: Order,
+    has_upper: bool,
+    has_cursor: bool,
+    batch_size: usize,
+) -> String {
+    let upper = if has_upper { " AND B.key < ?4" } else { "" };
+    let cursor = if has_cursor {
+        let n = if has_upper { 5 } else { 4 };
+        match order {
+            Order::Asc => format!(" AND B.key > ?{n}"),
+            Order::Desc => format!(" AND B.key < ?{n}"),
+        }
+    } else {
+        String::new()
+    };
+    let order = match order {
+        Order::Asc => "ASC",
+        Order::Desc => "DESC",
+    };
+    format!(
+        r#"
+SELECT B.key, B.ts, B.document_id, C.table_id, C.json_value, C.prev_ts, B.deleted
+FROM indexes B
+LEFT JOIN documents C
+ON B.ts = C.ts
+AND B.table_id = C.table_id
+AND B.document_id = C.id
+WHERE B.index_id = ?1
+AND B.key >= ?3{upper}{cursor}
+AND B.ts = (
+    SELECT MAX(X.ts)
+    FROM indexes X
+    WHERE X.index_id = B.index_id AND X.key = B.key AND X.ts <= ?2
+)
+ORDER BY B.key {order}
+LIMIT {batch_size}
+"#
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        collections::BTreeMap,
+        sync::Arc,
+    };
+
+    use common::{
+        document::{
+            CreationTime,
+            ResolvedDocument,
+        },
+        index::IndexKeyBytes,
+        interval::{
+            BinaryKey,
+            End,
+            Interval,
+            StartIncluded,
+        },
+        obj,
+        persistence::{
+            ConflictStrategy,
+            DocumentLogEntry,
+            LatestDocument,
+            NoopRetentionValidator,
+            Persistence,
+            PersistenceIndexEntry,
+            PersistenceReader,
+            TimestampRange,
+        },
+        query::Order,
+        types::{
+            IndexId,
+            Timestamp,
+        },
+        value::{
+            DeveloperDocumentId,
+            InternalDocumentId,
+            InternalId,
+            ResolvedDocumentId,
+            TableNumber,
+            TabletId,
+        },
+    };
+    use futures::TryStreamExt;
+    use proptest::prelude::*;
+    use rusqlite::ToSql;
+
+    use super::{
+        index_scan_page_sql,
+        SqlitePersistence,
+    };
+
+    /// One indexed key and its history: `(ts, Some(v))` is a live write of
+    /// value `v`, `(ts, None)` is a tombstone.
+    struct KeySpec {
+        key: Vec<u8>,
+        doc_n: u8,
+        versions: Vec<(u64, Option<i64>)>,
+    }
+
+    struct Fixture {
+        persistence: SqlitePersistence,
+        index_id: IndexId,
+        tablet_id: TabletId,
+        table_number: TableNumber,
+        // Kept alive so the database file outlives the test body.
+        _dir: tempfile::TempDir,
+    }
+
+    fn internal_id(n: u8) -> InternalId {
+        InternalId::from([n; 16])
+    }
+
+    fn make_doc(
+        tablet_id: TabletId,
+        table_number: TableNumber,
+        doc_n: u8,
+        v: i64,
+    ) -> anyhow::Result<ResolvedDocument> {
+        let id = ResolvedDocumentId::new(
+            tablet_id,
+            DeveloperDocumentId::new(table_number, internal_id(doc_n)),
+        );
+        ResolvedDocument::new(id, CreationTime::try_from(1234.5)?, obj!("v" => v)?)
+    }
+
+    async fn make_fixture(specs: &[KeySpec]) -> anyhow::Result<Fixture> {
+        let dir = tempfile::tempdir()?;
+        let path = dir.path().join("test.sqlite3");
+        let persistence = SqlitePersistence::new(path.to_str().unwrap())?;
+        let index_id = IndexId(internal_id(255));
+        let tablet_id = TabletId(internal_id(254));
+        let table_number = TableNumber::try_from(1)?;
+
+        let mut documents = vec![];
+        let mut indexes = vec![];
+        for spec in specs {
+            let doc_id = InternalDocumentId::new(tablet_id, internal_id(spec.doc_n));
+            for &(ts, v) in &spec.versions {
+                let ts = Timestamp::try_from(ts)?;
+                let value = v
+                    .map(|v| make_doc(tablet_id, table_number, spec.doc_n, v))
+                    .transpose()?;
+                documents.push(DocumentLogEntry {
+                    ts,
+                    id: doc_id,
+                    value,
+                    prev_ts: None,
+                });
+                indexes.push(PersistenceIndexEntry {
+                    ts,
+                    index_id,
+                    key: IndexKeyBytes(spec.key.clone()),
+                    value: v.map(|_| doc_id),
+                });
+            }
+        }
+        persistence
+            .write(&documents, &indexes, ConflictStrategy::Error)
+            .await?;
+        Ok(Fixture {
+            persistence,
+            index_id,
+            tablet_id,
+            table_number,
+            _dir: dir,
+        })
+    }
+
+    fn make_interval(start: Vec<u8>, end: Option<Vec<u8>>) -> Interval {
+        Interval {
+            start: StartIncluded(BinaryKey::from(start)),
+            end: match end {
+                Some(end) => End::Excluded(BinaryKey::from(end)),
+                None => End::Unbounded,
+            },
+        }
+    }
+
+    /// The reference implementation: latest visible version per key at
+    /// `read_ts`, tombstones dropped, interval applied, in scan order.
+    fn expected_scan(
+        fixture: &Fixture,
+        specs: &[KeySpec],
+        read_ts: u64,
+        interval: &Interval,
+        order: Order,
+    ) -> anyhow::Result<Vec<(IndexKeyBytes, LatestDocument)>> {
+        let mut rows = vec![];
+        for spec in specs {
+            if !interval.contains(&spec.key) {
+                continue;
+            }
+            let visible = spec
+                .versions
+                .iter()
+                .filter(|(ts, _)| *ts <= read_ts)
+                .max_by_key(|(ts, _)| *ts);
+            let Some(&(ts, Some(v))) = visible else {
+                continue;
+            };
+            rows.push((
+                IndexKeyBytes(spec.key.clone()),
+                LatestDocument {
+                    ts: Timestamp::try_from(ts)?,
+                    value: make_doc(fixture.tablet_id, fixture.table_number, spec.doc_n, v)?,
+                    prev_ts: None,
+                },
+            ));
+        }
+        rows.sort_by(|(a, _), (b, _)| a.cmp(b));
+        if order == Order::Desc {
+            rows.reverse();
+        }
+        Ok(rows)
+    }
+
+    async fn run_scan(
+        fixture: &Fixture,
+        read_ts: u64,
+        interval: &Interval,
+        order: Order,
+        size_hint: usize,
+    ) -> anyhow::Result<Vec<(IndexKeyBytes, LatestDocument)>> {
+        fixture
+            .persistence
+            .index_scan(
+                fixture.index_id,
+                fixture.tablet_id,
+                Timestamp::try_from(read_ts)?,
+                interval,
+                order,
+                size_hint,
+                Arc::new(NoopRetentionValidator),
+            )
+            .try_collect()
+            .await
+    }
+
+    /// 25 keys with updates, tombstones on page boundaries, and writes past
+    /// the read snapshot, scanned under every pagination regime: the
+    /// paginated scan must be indistinguishable from the one-shot scan it
+    /// replaced.
+    #[tokio::test]
+    async fn paginated_scan_matches_reference() -> anyhow::Result<()> {
+        let specs: Vec<KeySpec> = (0u8..25)
+            .map(|k| {
+                let mut versions = vec![(10, Some(1))];
+                if k % 3 == 0 {
+                    versions.push((20, Some(2)));
+                }
+                if k % 5 == 0 {
+                    versions.push((30, None));
+                }
+                if k % 2 == 0 {
+                    versions.push((40, Some(3)));
+                }
+                KeySpec {
+                    key: vec![k],
+                    doc_n: k,
+                    versions,
+                }
+            })
+            .collect();
+        let fixture = make_fixture(&specs).await?;
+
+        let intervals = [
+            make_interval(vec![], None),
+            make_interval(vec![3], Some(vec![20])),
+        ];
+        // At ts 35 the tombstones (ts 30) are the latest visible versions;
+        // at ts 45 the ts-40 writes resurrect the even keys among them.
+        for read_ts in [35, 45] {
+            for interval in &intervals {
+                for order in [Order::Asc, Order::Desc] {
+                    let expected = expected_scan(&fixture, &specs, read_ts, interval, order)?;
+                    for size_hint in [1, 2, 3, 10_000] {
+                        let got = run_scan(&fixture, read_ts, interval, order, size_hint).await?;
+                        assert_eq!(
+                            got, expected,
+                            "scan mismatch at read_ts={read_ts} order={order:?} \
+                             size_hint={size_hint}"
+                        );
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+
+    /// Ten consecutive tombstoned keys form entire pages with no live rows.
+    /// A scan that terminates on "page yielded fewer live rows than
+    /// requested" would stop in the middle of the interval and silently drop
+    /// every key after the tombstone run.
+    #[tokio::test]
+    async fn page_of_tombstones_does_not_terminate_scan() -> anyhow::Result<()> {
+        let specs: Vec<KeySpec> = (0u8..30)
+            .map(|k| {
+                let mut versions = vec![(10, Some(1))];
+                if (10..20).contains(&k) {
+                    versions.push((20, None));
+                }
+                KeySpec {
+                    key: vec![k],
+                    doc_n: k,
+                    versions,
+                }
+            })
+            .collect();
+        let fixture = make_fixture(&specs).await?;
+
+        let interval = make_interval(vec![], None);
+        for order in [Order::Asc, Order::Desc] {
+            let expected = expected_scan(&fixture, &specs, 25, &interval, order)?;
+            assert_eq!(expected.len(), 20);
+            let got = run_scan(&fixture, 25, &interval, order, 5).await?;
+            assert_eq!(got, expected, "tombstone run must not end the scan early");
+        }
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn empty_table_and_empty_range() -> anyhow::Result<()> {
+        let empty = make_fixture(&[]).await?;
+        let all = make_interval(vec![], None);
+        assert!(run_scan(&empty, 100, &all, Order::Asc, 3).await?.is_empty());
+
+        let specs: Vec<KeySpec> = (0u8..5)
+            .map(|k| KeySpec {
+                key: vec![k],
+                doc_n: k,
+                versions: vec![(10, Some(1))],
+            })
+            .collect();
+        let fixture = make_fixture(&specs).await?;
+        let out_of_range = make_interval(vec![200], Some(vec![201]));
+        assert!(run_scan(&fixture, 100, &out_of_range, Order::Asc, 3)
+            .await?
+            .is_empty());
+        Ok(())
+    }
+
+    /// One row of the documents log for the `load_documents` tests:
+    /// `value: None` is a delete entry, which the log emits as-is.
+    #[derive(Clone)]
+    struct LogEntrySpec {
+        ts: u64,
+        tablet_n: u8,
+        doc_n: u8,
+        value: Option<i64>,
+    }
+
+    async fn make_log_fixture(
+        specs: &[LogEntrySpec],
+    ) -> anyhow::Result<(SqlitePersistence, tempfile::TempDir)> {
+        let dir = tempfile::tempdir()?;
+        let path = dir.path().join("test.sqlite3");
+        let persistence = SqlitePersistence::new(path.to_str().unwrap())?;
+        let documents = specs
+            .iter()
+            .map(log_entry)
+            .collect::<anyhow::Result<Vec<_>>>()?;
+        persistence
+            .write(&documents, &[], ConflictStrategy::Error)
+            .await?;
+        Ok((persistence, dir))
+    }
+
+    fn log_entry(spec: &LogEntrySpec) -> anyhow::Result<DocumentLogEntry> {
+        let tablet_id = TabletId(internal_id(spec.tablet_n));
+        let table_number = TableNumber::try_from(1)?;
+        let value = spec
+            .value
+            .map(|v| make_doc(tablet_id, table_number, spec.doc_n, v))
+            .transpose()?;
+        Ok(DocumentLogEntry {
+            ts: Timestamp::try_from(spec.ts)?,
+            id: InternalDocumentId::new(tablet_id, internal_id(spec.doc_n)),
+            value,
+            prev_ts: None,
+        })
+    }
+
+    /// The reference implementation: every log row in the timestamp range,
+    /// deletes included, in `(ts, table_id, id)` scan order.
+    fn expected_log(
+        specs: &[LogEntrySpec],
+        range: &TimestampRange,
+        order: Order,
+    ) -> anyhow::Result<Vec<DocumentLogEntry>> {
+        let mut rows = vec![];
+        for spec in specs {
+            let ts = Timestamp::try_from(spec.ts)?;
+            if ts < range.min_timestamp_inclusive() || ts >= range.max_timestamp_exclusive() {
+                continue;
+            }
+            let entry = log_entry(spec)?;
+            let key = (
+                spec.ts,
+                entry.id.table().0[..].to_vec(),
+                entry.id.internal_id()[..].to_vec(),
+            );
+            rows.push((key, entry));
+        }
+        rows.sort_by(|(a, _), (b, _)| a.cmp(b));
+        if order == Order::Desc {
+            rows.reverse();
+        }
+        Ok(rows.into_iter().map(|(_, entry)| entry).collect())
+    }
+
+    async fn run_load(
+        persistence: &SqlitePersistence,
+        range: TimestampRange,
+        order: Order,
+        page_size: u32,
+    ) -> anyhow::Result<Vec<DocumentLogEntry>> {
+        persistence
+            .load_documents(range, order, page_size, Arc::new(NoopRetentionValidator))
+            .try_collect()
+            .await
+    }
+
+    async fn run_load_from_table(
+        persistence: &SqlitePersistence,
+        tablet_id: TabletId,
+        range: TimestampRange,
+        order: Order,
+        page_size: u32,
+    ) -> anyhow::Result<Vec<DocumentLogEntry>> {
+        persistence
+            .load_documents_from_table(
+                tablet_id,
+                range,
+                order,
+                page_size,
+                Arc::new(NoopRetentionValidator),
+            )
+            .try_collect()
+            .await
+    }
+
+    /// `load_documents_from_table` restricts the scan in SQL, so `LIMIT`
+    /// counts only rows that will be yielded. Two tablets are interleaved at
+    /// every timestamp, so a filter applied *after* the limit would hand back
+    /// short pages and terminate the stream early, losing most of the log.
+    /// Page sizes below the number of rows per timestamp also put a page
+    /// boundary inside a same-`ts` run, where the cursor's `(table_id, id)`
+    /// tiebreak has to hold even though `table_id` is now pinned by the
+    /// filter.
+    #[tokio::test]
+    async fn paginated_load_from_table_matches_reference() -> anyhow::Result<()> {
+        let mut specs = vec![];
+        for ts in [10u64, 20, 30] {
+            for tablet_n in [1u8, 2] {
+                for doc_n in 0u8..4 {
+                    specs.push(LogEntrySpec {
+                        ts,
+                        tablet_n,
+                        doc_n,
+                        value: Some(ts as i64),
+                    });
+                }
+            }
+        }
+        // A delete in the targeted tablet, and a whole timestamp belonging to
+        // the other one: neither may terminate the targeted stream.
+        specs.push(LogEntrySpec {
+            ts: 40,
+            tablet_n: 1,
+            doc_n: 0,
+            value: None,
+        });
+        specs.push(LogEntrySpec {
+            ts: 50,
+            tablet_n: 2,
+            doc_n: 0,
+            value: None,
+        });
+        let (persistence, _dir) = make_log_fixture(&specs).await?;
+
+        let target_n = 2u8;
+        let target = TabletId(internal_id(target_n));
+        let targeted: Vec<LogEntrySpec> = specs
+            .iter()
+            .filter(|spec| spec.tablet_n == target_n)
+            .cloned()
+            .collect();
+
+        let ranges = [
+            TimestampRange::all(),
+            TimestampRange::new(Timestamp::try_from(15u64)?..Timestamp::try_from(45u64)?),
+        ];
+        for range in &ranges {
+            for order in [Order::Asc, Order::Desc] {
+                let expected = expected_log(&targeted, range, order)?;
+                for page_size in [1, 3, 5, 10_000] {
+                    let got =
+                        run_load_from_table(&persistence, target, *range, order, page_size).await?;
+                    assert_eq!(
+                        got, expected,
+                        "load_from_table mismatch at range={range:?} order={order:?} \
+                         page_size={page_size}"
+                    );
+                    assert!(
+                        got.iter().all(|entry| entry.id.table() == target),
+                        "load_from_table returned a row from another tablet"
+                    );
+                }
+            }
+        }
+        Ok(())
+    }
+
+    /// Two tablets writing interleaved updates and deletes, with several rows
+    /// sharing the same timestamp: the compound cursor's `(table_id, id)`
+    /// tiebreak is what keeps pagination correct when a page boundary lands
+    /// in the middle of a same-`ts` run.
+    #[tokio::test]
+    async fn paginated_load_matches_reference() -> anyhow::Result<()> {
+        let mut specs = vec![];
+        for tablet_n in [1u8, 2] {
+            for doc_n in 0u8..6 {
+                specs.push(LogEntrySpec {
+                    ts: 10,
+                    tablet_n,
+                    doc_n,
+                    value: Some(1),
+                });
+                if doc_n % 2 == 0 {
+                    specs.push(LogEntrySpec {
+                        ts: 20,
+                        tablet_n,
+                        doc_n,
+                        value: Some(2),
+                    });
+                }
+                if doc_n % 3 == 0 {
+                    specs.push(LogEntrySpec {
+                        ts: 30,
+                        tablet_n,
+                        doc_n,
+                        value: None,
+                    });
+                }
+                if doc_n % 2 == 1 {
+                    specs.push(LogEntrySpec {
+                        ts: 40,
+                        tablet_n,
+                        doc_n,
+                        value: Some(3),
+                    });
+                }
+            }
+        }
+        let (persistence, _dir) = make_log_fixture(&specs).await?;
+
+        let ranges = [
+            TimestampRange::all(),
+            TimestampRange::new(Timestamp::try_from(15u64)?..Timestamp::try_from(35u64)?),
+        ];
+        for range in &ranges {
+            for order in [Order::Asc, Order::Desc] {
+                let expected = expected_log(&specs, range, order)?;
+                for page_size in [1, 2, 3, 10_000] {
+                    let got = run_load(&persistence, *range, order, page_size).await?;
+                    assert_eq!(
+                        got, expected,
+                        "load mismatch at range={range:?} order={order:?} page_size={page_size}"
+                    );
+                }
+            }
+        }
+        Ok(())
+    }
+
+    /// Ten documents written at one single timestamp: every page boundary
+    /// falls inside the same-`ts` run, so only the `(table_id, id)` tiebreak
+    /// of the cursor separates the pages.
+    #[tokio::test]
+    async fn same_ts_run_spans_pages() -> anyhow::Result<()> {
+        let specs: Vec<LogEntrySpec> = (0u8..10)
+            .map(|doc_n| LogEntrySpec {
+                ts: 17,
+                tablet_n: 1,
+                doc_n,
+                value: Some(i64::from(doc_n)),
+            })
+            .collect();
+        let (persistence, _dir) = make_log_fixture(&specs).await?;
+
+        let range = TimestampRange::all();
+        for order in [Order::Asc, Order::Desc] {
+            let expected = expected_log(&specs, &range, order)?;
+            assert_eq!(expected.len(), 10);
+            let got = run_load(&persistence, range, order, 3).await?;
+            assert_eq!(got, expected, "same-ts run must paginate by (table_id, id)");
+        }
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn load_empty_and_out_of_range() -> anyhow::Result<()> {
+        let (empty, _dir) = make_log_fixture(&[]).await?;
+        assert!(run_load(&empty, TimestampRange::all(), Order::Asc, 2)
+            .await?
+            .is_empty());
+
+        let specs: Vec<LogEntrySpec> = (0u8..5)
+            .map(|doc_n| LogEntrySpec {
+                ts: 10,
+                tablet_n: 1,
+                doc_n,
+                value: Some(1),
+            })
+            .collect();
+        let (persistence, _dir) = make_log_fixture(&specs).await?;
+        let out_of_range =
+            TimestampRange::new(Timestamp::try_from(100u64)?..Timestamp::try_from(200u64)?);
+        assert!(run_load(&persistence, out_of_range, Order::Asc, 2)
+            .await?
+            .is_empty());
+        Ok(())
+    }
+
+    // ---------------------------------------------------------------------
+    // The streaming page statement: pre-pagination oracle, differential
+    // property test, plan pin, and a benchmark for the commit message.
+    // ---------------------------------------------------------------------
+
+    /// The statement the SQLite reader ran before it paginated at all
+    /// (`_index_scan_inner` at daed8a92, the last unpaged version), kept
+    /// verbatim as an oracle. It read the whole interval in one go, so its
+    /// output is by definition what any sequence of pages must add up to.
+    /// Live rows only, as it returned them: `(key, ts, document_id)`.
+    fn legacy_scan_oracle(
+        fixture: &Fixture,
+        read_ts: u64,
+        interval: &Interval,
+        order: Order,
+    ) -> anyhow::Result<Vec<(Vec<u8>, u64, Vec<u8>)>> {
+        let StartIncluded(ref start) = interval.start;
+        let lower: &[u8] = &start[..];
+        let (upper_clause, upper) = match interval.end {
+            End::Excluded(ref t) => (" AND key < $4", Some(&t[..])),
+            End::Unbounded => ("", None),
+        };
+        let order = match order {
+            Order::Asc => "ASC",
+            Order::Desc => "DESC",
+        };
+        let query = format!(
+            r#"
+SELECT B.key, B.ts, B.document_id, C.table_id, C.json_value, C.prev_ts
+FROM (
+    SELECT index_id, key, MAX(ts) as max_ts
+    FROM indexes
+    WHERE index_id = $1 AND ts <= $2 AND key >= $3{upper_clause}
+    GROUP BY index_id, key
+) A
+JOIN indexes B
+ON B.deleted is FALSE
+AND A.index_id = B.index_id
+AND A.key = B.key
+AND A.max_ts = B.ts
+LEFT JOIN documents C
+ON B.ts = C.ts
+AND B.table_id = c.table_id
+AND B.document_id = C.id
+ORDER BY B.key {order}
+"#
+        );
+        let index_id: &[u8] = &fixture.index_id.0[..];
+        let mut params: Vec<&dyn ToSql> = vec![&index_id, &read_ts, &lower];
+        if let Some(ref u) = upper {
+            params.push(u);
+        }
+        let inner = fixture.persistence.inner.lock();
+        let mut stmt = inner.connection.prepare(&query)?;
+        let rows = stmt
+            .query_map(&params[..], |row| {
+                Ok((
+                    row.get::<_, Vec<u8>>(0)?,
+                    row.get::<_, u64>(1)?,
+                    row.get::<_, Vec<u8>>(2)?,
+                ))
+            })?
+            .collect::<Result<Vec<_>, _>>()?;
+        Ok(rows)
+    }
+
+    fn scan_rows_for_oracle(
+        rows: &[(IndexKeyBytes, LatestDocument)],
+    ) -> Vec<(Vec<u8>, u64, Vec<u8>)> {
+        rows.iter()
+            .map(|(key, doc)| {
+                (
+                    key.0.clone(),
+                    u64::from(doc.ts),
+                    doc.value.id().internal_id()[..].to_vec(),
+                )
+            })
+            .collect()
+    }
+
+    /// Random index histories: keys over a 4-symbol alphabet, 1–3 bytes long
+    /// so prefixes collide and the byte-order bounds get exercised; up to 20
+    /// distinct keys, each with 1–5 versions at distinct timestamps, about a
+    /// quarter of them tombstones.
+    fn history_strategy() -> impl Strategy<Value = BTreeMap<Vec<u8>, BTreeMap<u64, Option<i64>>>> {
+        prop::collection::btree_map(
+            prop::collection::vec(0u8..4, 1..=3),
+            prop::collection::btree_map(1u64..50, prop::option::weighted(0.75, 0i64..100), 1..=5),
+            1..=20,
+        )
+    }
+
+    proptest! {
+        #![proptest_config(ProptestConfig { cases: 128, ..ProptestConfig::default() })]
+
+        /// Every bound shape, both orders, page sizes 1..=10, random
+        /// histories: the paginated scan must equal both the pre-pagination
+        /// statement and the Rust reference. A counterexample is shrunk to
+        /// its smallest history.
+        #[test]
+        fn paginated_scan_matches_legacy_oracle_and_reference(
+            history in history_strategy(),
+            read_ts in 0u64..55,
+            lower in prop::collection::vec(0u8..4, 0..=2),
+            upper in prop::option::of(prop::collection::vec(0u8..5, 0..=2)),
+            desc in any::<bool>(),
+            size_hint in 1usize..=10,
+        ) {
+            let specs: Vec<KeySpec> = history
+                .into_iter()
+                .enumerate()
+                .map(|(i, (key, versions))| KeySpec {
+                    key,
+                    doc_n: i as u8,
+                    versions: versions.into_iter().collect(),
+                })
+                .collect();
+            let rt = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .unwrap();
+            rt.block_on(async {
+                let fixture = make_fixture(&specs).await.unwrap();
+                let interval = make_interval(lower, upper);
+                let order = if desc { Order::Desc } else { Order::Asc };
+                let got = run_scan(&fixture, read_ts, &interval, order, size_hint)
+                    .await
+                    .unwrap();
+                let expected = expected_scan(&fixture, &specs, read_ts, &interval, order).unwrap();
+                prop_assert_eq!(&got, &expected);
+                let legacy = legacy_scan_oracle(&fixture, read_ts, &interval, order).unwrap();
+                prop_assert_eq!(scan_rows_for_oracle(&got), legacy);
+                Ok(())
+            })?;
+        }
+    }
+
+    /// The performance claim as a test. For every bound shape and both
+    /// orders SQLite must serve a page by searching the primary key and
+    /// stopping: never by sorting a materialized range (`USE TEMP B-TREE`),
+    /// never by walking `indexes` without the key bounds (`SCAN B`).
+    #[test]
+    fn plan_never_sorts() -> anyhow::Result<()> {
+        let persistence = SqlitePersistence::new(":memory:")?;
+        let inner = persistence.inner.lock();
+        let index_id: &[u8] = &[0u8; 16];
+        let ts = 0u64;
+        let lower: &[u8] = &[];
+        let bound: &[u8] = &[0x7f];
+        for order in [Order::Asc, Order::Desc] {
+            for has_upper in [false, true] {
+                for has_cursor in [false, true] {
+                    let sql = index_scan_page_sql(order, has_upper, has_cursor, 51);
+                    let mut params: Vec<&dyn ToSql> = vec![&index_id, &ts, &lower];
+                    if has_upper {
+                        params.push(&bound);
+                    }
+                    if has_cursor {
+                        params.push(&bound);
+                    }
+                    let mut stmt = inner
+                        .connection
+                        .prepare(&format!("EXPLAIN QUERY PLAN {sql}"))?;
+                    let plan = stmt
+                        .query_map(&params[..], |row| row.get::<_, String>(3))?
+                        .collect::<Result<Vec<_>, _>>()?
+                        .join(" | ");
+                    let case = format!("{order:?} upper={has_upper} cursor={has_cursor}: {plan}");
+                    assert!(
+                        !plan.contains("TEMP B-TREE"),
+                        "page sorts a materialized range: {case}"
+                    );
+                    assert!(
+                        !plan.contains("SCAN B"),
+                        "page scans indexes without bounds: {case}"
+                    );
+                    assert!(
+                        plan.contains("SEARCH B USING INDEX"),
+                        "page does not search the primary key: {case}"
+                    );
+                }
+            }
+        }
+        Ok(())
+    }
+
+    /// Not a test: times the three statement shapes on synthetic data, for
+    /// the numbers in the commit message. Run with
+    /// `cargo test -p sqlite -- --ignored --nocapture bench_index_scan_forms`;
+    /// `SQLITE_BENCH_KEYS=100000,300000` overrides the sizes.
+    #[tokio::test]
+    #[ignore]
+    async fn bench_index_scan_forms() -> anyhow::Result<()> {
+        use std::time::Instant;
+
+        // #522's page statement, kept verbatim (modulo `?N` numbering, which
+        // does not change the plan) so the comparison is like for like.
+        fn grouped_page_sql(order: Order, has_cursor: bool, limit: usize) -> String {
+            let cursor = match (has_cursor, order) {
+                (false, _) => "",
+                (true, Order::Asc) => " AND key > ?4",
+                (true, Order::Desc) => " AND key < ?4",
+            };
+            let order = match order {
+                Order::Asc => "ASC",
+                Order::Desc => "DESC",
+            };
+            format!(
+                r#"
+SELECT B.key, B.ts, B.document_id, C.table_id, C.json_value, C.prev_ts, B.deleted
+FROM (
+    SELECT index_id, key, MAX(ts) as max_ts
+    FROM indexes
+    WHERE index_id = ?1 AND ts <= ?2 AND key >= ?3{cursor}
+    GROUP BY index_id, key
+    ORDER BY key {order}
+    LIMIT {limit}
+) A
+JOIN indexes B
+ON A.index_id = B.index_id
+AND A.key = B.key
+AND A.max_ts = B.ts
+LEFT JOIN documents C
+ON B.ts = C.ts
+AND B.table_id = c.table_id
+AND B.document_id = C.id
+ORDER BY B.key {order}
+"#
+            )
+        }
+        // The pre-pagination statement over the whole interval, for the
+        // "what it cost before" column.
+        fn legacy_whole_range_sql(order: Order) -> String {
+            let order = match order {
+                Order::Asc => "ASC",
+                Order::Desc => "DESC",
+            };
+            format!(
+                r#"
+SELECT B.key, B.ts, B.document_id, C.table_id, C.json_value, C.prev_ts
+FROM (
+    SELECT index_id, key, MAX(ts) as max_ts
+    FROM indexes
+    WHERE index_id = ?1 AND ts <= ?2 AND key >= ?3
+    GROUP BY index_id, key
+) A
+JOIN indexes B
+ON B.deleted is FALSE
+AND A.index_id = B.index_id
+AND A.key = B.key
+AND A.max_ts = B.ts
+LEFT JOIN documents C
+ON B.ts = C.ts
+AND B.table_id = c.table_id
+AND B.document_id = C.id
+ORDER BY B.key {order}
+"#
+            )
+        }
+
+        let sizes: Vec<usize> = std::env::var("SQLITE_BENCH_KEYS")
+            .unwrap_or_else(|_| "100000,300000,1000000".to_owned())
+            .split(',')
+            .map(|s| {
+                s.trim()
+                    .parse()
+                    .expect("SQLITE_BENCH_KEYS: comma-separated integers")
+            })
+            .collect();
+        let dir = tempfile::tempdir()?;
+        let index_id = IndexId(internal_id(255));
+        let tablet_id = TabletId(internal_id(254));
+        let table_number = TableNumber::try_from(1)?;
+
+        println!();
+        println!(
+            "| keys | order | case | legacy whole range | #522 grouped page | streaming page |"
+        );
+        println!("|---|---|---|---|---|---|");
+        for &n in &sizes {
+            let path = dir.path().join(format!("bench-{n}.sqlite3"));
+            let persistence = SqlitePersistence::new(path.to_str().unwrap())?;
+            // n keys in numeric byte order, 1–3 versions each (2 on average, so
+            // the walk pays its per-version seek), tiny documents.
+            let seed_started = Instant::now();
+            let mut documents = vec![];
+            let mut indexes = vec![];
+            for i in 0..n as u64 {
+                let mut id = [0u8; 16];
+                id[..8].copy_from_slice(&i.to_be_bytes());
+                let doc_id = InternalDocumentId::new(tablet_id, InternalId::from(id));
+                let resolved_id = ResolvedDocumentId::new(
+                    tablet_id,
+                    DeveloperDocumentId::new(table_number, InternalId::from(id)),
+                );
+                let key = IndexKeyBytes((i as u32).to_be_bytes().to_vec());
+                for v in 0..(1 + i % 3) {
+                    let ts = Timestamp::try_from(10 + v * 10)?;
+                    let value = ResolvedDocument::new(
+                        resolved_id,
+                        CreationTime::try_from(1234.5)?,
+                        obj!("v" => (v as i64))?,
+                    )?;
+                    documents.push(DocumentLogEntry {
+                        ts,
+                        id: doc_id,
+                        value: Some(value),
+                        prev_ts: None,
+                    });
+                    indexes.push(PersistenceIndexEntry {
+                        ts,
+                        index_id,
+                        key: key.clone(),
+                        value: Some(doc_id),
+                    });
+                }
+                if documents.len() >= 20_000 {
+                    persistence
+                        .write(&documents, &indexes, ConflictStrategy::Error)
+                        .await?;
+                    documents.clear();
+                    indexes.clear();
+                }
+            }
+            if !documents.is_empty() {
+                persistence
+                    .write(&documents, &indexes, ConflictStrategy::Error)
+                    .await?;
+            }
+            let seeded_in = seed_started.elapsed();
+            let inner = persistence.inner.lock();
+            let index_bytes: &[u8] = &index_id.0[..];
+            let read_ts = u64::MAX / 2;
+            let lower: &[u8] = &[];
+            let mid = ((n / 2) as u32).to_be_bytes().to_vec();
+            let mid: &[u8] = &mid[..];
+
+            let time = |sql: &str, params: &[&dyn ToSql]| -> anyhow::Result<(f64, usize)> {
+                let mut best = f64::MAX;
+                let mut rows = 0usize;
+                for _ in 0..3 {
+                    let mut stmt = inner.connection.prepare(sql)?;
+                    let started = Instant::now();
+                    rows = stmt
+                        .query_map(params, |row| row.get::<_, Vec<u8>>(0))?
+                        .count();
+                    best = best.min(started.elapsed().as_secs_f64() * 1000.0);
+                }
+                Ok((best, rows))
+            };
+            let base: Vec<&dyn ToSql> = vec![&index_bytes, &read_ts, &lower];
+            let with_cursor: Vec<&dyn ToSql> = vec![&index_bytes, &read_ts, &lower, &mid];
+            for order in [Order::Asc, Order::Desc] {
+                let (legacy_ms, legacy_rows) = time(&legacy_whole_range_sql(order), &base)?;
+                let cases: [(&str, usize, &Vec<&dyn ToSql>, bool); 4] = [
+                    ("take(1)", 1, &base, false),
+                    ("51-row page", 51, &base, false),
+                    ("100-row page", 100, &base, false),
+                    ("51-row page at depth 50% (cursor)", 51, &with_cursor, true),
+                ];
+                for (label, limit, params, has_cursor) in cases {
+                    let (g, _) = time(&grouped_page_sql(order, has_cursor, limit), params)?;
+                    let (w, _) = time(
+                        &index_scan_page_sql(order, false, has_cursor, limit),
+                        params,
+                    )?;
+                    println!(
+                        "| {n} | {order:?} | {label} | {legacy_ms:.1} ms ({legacy_rows} rows) | \
+                         {g:.2} ms | {w:.3} ms |"
+                    );
+                }
+            }
+            println!(
+                "| {n} | | seeded {} index rows in {:.1} s | | | |",
+                n + (n / 3) * 3 / 2 + n / 3,
+                seeded_in.as_secs_f64()
+            );
+        }
+        Ok(())
+    }
+}


### PR DESCRIPTION
Refs #495. One commit, two parts. The pagination is #522 by @Iann29, squashed in unchanged in substance: `size_hint` paging of `index_scan` with a key cursor, tombstones counted toward the page, retention validated per page, and the same paging for `load_documents`. On top of it, the one further change SQLite needs to actually benefit: the per-page statement. If #522 lands first I will rebase this down to just the statement change; folding it into #522 is fine by me too.

## Summary

Paging with `size_hint` and a cursor fixes the materialization #495 reports, but the page statement in #522 is MySQL's idiom, `GROUP BY key … MAX(ts) … ORDER BY key LIMIT n`, which SQLite cannot execute lazily: `EXPLAIN QUERY PLAN` shows `USE TEMP B-TREE FOR ORDER BY` for it in every case (both orders, bounded or unbounded interval, with or without a cursor), so each page still groups every key in the scanned range before applying the limit. Cost stays proportional to the range, not the page. This PR replaces that one statement with a walk of the `(index_id, key, ts)` primary key that keeps, per key, the row with the newest `ts` at or before the read timestamp (a correlated `MAX(ts)` — one seek per visited row) and stops at `LIMIT`. Same rows, same tombstone counting, same cursor, same per-page retention check. In the benchmark below the cost of a page changes by at most 0.02 ms from 100k to 1M keys in every case but one, an ascending page resumed from a cursor (see Scale).

Measured on a 4 GB `convex-local-backend` store (one index with 38,545 rows over 38,338 keys; a range of 30,913 keys; row sequences compared on key + ts + deleted and identical):

| shape | grouped page statement (#522) | this PR |
|---|---|---|
| #495's repro: `take(1)`, whole index, DESC / ASC | 14 / 10 ms | 0.01 / 0.01 ms |
| 100-row page (`DEFAULT_QUERY_PREFETCH`), whole index, DESC | 32 ms | 0.19 ms |
| 51-row page, range, DESC, page 1 / page 2 (cursor) | 18 / 19 ms | 0.8 / 0.9 ms |
| 51-row page, range, ASC, page 1 / page 2 | 8 / 8.5 ms | 0.12 / 0.12 ms |
| 5,000-row page (clamp), range, DESC / ASC | 800 ms / n.m. | 137 / 184 ms |
| whole range paged at 5,000, DESC | 7 pages | identical 30,913-row sequence |

(the unpaged statement on `main` today: 7.3 s for the 51-row page.)

## Why the grouped form cannot stream in SQLite

The three readers spell "latest version per key, in key order, first n" differently:

- `crates/postgres`: `SELECT DISTINCT ON (key_prefix, key_sha256) … ORDER BY key_prefix, key_sha256, ts DESC LIMIT n` — Postgres streams `DISTINCT ON` over the sorted index and stops at the limit.
- `crates/mysql`: `SELECT key …, MAX(ts) … FORCE INDEX FOR GROUP BY (PRIMARY) … GROUP BY key ORDER BY key LIMIT n` — MySQL's loose index scan walks the groups in order and stops at the limit.
- SQLite has neither `DISTINCT ON` nor a loose index scan. For the grouped form it computes every group first and sorts them:

```
CO-ROUTINE A | SEARCH indexes USING COVERING INDEX sqlite_autoindex_indexes_1 (index_id=? AND key>? AND key<?) | USE TEMP B-TREE FOR ORDER BY | SCAN A | SEARCH B USING INDEX … | SEARCH C USING INDEX … LEFT-JOIN | USE TEMP B-TREE FOR ORDER BY
```

The primary-key walk with a correlated `MAX` is the shape SQLite does stream:

```
SEARCH B USING INDEX sqlite_autoindex_indexes_1 (index_id=? AND key>? AND key<?) | CORRELATED SCALAR SUBQUERY 1 | SEARCH X USING COVERING INDEX sqlite_autoindex_indexes_1 (index_id=? AND key=? AND ts<?) | SEARCH C USING INDEX sqlite_autoindex_documents_1 (ts=? AND table_id=? AND id=?) LEFT-JOIN
```

## The statement

```sql
SELECT B.key, B.ts, B.document_id, C.table_id, C.json_value, C.prev_ts, B.deleted
FROM indexes B
LEFT JOIN documents C
ON B.ts = C.ts AND B.table_id = C.table_id AND B.document_id = C.id
WHERE B.index_id = ?1
AND B.key >= ?3 [AND B.key < ?4] [AND B.key <|> ?cursor]
AND B.ts = (SELECT MAX(X.ts) FROM indexes X
            WHERE X.index_id = B.index_id AND X.key = B.key AND X.ts <= ?2)
ORDER BY B.key {ASC|DESC}
LIMIT {batch_size}
```

Placeholders are numbered (`?N`) rather than named: SQLite numbers `$name` placeholders by first textual appearance, and the read timestamp is now referenced after the key bounds. Everything around the statement — `size_hint.clamp(1, 5000)`, the cursor strictly past the last scanned key, tombstones selected (not filtered) so they count toward the page, retention validated after each page, the `load_documents` paging — is #522's.

## Semantics and corner cases

- Per key, `B.ts = MAX(ts ≤ read_ts)` picks exactly the row the `GROUP BY … MAX(ts)` form joins back to (the primary key makes `(index_id, key, ts)` unique); keys with every version newer than the snapshot yield `NULL` and are excluded, as before.
- Cost model: the grouped form ∝ keys in the scanned range, every page (fit from two measured points: ≈ 4 ms + 0.45 µs per key); this PR: at most 0.02 ms of change from 100k to 1M keys in every measured case except the ascending cursor page, which grows with the cursor's depth into the range (Scale).
- A hot key with many versions costs one seek per version here and no seek in the grouped form — same complexity, a constant factor — and the version count is bounded by `INDEX_RETENTION_DELAY` (4 min by default). An old-snapshot read over keys newer than `read_ts` visits and discards them, same bound. Tombstone runs count toward the page in both.

## Backend-level A/B (same store, same functions, only the binary differs)

| | `precompiled-2026-04-22-daed8a9` release | same release + this commit |
|---|---|---|
| boot-to-ready on the 4 GB store | 26–29 s | 1.9 s |
| RSS at ready | 2.0–3.2 GB | 56 MB |
| 50-row page of the 30,913-row range | 10,084 ms | 10.4 ms |
| 200-row page | `SystemTimeoutError` (15 s) | 34 ms |
| unified page over two ranges | 9,285 ms | 11.7 ms |
| full cursor walk of the range (30,913 rows) | 46 s, same 30,913 ids | 2.0 s, same ids, same order (sha256 match) |

## Scale (Rust benchmark in this PR, release build)

Apple M1 Pro, release build, commit 27b5e43cd2d7c196fbc67c8296767c8cc9efaeb8.

| keys | order | case | legacy whole range | #522 grouped page | streaming page |
|---|---|---|---|---|---|
| 100000 | Asc | take(1) | 188.7 ms (100000 rows) | 28.97 ms | 0.008 ms |
| 100000 | Asc | 51-row page | 188.7 ms (100000 rows) | 29.14 ms | 0.088 ms |
| 100000 | Asc | 100-row page | 188.7 ms (100000 rows) | 29.08 ms | 0.164 ms |
| 100000 | Asc | 51-row page at depth 50% (cursor) | 188.7 ms (100000 rows) | 20.76 ms | 4.729 ms |
| 100000 | Desc | take(1) | 192.9 ms (100000 rows) | 38.18 ms | 0.008 ms |
| 100000 | Desc | 51-row page | 192.9 ms (100000 rows) | 41.91 ms | 0.092 ms |
| 100000 | Desc | 100-row page | 192.9 ms (100000 rows) | 43.27 ms | 0.177 ms |
| 100000 | Desc | 51-row page at depth 50% (cursor) | 192.9 ms (100000 rows) | 21.49 ms | 0.095 ms |
| 100000 | | seeded 183332 index rows in 0.6 s | | | |
| 300000 | Asc | take(1) | 641.4 ms (300000 rows) | 90.67 ms | 0.009 ms |
| 300000 | Asc | 51-row page | 641.4 ms (300000 rows) | 93.06 ms | 0.092 ms |
| 300000 | Asc | 100-row page | 641.4 ms (300000 rows) | 89.01 ms | 0.173 ms |
| 300000 | Asc | 51-row page at depth 50% (cursor) | 641.4 ms (300000 rows) | 64.16 ms | 14.434 ms |
| 300000 | Desc | take(1) | 631.2 ms (300000 rows) | 118.82 ms | 0.009 ms |
| 300000 | Desc | 51-row page | 631.2 ms (300000 rows) | 129.76 ms | 0.097 ms |
| 300000 | Desc | 100-row page | 631.2 ms (300000 rows) | 133.86 ms | 0.185 ms |
| 300000 | Desc | 51-row page at depth 50% (cursor) | 631.2 ms (300000 rows) | 67.87 ms | 0.098 ms |
| 300000 | | seeded 550000 index rows in 2.0 s | | | |
| 1000000 | Asc | take(1) | 2115.6 ms (1000000 rows) | 308.76 ms | 0.009 ms |
| 1000000 | Asc | 51-row page | 2115.6 ms (1000000 rows) | 299.27 ms | 0.098 ms |
| 1000000 | Asc | 100-row page | 2115.6 ms (1000000 rows) | 301.99 ms | 0.179 ms |
| 1000000 | Asc | 51-row page at depth 50% (cursor) | 2115.6 ms (1000000 rows) | 214.71 ms | 49.529 ms |
| 1000000 | Desc | take(1) | 2138.4 ms (1000000 rows) | 398.48 ms | 0.009 ms |
| 1000000 | Desc | 51-row page | 2138.4 ms (1000000 rows) | 443.95 ms | 0.101 ms |
| 1000000 | Desc | 100-row page | 2138.4 ms (1000000 rows) | 462.18 ms | 0.196 ms |
| 1000000 | Desc | 51-row page at depth 50% (cursor) | 2138.4 ms (1000000 rows) | 223.74 ms | 0.102 ms |
| 1000000 | | seeded 1833332 index rows in 7.0 s | | | |

One case does not stay flat: the ascending 51-row page resumed from a cursor at 50 % depth takes 4.729 / 14.434 / 49.529 ms at 100k / 300k / 1M keys, against 0.095 / 0.098 / 0.102 ms for the same page descending. With an ascending cursor the statement carries two lower bounds on `key`, the range start `?3` and the cursor, and `EXPLAIN QUERY PLAN` seeks on only one of them: `SEARCH B USING INDEX sqlite_autoindex_indexes_1 (index_id=? AND key>?)`, versus `(index_id=? AND key>? AND key<?)` for the descending cursor, where the cursor is an upper bound. The timing shows the walk starting at the range start and filtering up to the cursor. At 1M keys that case is still below the grouped page (214.71 ms) and the legacy scan (2115.6 ms). The statement is unchanged for it in this commit.

## Tests (all in `crates/sqlite/src/lib.rs`, `mod tests`)

- From #522: the paginated scan against an in-memory reference across size hints (1, 2, 3, 10_000), both orders, partial intervals, snapshot timestamps that hide newer writes, tombstones on page boundaries, a mid-range run of tombstone-only pages; `paginated_load_from_table_matches_reference` interleaving two tablets at every timestamp across both orders and four page sizes.
- `paginated_scan_matches_legacy_oracle_and_reference` — proptest over random histories (colliding key prefixes, 1–5 versions per key, tombstones, reads before/inside/after the history), every bound shape including unbounded, both orders, page sizes 1–10. The paginated scan must equal both the pre-pagination statement (kept verbatim as an oracle) and #522's Rust reference.
- `plan_never_sorts` — `EXPLAIN QUERY PLAN` for every bound shape × cursor × order must contain neither `TEMP B-TREE` nor `SCAN B`, and must search the primary key. A plan regression fails the build.
- `bench_index_scan_forms` (ignored) — seeds 100k / 300k / 1M keys and times the pre-pagination, grouped and streaming statements.

`proptest` joins the crate's dev-dependencies (already a workspace dependency; `Cargo.lock` +1 line).

## Reproduce

```sh
cargo test -p sqlite                                   # all pass; the 1 ignored test is the benchmark
cargo test --release -p sqlite -- --ignored --nocapture bench_index_scan_forms
```

Related: #522 (the pagination half of this commit), #539 (`max_ts`; independent).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
