### PR TITLE
[proposal] ai-sdk-provider: convexGateway.imageModel + gateway image-gen plan

### DIFF
--- a/npm-packages/@convex-dev/ai-sdk-provider/src/index.ts
+++ b/npm-packages/@convex-dev/ai-sdk-provider/src/index.ts
@@ -16,6 +16,7 @@ import { getServiceToken } from "convex/server";
 type Provider = ReturnType<typeof createOpenAICompatible>;
 type ChatModel = ReturnType<Provider>;
 type EmbeddingModel = ReturnType<Provider["embeddingModel"]>;
+type ImageModel = ReturnType<Provider["imageModel"]>;
 type LanguageModel = Parameters<typeof wrapLanguageModel>[0]["model"];
 type GatewayLanguageModel = ReturnType<typeof wrapLanguageModel>;
 
@@ -177,4 +178,19 @@ convexGateway.embeddingModel = function (modelId: string): EmbeddingModel {
       overrideMaxEmbeddingsPerCall: () => maxEmbeddingsPerCall,
     },
   });
+};
+
+/**
+ * Image model for the hosted Convex AI gateway. Use with the AI SDK's
+ * `experimental_generateImage`. Cost is billed per image (per the gateway's
+ * usage accounting) rather than per token.
+ *
+ *   import { experimental_generateImage as generateImage } from "ai";
+ *   const { images } = await generateImage({
+ *     model: convexGateway.imageModel("openai/gpt-image-1"),
+ *     prompt, n,
+ *   });
+ */
+convexGateway.imageModel = function (modelId: string): ImageModel {
+  return createGatewayProvider().imageModel(modelId);
 };


### PR DESCRIPTION
> **Proposal for review** (@andy). Client half is concrete + type-checked; the server half is a design below.

## Why

Image and video generation are billed **per image / per second**, not per token, and (unlike chat) the cost is known up front. [`@convex-dev/ai-budget`](https://www.npmjs.com/package/@convex-dev/ai-budget) can already meter these today via a **direct** provider call (`ai.meter` + `estimatedCostNanos` + per-unit pricing), so nothing is blocked. But routing image/video **through the gateway** — unified deployment-JWT auth, one billing pipeline, provider-agnostic model ids — needs a gateway image endpoint. This PR does the easy half and proposes the rest.

## What's in this PR (concrete)

`convexGateway.imageModel(id)` — an openai-compatible `ImageModelV4` with the same `getServiceToken("ai-gateway")` fetch as chat, for the AI SDK's `experimental_generateImage`:

```ts
import { experimental_generateImage as generateImage } from "ai";
const { images } = await generateImage({
  model: convexGateway.imageModel("openai/gpt-image-1"),
  prompt, n,
});
```

Mirrors `convexGateway.embeddingModel`; type-checked against `@ai-sdk/openai-compatible@3.0.14`. It targets `${gateway}/v1/images/generations` — which the gateway doesn't serve **yet**; that's the proposal.

## Proposed server work (for review)

1. **Endpoint:** OpenAI-compatible `POST /v1/images/generations` (the openai-compatible image model already targets this path — no client changes if you match it). Proxy to upstream image APIs (OpenAI `gpt-image-1`, etc.).
2. **Provider routing:** map gateway `provider/model` ids to the upstream image endpoint, same dispatch as chat.
3. **Billing:** per-image accounting (resolution/quality tier) instead of token metering, and surface the charge in the response `usage.cost` **exactly like chat does** — then the provider's existing `metadataExtractor` (merged in #548) lifts it to `providerMetadata.convexGateway.cost` for free, and ai-budget records the real cost with no extra work.
4. **Reuse:** auth (deployment JWT), rate limiting, and the proxy all carry over from the chat path.

## Video (proposed follow-up, not in this PR)

Video is **async** — submit → poll → done. The AI SDK already models this (`experimental_startVideo` + `experimental_getVideoStatus`), and it lines up with ai-budget's new `begin`/`settle` + `reserveTtlMs` (reserve at submit, settle on the completion webhook). It needs a gateway job API (submit/status), so it's a larger, separate step — flagging it so the image endpoint's shape leaves room for it.

## Testing
- Type-checked the `imageModel` construct against `@ai-sdk/openai-compatible@3.0.14`.
- I couldn't run the monorepo build here (pnpm workspace) — please run `npm run build` / `npm test` in the package before merge.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
