### PR TITLE
node-executor: don't cache source packages missing files on disk

### DIFF
--- a/npm-packages/node-executor/src/source_package.test.ts
+++ b/npm-packages/node-executor/src/source_package.test.ts
@@ -1,0 +1,183 @@
+import { createHash } from "node:crypto";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { partialExtract } = vi.hoisted(() => ({
+  partialExtract: { value: false },
+}));
+
+vi.mock("adm-zip", async () => {
+  const { default: ActualAdmZip } =
+    await vi.importActual<typeof import("adm-zip")>("adm-zip");
+  return {
+    default: function MockAdmZip(
+      ...args: ConstructorParameters<typeof ActualAdmZip>
+    ) {
+      const zip = new ActualAdmZip(...args);
+      const originalExtract = zip.extractAllTo.bind(zip);
+      zip.extractAllTo = (outputDir: string, overwrite?: boolean) => {
+        if (!partialExtract.value) {
+          return originalExtract(outputDir, overwrite);
+        }
+        const metadata = zip.getEntry("metadata.json");
+        if (metadata === null) {
+          throw new Error("zip is missing metadata.json");
+        }
+        fs.mkdirSync(outputDir, { recursive: true });
+        fs.writeFileSync(
+          path.join(outputDir, "metadata.json"),
+          metadata.getData(),
+        );
+      };
+      return zip;
+    },
+  };
+});
+
+import AdmZip from "adm-zip";
+import {
+  availableSourcePackages,
+  maybeDownloadAndLinkPackages,
+  PackageRefcounts,
+  type SourcePackage,
+} from "./source_package";
+
+const MODULE_PATH = "actions/hello.js";
+const MODULE_SOURCE =
+  'export default { isAction: true, invokeAction: async () => "{}" };\n';
+
+function writeSourceZip(
+  zipPath: string,
+  modulePath: string,
+  source: string,
+): { sha256: string } {
+  const zip = new AdmZip();
+  const metadata = {
+    modulePaths: [modulePath],
+    moduleEnvironments: [[modulePath, "node"]],
+  };
+  zip.addFile("metadata.json", Buffer.from(JSON.stringify(metadata)));
+  zip.addFile(`modules/${modulePath}`, Buffer.from(source));
+  const zipBuffer = zip.toBuffer();
+  fs.writeFileSync(zipPath, zipBuffer);
+  return {
+    sha256: createHash("sha256").update(zipBuffer).digest("base64url"),
+  };
+}
+
+function sourcePackageFromZip(
+  zipPath: string,
+  key: string,
+  sha256: string,
+): SourcePackage {
+  const uri = pathToFileURL(zipPath).href;
+  return {
+    uri,
+    key,
+    sha256,
+    bundled_source: { uri, key, sha256 },
+  };
+}
+
+describe("maybeDownloadAndLinkPackages", () => {
+  let tmpDir: string;
+  let tmpdirSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    partialExtract.value = false;
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "convex-source-package-"));
+    tmpdirSpy = vi.spyOn(os, "tmpdir").mockReturnValue(tmpDir);
+    availableSourcePackages.clear();
+  });
+
+  afterEach(() => {
+    tmpdirSpy.mockRestore();
+    availableSourcePackages.clear();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("should extract module files onto disk before caching the package", async () => {
+    const zipPath = path.join(tmpDir, "pkg.zip");
+    const { sha256 } = writeSourceZip(zipPath, MODULE_PATH, MODULE_SOURCE);
+    const sourcePackage = sourcePackageFromZip(zipPath, "pkg-extract", sha256);
+    const context = new PackageRefcounts();
+
+    try {
+      const local = await maybeDownloadAndLinkPackages(context, sourcePackage);
+      const moduleFile = path.join(
+        local.dir,
+        "modules",
+        ...MODULE_PATH.split("/"),
+      );
+      expect(fs.existsSync(moduleFile)).toBe(true);
+      expect(fs.readFileSync(moduleFile, "utf-8")).toBe(MODULE_SOURCE);
+      expect(local.modules.has(MODULE_PATH)).toBe(true);
+    } finally {
+      context.dispose();
+    }
+  });
+
+  it("should not cache an extract that writes metadata.json but no module files", async () => {
+    const zipPath = path.join(tmpDir, "pkg.zip");
+    const { sha256 } = writeSourceZip(zipPath, MODULE_PATH, MODULE_SOURCE);
+    const sourcePackage = sourcePackageFromZip(zipPath, "pkg-partial", sha256);
+    partialExtract.value = true;
+
+    const context = new PackageRefcounts();
+    try {
+      await expect(
+        maybeDownloadAndLinkPackages(context, sourcePackage),
+      ).rejects.toThrow(/missing modules\/actions\/hello\.js on disk/);
+      expect(availableSourcePackages.has(sourcePackage.key)).toBe(false);
+    } finally {
+      context.dispose();
+    }
+  });
+
+  it("should re-download when a cached package directory is later emptied", async () => {
+    const zipPath = path.join(tmpDir, "pkg.zip");
+    const { sha256 } = writeSourceZip(zipPath, MODULE_PATH, MODULE_SOURCE);
+    const sourcePackage = sourcePackageFromZip(zipPath, "pkg-stale", sha256);
+
+    const firstContext = new PackageRefcounts();
+    let packageDir: string;
+    try {
+      const local = await maybeDownloadAndLinkPackages(
+        firstContext,
+        sourcePackage,
+      );
+      packageDir = local.dir;
+      expect(
+        fs.existsSync(
+          path.join(packageDir, "modules", ...MODULE_PATH.split("/")),
+        ),
+      ).toBe(true);
+    } finally {
+      firstContext.dispose();
+    }
+
+    expect(availableSourcePackages.has(sourcePackage.key)).toBe(true);
+    fs.rmSync(packageDir, { recursive: true, force: true });
+    expect(availableSourcePackages.has(sourcePackage.key)).toBe(true);
+
+    const secondContext = new PackageRefcounts();
+    try {
+      const local = await maybeDownloadAndLinkPackages(
+        secondContext,
+        sourcePackage,
+      );
+      const moduleFile = path.join(
+        local.dir,
+        "modules",
+        ...MODULE_PATH.split("/"),
+      );
+      expect(fs.existsSync(moduleFile)).toBe(true);
+      expect(fs.readFileSync(moduleFile, "utf-8")).toBe(MODULE_SOURCE);
+    } finally {
+      secondContext.dispose();
+    }
+  });
+});

--- a/npm-packages/node-executor/src/source_package.ts
+++ b/npm-packages/node-executor/src/source_package.ts
@@ -79,6 +79,46 @@ function parseMetadataFile(contents: string): MetadataJson {
   };
 }
 
+function extractedModulePathOnDisk(dir: string, modulePath: string): string {
+  return path.join(dir, "modules", ...modulePath.split("/"));
+}
+
+function assertExtractedSourcePackageOnDisk(
+  dir: string,
+  modulePaths: string[],
+): void {
+  const metadataPath = path.join(dir, "metadata.json");
+  if (!fs.existsSync(metadataPath)) {
+    throw new Error(
+      `Extracted source package at ${dir} is missing metadata.json on disk`,
+    );
+  }
+  for (const modulePath of modulePaths) {
+    const filePath = extractedModulePathOnDisk(dir, modulePath);
+    if (!fs.existsSync(filePath)) {
+      throw new Error(
+        `Extracted source package at ${dir} is missing modules/${modulePath} on disk`,
+      );
+    }
+  }
+}
+
+function isExtractedSourcePackageOnDisk(dir: string): boolean {
+  try {
+    const metadataPath = path.join(dir, "metadata.json");
+    if (!fs.existsSync(metadataPath)) {
+      return false;
+    }
+    const metadata = parseMetadataFile(
+      fs.readFileSync(metadataPath, { encoding: "utf-8" }),
+    );
+    assertExtractedSourcePackageOnDisk(dir, metadata.modulePaths);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 // In-flight `removeDir` promises
 const pendingRemovals = new Map<string, Promise<void>>();
 
@@ -105,6 +145,7 @@ function removeDir(dir: string): Promise<void> {
  *
  * This runs to completion synchronously so that callers can register their
  * interest in a package (via the refcount) before yielding to other requests.
+ * Settled entries are dropped when `isPresentOnDisk` reports the files gone.
  */
 function getOrStartDownload<T>(
   context: PackageRefcounts,
@@ -112,10 +153,24 @@ function getOrStartDownload<T>(
   key: string,
   dir: string,
   startDownload: (dir: string) => Promise<T>,
+  isPresentOnDisk?: (dir: string) => boolean,
 ): PackageCacheEntry<T> {
   const cached = cache.get(key);
   if (cached !== undefined) {
-    return context.adopt(cached);
+    if (
+      cached.settled &&
+      isPresentOnDisk !== undefined &&
+      !isPresentOnDisk(cached.dir)
+    ) {
+      logDebug(
+        `Cached package ${key} is missing files on disk at ${cached.dir}; re-downloading`,
+      );
+      if (cache.get(key) === cached) {
+        cache.delete(key);
+      }
+    } else {
+      return context.adopt(cached);
+    }
   }
   const entry: PackageCacheEntry<T> = {
     dir,
@@ -166,6 +221,7 @@ export async function maybeDownloadAndLinkPackages(
     path.join(os.tmpdir(), `source/${sourcePackage.key}`),
     (dir) =>
       downloadAndLinkSourcePackage(dir, sourcePackage.bundled_source, external),
+    isExtractedSourcePackageOnDisk,
   );
 
   const [modules] = await Promise.all([source.ready, external?.ready]);
@@ -425,6 +481,8 @@ async function processSourcePackageStream(
     );
   }
 
+  assertExtractedSourcePackageOnDisk(dir, metadataJson.modulePaths);
+
   return modulesFromMetadataJson(metadataJson);
 }
 
@@ -464,6 +522,10 @@ export async function populatePrebuildPackages() {
         fs.readFileSync(`${pkgDir}/metadata.json`, { encoding: "utf-8" }),
       );
       modules = modulesFromMetadataJson(metadata);
+      if (!isExtractedSourcePackageOnDisk(pkgDir)) {
+        logDebug(`Incomplete prebuild source package at ${pkgDir}, skipping`);
+        continue;
+      }
     } catch (e: any) {
       logDebug(`Failed to parse metadata.json during prebuild, skipping: ${e}`);
       continue;


### PR DESCRIPTION
## Summary

Fixes #519.

On self-hosted backends, a failed or empty source-package extract could be treated as success and then pinned in `availableSourcePackages` forever. Later Node action invocations hit the cache and never re-downloaded, so every `"use node"` action failed with `Cannot find module …/modules/X.js` until the process was restarted.

Two independent gaps caused that:

1. **Extract validation used zip entry names, not the filesystem.** `processSourcePackageStream` compared `metadata.json` to `zip.getEntries()`, then cached the package even if `extractAllTo` wrote nothing (or only `metadata.json`).
2. **Settled cache hits never rechecked disk.** Once a key was in `availableSourcePackages`, `getOrStartDownload` returned it even if the directory had since been emptied.

## Change

- After unzip, require `metadata.json` and every listed module file to exist on disk before the package is considered ready. Failures stay uncached (existing `getOrStartDownload` catch path).
- On a settled source-package cache hit, revalidate those files. If they are gone, drop the entry and download again. In-flight downloads for the same key still share one extract.
- Skip incomplete Lambda prebuild directories instead of caching them.

## Test plan

- [x] `npx vitest run src/source_package.test.ts` in `npm-packages/node-executor` (3 passing):
  - extract writes module files before caching
  - a metadata-only extract throws and is not cached
  - deleting a cached package directory causes the next call to re-download

By submitting this pull request, I confirm that Convex can use, modify, copy, and redistribute the contribution, under the terms of its choice.
