### PR TITLE
Fix self-hosted dashboard HTTP 500 by shipping the Next standalone build (#553)

### DIFF
--- a/self-hosted/docker-build/Dockerfile.dashboard
+++ b/self-hosted/docker-build/Dockerfile.dashboard
@@ -29,7 +29,6 @@ WORKDIR /app/npm-packages
 RUN pnpm install --frozen-lockfile
 ENV NODE_ENV=production
 RUN turbo run build --filter=dashboard-self-hosted...
-RUN pnpm --filter=dashboard-self-hosted deploy --legacy --prod /tmp/deploy
 
 FROM ubuntu:noble
 
@@ -49,14 +48,23 @@ EOF
 
 RUN groupadd --system --gid 1001 nodejs
 RUN useradd --system --uid 1001 --gid nodejs nextjs
-COPY --from=build --chown=nextjs:nodejs /tmp/deploy/ /app/
 WORKDIR /app
-# Since the pnpm workspace root (npm-packages/, where pnpm-lock.yaml lives) is
-# an ancestor of the package, Next infers it as outputFileTracingRoot and nests
-# the standalone output under the package's workspace-relative path.
-RUN cp /app/.next/standalone/dashboard-self-hosted/server.js .
+# Next writes a self-contained standalone build under .next/standalone: it bundles
+# server.js, the traced production node_modules, and the .next/node_modules links
+# that Turbopack's server chunks require() at runtime. We copy that tree as-is
+# instead of running `pnpm deploy`, which prunes nested node_modules (including
+# .next/node_modules) and leaves the server unable to resolve those links, so the
+# dashboard returns HTTP 500 on every page (see issue #553).
+#
+# The pnpm workspace root (npm-packages/, where pnpm-lock.yaml lives) is an
+# ancestor of the package, so Next uses it as outputFileTracingRoot and nests the
+# app one level down, under dashboard-self-hosted/.
+COPY --from=build --chown=nextjs:nodejs /app/npm-packages/dashboard-self-hosted/.next/standalone/ ./
+# Static assets are not part of the standalone bundle, so copy them in separately.
+# (public/ is already included under dashboard-self-hosted/ by the standalone output.)
+COPY --from=build --chown=nextjs:nodejs /app/npm-packages/dashboard-self-hosted/.next/static/ ./dashboard-self-hosted/.next/static/
 USER nextjs
 EXPOSE 6791
 ENV PORT=6791
 ENV HOSTNAME=0.0.0.0
-CMD ["node", "./server.js"]
+CMD ["node", "dashboard-self-hosted/server.js"]


### PR DESCRIPTION
The self-hosted dashboard returns HTTP 500 on every page. The container starts and the backend is healthy, but the dashboard cannot resolve one of its modules at runtime, so nothing renders. Fixes #553.

## The problem

Every dashboard page fails with:

```
Error: Failed to load external module @radix-ui/react-icons-311a50637b01fce4:
Error: Cannot find module '@radix-ui/react-icons-311a50637b01fce4'
```

This is not a missing npm dependency. `@radix-ui/react-icons` is declared and used all over the dashboard, and it is present in `node_modules`. The real cause is how the runtime image is assembled.

Since the dashboard moved to Turbopack (#57092), the self-hosted build uses `output: "standalone"`. In that mode Turbopack's server chunks `require()` external packages by a hashed id, for example:

```js
require("@radix-ui/react-icons-311a50637b01fce4")
```

Those hashed ids resolve through alias symlinks Turbopack writes under `.next/node_modules/`, each pointing into the traced pnpm store that lives inside `.next/standalone/`. So `.next/node_modules` is load-bearing at runtime.

The Dockerfile built the runtime image with `pnpm deploy --legacy --prod`. `pnpm deploy` prunes every nested `node_modules`, including `.next/node_modules`, so those alias links never made it into the image. At runtime the server cannot resolve the hashed `require` and 500s on the first page that imports the icons. That import lives in `_app`, so it is every page.

The Next standalone output is already self-contained: it ships `server.js`, the traced production `node_modules`, `public/`, and the `.next/node_modules` alias links. So the fix is to copy that tree directly and drop `pnpm deploy` entirely.

## The fix

One file, `self-hosted/docker-build/Dockerfile.dashboard`:

- Drop `pnpm --filter=dashboard-self-hosted deploy --legacy --prod /tmp/deploy`.
- Copy `.next/standalone/` into the runtime image as-is, which keeps the alias links intact.
- Copy `.next/static/` in separately, since static assets are not part of the standalone bundle (`public/` already is).
- Run `node dashboard-self-hosted/server.js`. The pnpm workspace root is an ancestor of the package, so Next uses it as `outputFileTracingRoot` and nests the app one level down.

Net effect: one fewer build step, and a smaller, correct runtime image.

## Before and after

Reproduced the old behavior by assembling the runtime exactly as the previous Dockerfile did (`pnpm deploy` output, `server.js` copied up):

- `GET /` returns HTTP 500 with the exact module hash from the issue.

With the fix, verified end to end with a real `docker build` plus `docker run`:

- `GET /` and `GET /data` return HTTP 200.
- `public/` and `_next/static` assets return HTTP 200.
- No "Cannot find module" errors in the server logs.
