### PR TITLE
Don't panic when TaskExecutor channel closes during shutdown

### DIFF
--- a/crates/isolate/src/environment/action/mod.rs
+++ b/crates/isolate/src/environment/action/mod.rs
@@ -674,7 +674,8 @@ impl<RT: Runtime> ActionEnvironment<RT> {
                 variant: TaskRequestEnum::AsyncOp(AsyncOpRequest::SendStream { stream, stream_id }),
                 parent_trace: EncodedSpan::from_parent(),
             })
-            .map_err(|_| {
+.map_err(|_| {
+                self.task_promise_resolvers.remove(&task_id);
                 anyhow!(ErrorMetadata::operational_internal_server_error())
                     .context("TaskExecutor went away")
             })?;

--- a/crates/isolate/src/environment/action/mod.rs
+++ b/crates/isolate/src/environment/action/mod.rs
@@ -59,6 +59,7 @@ use deno_core::v8::{
     self,
     scope,
 };
+use errors::ErrorMetadata;
 use futures::{
     future::BoxFuture,
     select_biased,
@@ -513,7 +514,7 @@ impl<RT: Runtime> ActionEnvironment<RT> {
                 scope
                     .state_mut()?
                     .environment
-                    .send_stream(stream_id, Some(body));
+                    .send_stream(stream_id, Some(body))?;
                 Some(stream_id)
             },
             None => None,
@@ -579,7 +580,7 @@ impl<RT: Runtime> ActionEnvironment<RT> {
         let stream_id = state.create_request_stream()?;
         state
             .environment
-            .send_stream(stream_id, Some(sender_closed));
+            .send_stream(stream_id, Some(sender_closed))?;
 
         Ok(stream_id)
     }
@@ -665,7 +666,7 @@ impl<RT: Runtime> ActionEnvironment<RT> {
         &mut self,
         stream_id: uuid::Uuid,
         stream: Option<BoxStream<'static, anyhow::Result<bytes::Bytes>>>,
-    ) {
+    ) -> anyhow::Result<()> {
         let task_id = self.next_task_id.increment();
         self.pending_task_sender
             .send(TaskRequest {
@@ -673,7 +674,11 @@ impl<RT: Runtime> ActionEnvironment<RT> {
                 variant: TaskRequestEnum::AsyncOp(AsyncOpRequest::SendStream { stream, stream_id }),
                 parent_trace: EncodedSpan::from_parent(),
             })
-            .expect("TaskExecutor went away?");
+            .map_err(|_| {
+                anyhow!(ErrorMetadata::operational_internal_server_error())
+                    .context("TaskExecutor went away")
+            })?;
+        Ok(())
     }
 
     #[fastrace::trace]
@@ -1336,7 +1341,10 @@ impl<RT: Runtime> ActionEnvironment<RT> {
                 variant: request,
                 parent_trace: EncodedSpan::from_parent(),
             })
-            .expect("TaskExecutor went away?");
+            .map_err(|_| {
+                anyhow!(ErrorMetadata::operational_internal_server_error())
+                    .context("TaskExecutor went away")
+            })?;
         Ok(())
     }
 


### PR DESCRIPTION
During shutdown, an in-flight isolate action can still synchronously enqueue onto `pending_task_sender` after the `TaskExecutor`'s receiving end has already been torn down by the global shutdown chain. Both call sites used `.expect("TaskExecutor went away?")`, so that race panicked and with `panic = abort`, the whole backend process aborted, turning a transient Postgres connection drop mid-commit into a full VM reboot on self-hosted single-instance deployments.

This implements the minimal fix from the issue thread: both sites now return `ErrorMetadata::operational_internal_server_error()` via `?` instead of panicking, so a closed channel during shutdown surfaces as a normal system error on the in-flight action/cron job instead of aborting the process.